### PR TITLE
Fix settings crash due to no codec registered

### DIFF
--- a/src/main/java/io/github/railroad/settings/handler/SettingsHandler.java
+++ b/src/main/java/io/github/railroad/settings/handler/SettingsHandler.java
@@ -86,10 +86,8 @@ public class SettingsHandler {
     public void loadSettingsFromFile() {
         try {
             String fileInput = Files.readString(configPath);
-
-            if (fileInput.isEmpty()) {
-                Railroad.LOGGER.error("Settings file is empty!");
-                throw new JsonSyntaxException("Settings file is empty!");
+            if(fileInput.isBlank() || fileInput.trim().replace(" ", "").equals("{}")) {
+                saveSettingsFile();
             }
 
             JsonObject json = Railroad.GSON.fromJson(fileInput, JsonObject.class);
@@ -107,7 +105,7 @@ public class SettingsHandler {
     public void saveSettingsFile() {
         Railroad.LOGGER.debug("Saving settings file");
         try {
-            Files.writeString(configPath, settings.toJson().toString());
+            Files.writeString(configPath, Railroad.GSON.toJson(settings.toJson()));
         } catch (IOException e) {
             Railroad.LOGGER.error("Failed to save settings file", e);
         }
@@ -456,6 +454,19 @@ public class SettingsHandler {
                             combo.getItems().addAll("default-dark", "default-light");
                             combo.setValue(t);
                             return combo;
+                        })
+        );
+
+        registerCodec(
+                new SettingCodec<Boolean, CheckBox, JsonElement>("railroad:ide.auto_pair_inside_strings",
+                        CheckBox::isSelected,
+                        (selected, checkBox) -> checkBox.setSelected(selected),
+                        JsonElement::getAsBoolean,
+                        JsonPrimitive::new,
+                        selected -> {
+                            var checkBox = new CheckBox();
+                            checkBox.setSelected(selected);
+                            return checkBox;
                         })
         );
     }


### PR DESCRIPTION
This pull request introduces improvements to the `SettingsHandler` class. The changes focus on enhancing the handling of settings files and adding support for a new codec. Key updates include refining the logic for handling empty settings files, improving the JSON serialization process, and registering a new setting codec for an "auto pair inside strings" feature.

### Enhancements to settings file handling:

* Updated the `loadSettingsFromFile` method to check for both blank content and empty JSON objects (`{}`) when determining if the settings file is empty. If empty, the method now calls `saveSettingsFile` instead of throwing an exception.
* Improved the `saveSettingsFile` method to use `Railroad.GSON.toJson` for JSON serialization, ensuring consistency with the deserialization process.

### New codec registration:

* Added a new `SettingCodec` for the `railroad:ide.auto_pair_inside_strings` setting, which uses a `CheckBox` UI component and supports JSON serialization/deserialization.