### PR TITLE
feat(welcome): Display project facets as tags in the project list

### DIFF
--- a/src/main/java/dev/railroadide/railroad/project/Project.java
+++ b/src/main/java/dev/railroadide/railroad/project/Project.java
@@ -118,7 +118,7 @@ public class Project implements JsonSerializable<JsonObject>, dev.railroadide.ra
 
     private void discoverFacets() {
         this.facets.clear();
-        /*FacetManager.scan(this).thenAcceptAsync(facets -> {
+        FacetManager.scan(this).thenAcceptAsync(facets -> {
             for (Facet<?> facet : facets) {
                 if (facet != null) {
                     this.facets.add(facet);
@@ -129,7 +129,7 @@ public class Project implements JsonSerializable<JsonObject>, dev.railroadide.ra
         }).exceptionally(ex -> {
             Railroad.LOGGER.error("Failed to discover facets for project: {}", getPathString(), ex);
             return null;
-        });*/
+        });
     }
 
     @Override

--- a/src/main/java/dev/railroadide/railroad/ui/nodes/ProjectListCell.java
+++ b/src/main/java/dev/railroadide/railroad/ui/nodes/ProjectListCell.java
@@ -39,7 +39,7 @@ public class ProjectListCell extends ListCell<Project> {
     private final Label pathLabel = new Label();
     private final Label lastOpenedLabel = new Label();
     private final RRButton ellipsisButton = new RRButton();
-    private final HBox facetTagsBox = new HBox(5); // 5px spacing between tags
+    private final HBox facetTagsBox = new HBox(5);
 
     /**
      * Constructs a new ProjectListCell with modern styling and context menu functionality.
@@ -64,7 +64,6 @@ public class ProjectListCell extends ListCell<Project> {
         icon.setEffect(new DropShadow(8, Color.rgb(0, 0, 0, 0.10)));
 
         infoBox.setAlignment(Pos.CENTER_LEFT);
-        // infoBox.setSpacing(7); // This is now set in the field declaration
         VBox.setVgrow(infoBox, Priority.ALWAYS);
         nameLabel.getStyleClass().add("project-list-name");
 
@@ -136,7 +135,7 @@ public class ProjectListCell extends ListCell<Project> {
                     tagLabel.getStyleClass().add("facet-" + facet.getType().id());
                     String description = facet.getType().description();
                     if (description != null && !description.isBlank()) {
-                        javafx.scene.control.Tooltip.install(tagLabel, new javafx.scene.control.Tooltip(description));
+                        Tooltip.install(tagLabel, new Tooltip(description));
                     }
                     facetTagsBox.getChildren().add(tagLabel);
                 }

--- a/src/main/java/dev/railroadide/railroad/ui/nodes/ProjectListCell.java
+++ b/src/main/java/dev/railroadide/railroad/ui/nodes/ProjectListCell.java
@@ -1,9 +1,13 @@
 package dev.railroadide.railroad.ui.nodes;
 
+import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;
+import org.kordamp.ikonli.javafx.FontIcon;
+
 import dev.railroadide.core.ui.RRButton;
 import dev.railroadide.core.ui.RRCard;
 import dev.railroadide.railroad.Railroad;
 import dev.railroadide.railroad.project.Project;
+import dev.railroadide.railroad.project.facet.Facet;
 import dev.railroadide.railroad.utility.StringUtils;
 import io.github.palexdev.mfxcore.builders.InsetsBuilder;
 import javafx.geometry.Insets;
@@ -19,8 +23,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
-import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;
-import org.kordamp.ikonli.javafx.FontIcon;
+import javafx.scene.control.Tooltip;
 
 /**
  * A modern list cell component for displaying project items in project lists.
@@ -31,11 +34,12 @@ public class ProjectListCell extends ListCell<Project> {
     private final RRCard card = new RRCard(14, new Insets(8, 32, 8, 32));
     private final HBox root = new HBox(16);
     private final ImageView icon = new ImageView();
-    private final VBox infoBox = new VBox(7);
+    private final VBox infoBox = new VBox(4);
     private final Label nameLabel = new Label();
     private final Label pathLabel = new Label();
     private final Label lastOpenedLabel = new Label();
     private final RRButton ellipsisButton = new RRButton();
+    private final HBox facetTagsBox = new HBox(5); // 5px spacing between tags
 
     /**
      * Constructs a new ProjectListCell with modern styling and context menu functionality.
@@ -60,13 +64,17 @@ public class ProjectListCell extends ListCell<Project> {
         icon.setEffect(new DropShadow(8, Color.rgb(0, 0, 0, 0.10)));
 
         infoBox.setAlignment(Pos.CENTER_LEFT);
-        infoBox.setSpacing(7);
+        // infoBox.setSpacing(7); // This is now set in the field declaration
         VBox.setVgrow(infoBox, Priority.ALWAYS);
         nameLabel.getStyleClass().add("project-list-name");
+
+        facetTagsBox.getStyleClass().add("project-list-facet-tags");
+        facetTagsBox.setAlignment(Pos.CENTER_LEFT);
+
         pathLabel.getStyleClass().add("project-list-path");
         lastOpenedLabel.getStyleClass().add("project-list-last-opened");
-        infoBox.getChildren().addAll(nameLabel, pathLabel, lastOpenedLabel);
 
+        infoBox.getChildren().addAll(nameLabel, facetTagsBox, pathLabel, lastOpenedLabel);
         var ellipsisIcon = new FontIcon(FontAwesomeSolid.ELLIPSIS_V);
         ellipsisIcon.setIconSize(16);
         ellipsisButton.setGraphic(ellipsisIcon);
@@ -105,6 +113,10 @@ public class ProjectListCell extends ListCell<Project> {
     @Override
     protected void updateItem(Project project, boolean empty) {
         super.updateItem(project, empty);
+
+        // Always clear old tags, as cells are reused
+        facetTagsBox.getChildren().clear(); 
+
         if (empty || project == null) {
             setText(null);
             setGraphic(null);
@@ -114,7 +126,23 @@ public class ProjectListCell extends ListCell<Project> {
             nameLabel.setText(project.getAlias());
             pathLabel.setText(project.getPathString());
             lastOpenedLabel.setText(StringUtils.formatElapsed(project.getLastOpened()));
+
+            // Populate Facet Tags
+            for (Facet<?> facet : project.getFacets()) {
+                if (facet != null && facet.getType() != null) {
+                    // Use the FacetType's name for the tag
+                    Label tagLabel = new Label(facet.getType().name()); 
+                    tagLabel.getStyleClass().add("project-list-facet-tag");
+                    tagLabel.getStyleClass().add("facet-" + facet.getType().id());
+                    String description = facet.getType().description();
+                    if (description != null && !description.isBlank()) {
+                        javafx.scene.control.Tooltip.install(tagLabel, new javafx.scene.control.Tooltip(description));
+                    }
+                    facetTagsBox.getChildren().add(tagLabel);
+                }
+            }
             setGraphic(card);
         }
     }
+
 } 

--- a/src/main/resources/assets/railroad/styles/base.css
+++ b/src/main/resources/assets/railroad/styles/base.css
@@ -1,4 +1,3 @@
-@import "components/project-list.css";
 .Railroad, .split-pane, .scroll-pane {
     -fx-background-color: -color-bg-default;
     -fx-text-fill: -color-fg-default;

--- a/src/main/resources/assets/railroad/styles/base.css
+++ b/src/main/resources/assets/railroad/styles/base.css
@@ -1,3 +1,4 @@
+@import "components/project-list.css";
 .Railroad, .split-pane, .scroll-pane {
     -fx-background-color: -color-bg-default;
     -fx-text-fill: -color-fg-default;

--- a/src/main/resources/assets/railroad/styles/components/project-list.css
+++ b/src/main/resources/assets/railroad/styles/components/project-list.css
@@ -12,3 +12,29 @@
 .project-list-node, .project-list-node .Pane {
     -fx-background-color: -color-bg-subtle;
 }
+/* base tag style */
+.project-list-facet-tag {
+    -fx-font-size: 0.8em; 
+    -fx-font-weight: 500;
+    -fx-padding: 2px 6px;
+    -fx-border-radius: 4px;
+    -fx-background-radius: 4px;
+    -fx-background-color: -rr-base-color-level-3;
+    -fx-text-fill: -rr-text-color-level-2;
+}
+
+
+.facet-java {
+    -fx-background-color: #E89D42; /* Orange */
+    -fx-text-fill: #3D2D1A;
+}
+
+.facet-gradle {
+    -fx-background-color: #38809A; /* Blue */
+    -fx-text-fill: #FFFFFF;
+}
+
+.facet-fabric {
+    -fx-background-color: #C3C3C3; /* Light Grey */
+    -fx-text-fill: #2B2B2B;
+}

--- a/src/main/resources/assets/railroad/styles/components/project-list.css
+++ b/src/main/resources/assets/railroad/styles/components/project-list.css
@@ -12,3 +12,29 @@
 .project-list-node, .project-list-node .Pane {
     -fx-background-color: -color-bg-subtle;
 }
+/* base tag style */
+.project-list-facet-tag {
+    -fx-font-size: 0.8em; 
+    -fx-font-weight: 500;
+    -fx-padding: 2px 6px;
+    -fx-border-radius: 4px;
+    -fx-background-radius: 4px;
+    -fx-background-color: -rr-base-color-level-3;
+    -fx-text-fill: -rr-text-color-level-2;
+}
+
+
+.facet-java {
+    -fx-background-color: #E89D42; /* Orange */
+    -fx-text-fill: #3D2D1A;
+}
+
+.facet-gradle, .facet-maven {
+    -fx-background-color: #38809A; /* Blue */
+    -fx-text-fill: #FFFFFF;
+}
+
+.facet-fabric {
+    -fx-background-color: #C3C3C3; /* Light Grey */
+    -fx-text-fill: #2B2B2B;
+}


### PR DESCRIPTION
Closes #79

## Description
This PR implements the feature to display project "natures" (which are 'Facets' in the codebase) as tags in the project list on the welcome screen. This makes it much easier to identify a project's type (e.g., Java, Gradle, Fabric) without having to open it.

## Changes
* **ProjectListCell.java:**
    * Added a new `HBox` named `facetTagsBox` to hold the tag labels.
    * Updated the `infoBox` layout to include `facetTagsBox` directly under the project's name.
    * Modified `updateItem()` to clear old tags and then populate the `facetTagsBox` with new `Label`s based on the project's `getFacets()` list.
* **project-list.css (Assumed):**
    * Added new styles for `.project-list-facet-tag` to make the labels appear as rounded, styled tags.
* **Project.java (Recommended):**
    * Uncommented the facet discovery logic in `discoverFacets()` so that facets are properly detected and saved when a project is opened.