### PR TITLE
Add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1759143472,
+        "narHash": "sha256-TvODmeR2W7yX/JmOCmP+lAFNkTT7hAxYcF3Kz8SZV3w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5ed4e25ab58fd4c028b59d5611e14ea64de51d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
         {
           inherit jdk javafx;
           gradle = prev.gradle.override { java = jdk; };
+          lombok = prev.lombok.override { inherit jdk; };
         };
 
       devShells = forEachSystem (
@@ -54,9 +55,15 @@
               xorg.libXxf86vm
             ];
 
-            shellHook = ''
+            shellHook =
+            let
+              loadLombok = "-javaagent:${pkgs.lombok}/share/java/lombok.jar";
+              prev = "\${JAVA_TOOL_OPTIONS:+ $JAVA_TOOL_OPTIONS}";
+            in
+            ''
               export JAVAFX_MODULE_PATH=${pkgs.javafx}/lib
               export LD_LIBRARY_PATH="${pkgs.libGL}/lib:${pkgs.gtk3}/lib:${pkgs.glib.out}/lib:${pkgs.xorg.libX11}/lib:${pkgs.xorg.libXtst}/lib:${pkgs.xorg.libXi}/lib:${pkgs.xorg.libXxf86vm}/lib:$LD_LIBRARY_PATH"
+              export JAVA_TOOL_OPTIONS="${loadLombok}${prev}"
 
               mkdir ~/.config/Railroad
               touch ~/.config/Railroad/logger_config.json

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+  };
+
+  outputs = inputs:
+    let
+      javaVersion = 21;
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forEachSystem = f:
+        inputs.nixpkgs.lib.genAttrs systems (
+          system:
+          f {
+            pkgs = import inputs.nixpkgs {
+              inherit system;
+              overlays = [ inputs.self.overlays.default ];
+            };
+          }
+        );
+    in
+    {
+      overlays.default = final: prev:
+        let
+          jdk = prev."jdk${toString javaVersion}";
+          javafx = prev.openjfx;
+        in
+        {
+          inherit jdk javafx;
+          gradle = prev.gradle.override { java = jdk; };
+        };
+
+      devShells = forEachSystem (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              gradle
+              jdk
+              javafx
+
+              libGL
+              gtk3
+              glib
+              xorg.libX11
+              xorg.libXtst
+              xorg.libXi
+              xorg.libXxf86vm
+            ];
+
+            shellHook = ''
+              export JAVAFX_MODULE_PATH=${pkgs.javafx}/lib
+              export LD_LIBRARY_PATH="${pkgs.libGL}/lib:${pkgs.gtk3}/lib:${pkgs.glib.out}/lib:${pkgs.xorg.libX11}/lib:${pkgs.xorg.libXtst}/lib:${pkgs.xorg.libXi}/lib:${pkgs.xorg.libXxf86vm}/lib:$LD_LIBRARY_PATH"
+
+              mkdir ~/.config/Railroad
+              touch ~/.config/Railroad/logger_config.json
+            '';
+          };
+        }
+      );
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,8 @@
               javafx
 
               libGL
+              alsa-lib
+
               gtk3
               glib
               gsettings-desktop-schemas
@@ -64,7 +66,7 @@
             in
             ''
               export JAVAFX_MODULE_PATH=${pkgs.javafx}/lib
-              export LD_LIBRARY_PATH="${pkgs.libGL}/lib:${pkgs.gtk3}/lib:${pkgs.glib.out}/lib:${pkgs.xorg.libX11}/lib:${pkgs.xorg.libXtst}/lib:${pkgs.xorg.libXi}/lib:${pkgs.xorg.libXxf86vm}/lib:$LD_LIBRARY_PATH"
+              export LD_LIBRARY_PATH="${pkgs.libGL}/lib:${pkgs.gtk3}/lib:${pkgs.glib.out}/lib:${pkgs.xorg.libX11}/lib:${pkgs.xorg.libXtst}/lib:${pkgs.xorg.libXi}/lib:${pkgs.xorg.libXxf86vm}/lib:${pkgs.alsa-lib}/lib:$LD_LIBRARY_PATH"
               export JAVA_TOOL_OPTIONS="${loadLombok}${prev}"
               export GSETTINGS_SCHEMA_DIR="${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}/glib-2.0/schemas"
 

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,8 @@
               libGL
               gtk3
               glib
+              gsettings-desktop-schemas
+
               xorg.libX11
               xorg.libXtst
               xorg.libXi
@@ -64,6 +66,7 @@
               export JAVAFX_MODULE_PATH=${pkgs.javafx}/lib
               export LD_LIBRARY_PATH="${pkgs.libGL}/lib:${pkgs.gtk3}/lib:${pkgs.glib.out}/lib:${pkgs.xorg.libX11}/lib:${pkgs.xorg.libXtst}/lib:${pkgs.xorg.libXi}/lib:${pkgs.xorg.libXxf86vm}/lib:$LD_LIBRARY_PATH"
               export JAVA_TOOL_OPTIONS="${loadLombok}${prev}"
+              export GSETTINGS_SCHEMA_DIR="${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}/glib-2.0/schemas"
 
               mkdir ~/.config/Railroad
               touch ~/.config/Railroad/logger_config.json


### PR DESCRIPTION
adds nix flake for a devshell along with a .envrc file for direnv

tested with nix v2.28.5 on x86_64 with wayland

got no errors when launching within intellij