### PR TITLE
Add dynamic language file register loader

### DIFF
--- a/src/main/java/dev/railroadide/railroad/Railroad.java
+++ b/src/main/java/dev/railroadide/railroad/Railroad.java
@@ -8,6 +8,7 @@ import dev.railroadide.logger.LoggerManager;
 import dev.railroadide.logger.LoggerService;
 import dev.railroadide.railroad.config.ConfigHandler;
 import dev.railroadide.railroad.localization.L18n;
+import dev.railroadide.railroad.localization.Languages;
 import dev.railroadide.railroad.plugin.PluginManager;
 import dev.railroadide.railroad.plugin.defaults.DefaultEventBus;
 import dev.railroadide.railroad.project.LicenseRegistry;
@@ -97,6 +98,7 @@ public class Railroad extends Application {
             new InitializationStep("Loading configuration", ConfigHandler::initConfig),
             new InitializationStep("Scanning plugins", () -> PluginManager.loadPlugins(ConfigHandler.getConfigDirectory().resolve("plugins"))),
             new InitializationStep("Registering keybinds", Keybinds::initialize),
+            new InitializationStep("Scanning language files", Languages::initialize),
             new InitializationStep("Loading settings", Settings::initialize),
             new InitializationStep("Preparing settings handler", SettingsHandler::init),
             new InitializationStep("Preparing themes", ThemeManager::init),

--- a/src/main/java/dev/railroadide/railroad/localization/LanguageRegistryLoader.java
+++ b/src/main/java/dev/railroadide/railroad/localization/LanguageRegistryLoader.java
@@ -1,0 +1,75 @@
+package dev.railroadide.railroad.localization;
+
+import dev.railroadide.core.localization.Language;
+import dev.railroadide.railroad.Railroad;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class LanguageRegistryLoader {
+    private static final String FOLDER = "assets/railroad/lang";
+    private static final Pattern FILE_PATTERN = Pattern.compile("^([a-z]{2})_([a-z]{2})\\.lang$");
+
+    private LanguageRegistryLoader() {}
+
+    public static void load() {
+        try {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            Enumeration<URL> resources = cl.getResources(FOLDER);
+
+            while (resources.hasMoreElements()) {
+                URL url = resources.nextElement();
+                discoverFromFileSystem(url);
+            }
+        } catch (Exception e) {
+            Railroad.LOGGER.debug("Language load failed", e);
+        }
+    }
+
+
+    private static void discoverFromFileSystem(URL url) throws IOException, URISyntaxException {
+        Path dirPath = Paths.get(url.toURI());
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dirPath)) {
+            for (Path file : stream) {
+                if (Files.isRegularFile(file)) {
+                    String fileName = file.getFileName().toString();
+                    tryRegisterFromFileName(fileName);
+                }
+            }
+        }
+    }
+
+    private static void tryRegisterFromFileName(String fileName) {
+        Matcher matcher = FILE_PATTERN.matcher(fileName);
+        if (!matcher.matches()) {
+            return;
+        }
+
+        String lang = matcher.group(1);
+        String country = matcher.group(2);
+
+        String fullCode = (lang + "_" + country).toUpperCase(Locale.ROOT);
+        if (Language.REGISTRY.contains(fullCode)) {
+            return;
+        }
+
+        Locale locale = Locale.forLanguageTag(lang + "-" + country.toUpperCase(Locale.ROOT));
+        String displayName = locale.getDisplayName(locale);
+
+        Language.builder(displayName)
+            .languageCode(lang)
+            .countryCode(country.toUpperCase(Locale.ROOT))
+            .build();
+
+        Railroad.LOGGER.debug("Registered language: {} ({})", displayName, fullCode);
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/localization/Languages.java
+++ b/src/main/java/dev/railroadide/railroad/localization/Languages.java
@@ -8,18 +8,7 @@ public final class Languages {
         .countryCode("US")
         .build();
 
-    public static final Language ES_ES = Language.builder("Español")
-        .languageCode("es")
-        .countryCode("ES")
-        .build();
-
-    public static final Language FR_FR = Language.builder("Français")
-        .languageCode("fr")
-        .countryCode("FR")
-        .build();
-
-    public static final Language DE_DE = Language.builder("Deutsch")
-        .languageCode("de")
-        .countryCode("DE")
-        .build();
+    public static void initialize() {
+        LanguageRegistryLoader.load();
+    }
 }


### PR DESCRIPTION
## Summary
Introduce file-based language discovery and runtime selection. Languages are now loadered from `assets/railroad/lang/*.lang` (e.g., `ko_kr.lang`) and registered dynamically, enabling translators to add new languages without code changes.

## Changes
- Add `LanguageRegistryLoader` to scan `assets/railroad/lang`
- Parse `.lang` files as UTF-8 to prevent Unicode garbling
- Add `Languages.initialize()` and call early in app startup

## Related Ticket
- #78 