### PR TITLE
Java process builder

### DIFF
--- a/src/main/java/dev/railroadide/railroad/java/JDK.java
+++ b/src/main/java/dev/railroadide/railroad/java/JDK.java
@@ -14,6 +14,12 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 
+/**
+ * A descriptor for a Java Development Kit (JDK) installation.
+ * This class encapsulates information about a JDK, including its installation path, name,
+ * Java version, and brand (e.g., Oracle, Adoptium). It also provides utility methods
+ * for interacting with the JDK's command-line interface tools.
+ */
 @ToString
 @EqualsAndHashCode
 public final class JDK {
@@ -23,6 +29,14 @@ public final class JDK {
     private final Brand brand;
     private final JDKCLI cli;
 
+    /**
+     * Constructs a new {@code JDK} instance with the specified path, name, version, and brand.
+     *
+     * @param path The absolute path to the JDK installation directory.
+     * @param name The display name of the JDK.
+     * @param version The Java version of this JDK.
+     * @param brand The brand of this JDK (e.g., Oracle, Adoptium).
+     */
     public JDK(Path path, String name, JavaVersion version, Brand brand) {
         this.path = path;
         this.name = name;
@@ -31,6 +45,14 @@ public final class JDK {
         this.cli = new JDKCLI(this);
     }
 
+    /**
+     * Constructs a new {@code JDK} instance with the specified path, name, and version.
+     * The brand will be automatically determined based on the JDK's properties.
+     *
+     * @param path The absolute path to the JDK installation directory.
+     * @param name The display name of the JDK.
+     * @param version The Java version of this JDK.
+     */
     public JDK(Path path, String name, JavaVersion version) {
         this.path = path;
         this.name = name;
@@ -39,22 +61,42 @@ public final class JDK {
         this.cli = new JDKCLI(this);
     }
 
+    /**
+     * Returns the absolute path to the JDK installation directory.
+     * @return The path to the JDK.
+     */
     public Path path() {
         return path;
     }
 
+    /**
+     * Returns the display name of this JDK.
+     * @return The name of the JDK.
+     */
     public String name() {
         return name;
     }
 
+    /**
+     * Returns the Java version of this JDK.
+     * @return The Java version.
+     */
     public JavaVersion version() {
         return version;
     }
 
+    /**
+     * Returns the brand of this JDK.
+     * @return The JDK brand.
+     */
     public Brand brand() {
         return brand;
     }
 
+    /**
+     * Returns the command-line interface (CLI) utility for this JDK.
+     * @return The JDKCLI instance.
+     */
     public JDKCLI cli() {
         return cli;
     }
@@ -75,6 +117,9 @@ public final class JDK {
         return path.resolve(executableName);
     }
 
+    /**
+     * Represents the brand or vendor of a JDK distribution.
+     */
     public enum Brand {
         ORACLE("oracle", "/images/Oracle-icon.svg"),
         ADOPTIUM("temurin", "/images/Adoptium-icon.svg", "adoptopenjdk", "adoptium", "eclipse"),
@@ -95,34 +140,72 @@ public final class JDK {
         @Getter
         private String imagePath;
 
+        /**
+         * Constructs a Brand with a key, Ikon, and optional aliases.
+         * @param key The primary identifier for the brand.
+         * @param icon The Ikon associated with the brand.
+         * @param aliases Additional names or identifiers for the brand.
+         */
         Brand(String key, Ikon icon, String... aliases) {
             this.key = key;
             this.icon = icon;
             this.aliases = aliases;
         }
 
+        /**
+         * Constructs a Brand with a key, image path, and optional aliases.
+         * @param key The primary identifier for the brand.
+         * @param imagePath The path to the image icon associated with the brand.
+         * @param aliases Additional names or identifiers for the brand.
+         */
         Brand(String key, String imagePath, String... aliases) {
             this.key = key;
             this.imagePath = imagePath;
             this.aliases = aliases;
         }
 
+        /**
+         * Constructs a Brand with a key and an Ikon, with no aliases.
+         * @param key The primary identifier for the brand.
+         * @param icon The Ikon associated with the brand.
+         */
         Brand(String key, Ikon icon) {
             this(key, icon, (String[]) null);
         }
 
+        /**
+         * Constructs a Brand with a key and an image path, with no aliases.
+         * @param key The primary identifier for the brand.
+         * @param imagePath The path to the image icon associated with the brand.
+         */
         Brand(String key, String imagePath) {
             this(key, imagePath, (String[]) null);
         }
 
+        /**
+         * Checks if this brand has an associated Ikon.
+         * @return {@code true} if an Ikon is present, {@code false} otherwise.
+         */
         public boolean isIkon() {
             return icon != null;
         }
 
+        /**
+         * Checks if this brand has an associated image path.
+         * @return {@code true} if an image path is present, {@code false} otherwise.
+         */
         public boolean isImage() {
             return imagePath != null;
         }
 
+        /**
+         * Determines the {@code Brand} of a given JDK based on its properties and name.
+         * It first attempts to resolve the brand from the JDK's release properties (IMPLEMENTOR, VENDOR),
+         * then falls back to string matching on the JDK's name and path if properties are inconclusive.
+         *
+         * @param jdk The {@code JDK} instance to determine the brand for.
+         * @return The resolved {@code Brand}, or {@code UNKNOWN} if no specific brand can be identified.
+         */
         private static Brand from(JDK jdk) {
             String rawName = jdk.name();
             String path = jdk.path().toAbsolutePath().toString().toLowerCase(Locale.ROOT);

--- a/src/main/java/dev/railroadide/railroad/java/JDK.java
+++ b/src/main/java/dev/railroadide/railroad/java/JDK.java
@@ -1,5 +1,6 @@
 package dev.railroadide.railroad.java;
 
+import dev.railroadide.railroad.java.cli.JDKCLI;
 import dev.railroadide.railroad.utility.JavaVersion;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -7,8 +8,10 @@ import lombok.ToString;
 import org.kordamp.ikonli.Ikon;
 import org.kordamp.ikonli.fontawesome6.FontAwesomeBrands;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Properties;
 
 @ToString
@@ -18,12 +21,14 @@ public final class JDK {
     private final String name;
     private final JavaVersion version;
     private final Brand brand;
+    private final JDKCLI cli;
 
     public JDK(Path path, String name, JavaVersion version, Brand brand) {
         this.path = path;
         this.name = name;
         this.version = version;
         this.brand = brand;
+        this.cli = new JDKCLI(this);
     }
 
     public JDK(Path path, String name, JavaVersion version) {
@@ -31,6 +36,7 @@ public final class JDK {
         this.name = name;
         this.version = version;
         this.brand = Brand.from(this);
+        this.cli = new JDKCLI(this);
     }
 
     public Path path() {
@@ -47,6 +53,26 @@ public final class JDK {
 
     public Brand brand() {
         return brand;
+    }
+
+    public JDKCLI cli() {
+        return cli;
+    }
+
+    /**
+     * Resolves the absolute path to a tool executable within this JDK installation.
+     *
+     * @param executableName filename of the CLI tool (e.g. {@code jar} or {@code keytool})
+     * @return absolute path to the executable, best-effort even when this JDK descriptor points directly to {@code bin}
+     */
+    public Path executablePath(String executableName) {
+        Objects.requireNonNull(executableName, "Executable name cannot be null");
+        Path binDirectory = path.resolve("bin");
+        Path candidate = binDirectory.resolve(executableName);
+        if (Files.exists(candidate))
+            return candidate;
+
+        return path.resolve(executableName);
     }
 
     public enum Brand {

--- a/src/main/java/dev/railroadide/railroad/java/JDKManager.java
+++ b/src/main/java/dev/railroadide/railroad/java/JDKManager.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * for quick lookup. Provides helpers to refresh the cache and query the discovered installations.
  */
 public class JDKManager {
-    public static final String JAVA_EXECUTABLE_NAME = javaExecutableName();
+    public static final String JAVA_EXECUTABLE_NAME = OperatingSystem.CURRENT == OperatingSystem.WINDOWS ? "java.exe" : "java";
 
     private static final List<String> WIN_JDK_PATHS = List.of(
         "{drive}:\\Program Files\\Java",
@@ -299,14 +299,5 @@ public class JDKManager {
         }
 
         return new ArrayList<>(candidates);
-    }
-
-    /**
-     * Resolves the platform-specific filename for a Java executable.
-     *
-     * @return {@code java.exe} on Windows; otherwise {@code java}
-     */
-    private static String javaExecutableName() {
-        return OperatingSystem.CURRENT == OperatingSystem.WINDOWS ? "java.exe" : "java";
     }
 }

--- a/src/main/java/dev/railroadide/railroad/java/JDKManager.java
+++ b/src/main/java/dev/railroadide/railroad/java/JDKManager.java
@@ -19,6 +19,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * for quick lookup. Provides helpers to refresh the cache and query the discovered installations.
  */
 public class JDKManager {
+    /**
+     * The name of the Java executable, platform-dependent (e.g., "java.exe" on Windows, "java" on Linux/macOS).
+     */
     public static final String JAVA_EXECUTABLE_NAME = OperatingSystem.CURRENT == OperatingSystem.WINDOWS ? "java.exe" : "java";
 
     private static final List<String> WIN_JDK_PATHS = List.of(

--- a/src/main/java/dev/railroadide/railroad/java/cli/CLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/CLIBuilder.java
@@ -3,20 +3,73 @@ package dev.railroadide.railroad.java.cli;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Defines a generic, fluent-style builder for constructing and executing command-line processes.
+ * This interface provides a common structure for setting arguments, environment variables,
+ * and other execution parameters.
+ *
+ * @param <R> The result type returned by the {@link #run()} method (e.g., {@link Process}).
+ * @param <T> The concrete type of the builder implementation, enabling method chaining.
+ */
 public interface CLIBuilder<R, T extends CLIBuilder<R, T>> {
+    /**
+     * Adds a single command-line argument to the process.
+     *
+     * @param arg The argument to add.
+     * @return The builder instance for chaining.
+     */
     T addArgument(String arg);
 
+    /**
+     * Sets the working directory for the process.
+     *
+     * @param path The path to the working directory.
+     * @return The builder instance for chaining.
+     */
     T setWorkingDirectory(Path path);
 
+    /**
+     * Sets a custom environment variable for the process.
+     *
+     * @param key   The name of the environment variable.
+     * @param value The value of the environment variable.
+     * @return The builder instance for chaining.
+     */
     T setEnvironmentVariable(String key, String value);
 
+    /**
+     * Specifies whether the process should inherit the environment variables of the current process.
+     *
+     * @param useSystemVars {@code true} to inherit system environment variables, {@code false} otherwise.
+     * @return The builder instance for chaining.
+     */
     T useSystemEnvironmentVariables(boolean useSystemVars);
 
+    /**
+     * Sets a timeout for the process execution.
+     *
+     * @param seconds The timeout duration in seconds.
+     * @return The builder instance for chaining.
+     */
     default T setTimeout(long seconds) {
         return setTimeout(seconds, TimeUnit.SECONDS);
     }
 
+    /**
+     * Sets a timeout for the process execution with a specific time unit.
+     *
+     * @param duration The timeout duration.
+     * @param unit     The {@link TimeUnit} of the duration.
+     * @return The builder instance for chaining.
+     */
     T setTimeout(long duration, TimeUnit unit);
 
+    /**
+     * Executes the configured command-line process.
+     *
+     * @return The result of the process execution, typically a {@link Process} object.
+     * @throws IllegalStateException if the builder is not in a runnable state (e.g., missing required parameters).
+     * @throws RuntimeException      if the process fails to start.
+     */
     R run();
 }

--- a/src/main/java/dev/railroadide/railroad/java/cli/CLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/CLIBuilder.java
@@ -1,0 +1,22 @@
+package dev.railroadide.railroad.java.cli;
+
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+public interface CLIBuilder<R, T extends CLIBuilder<R, T>> {
+    T addArgument(String arg);
+
+    T setWorkingDirectory(Path path);
+
+    T setEnvironmentVariable(String key, String value);
+
+    T useSystemEnvironmentVariables(boolean useSystemVars);
+
+    default T setTimeout(long seconds) {
+        return setTimeout(seconds, TimeUnit.SECONDS);
+    }
+
+    T setTimeout(long duration, TimeUnit unit);
+
+    R run();
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/JDKCLI.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/JDKCLI.java
@@ -1,0 +1,125 @@
+package dev.railroadide.railroad.java.cli;
+
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.impl.*;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public record JDKCLI(JDK jdk) {
+    public JDKCLI(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public JavaExecutableCLIBuilder launchMainClass(Path mainClassPath) {
+        return JavaExecutableCLIBuilder.classFile(jdk, mainClassPath);
+    }
+
+    public JavaExecutableCLIBuilder launchJar(Path jarFilePath) {
+        return JavaExecutableCLIBuilder.jarFile(jdk, jarFilePath);
+    }
+
+    public JavaExecutableCLIBuilder launchModule(String moduleName) {
+        return JavaExecutableCLIBuilder.module(jdk, moduleName);
+    }
+
+    public JavaExecutableCLIBuilder launchSourceFile(Path sourceFilePath) {
+        return JavaExecutableCLIBuilder.sourceFile(jdk, sourceFilePath);
+    }
+
+    public JarCLIBuilder jar() {
+        return JarCLIBuilder.create(jdk);
+    }
+
+    public JarsignerCLIBuilder jarsigner() {
+        return JarsignerCLIBuilder.create(jdk);
+    }
+
+    public JavadocCLIBuilder javadoc() {
+        return JavadocCLIBuilder.create(jdk);
+    }
+
+    public JavapCLIBuilder javap() {
+        return JavapCLIBuilder.create(jdk);
+    }
+
+    public JcmdCLIBuilder jcmd() {
+        return JcmdCLIBuilder.create(jdk);
+    }
+
+    public JdbCLIBuilder jdb() {
+        return JdbCLIBuilder.create(jdk);
+    }
+
+    public JdeprscanCLIBuilder jdeprscan() {
+        return JdeprscanCLIBuilder.create(jdk);
+    }
+
+    public JdepsCLIBuilder jdeps() {
+        return JdepsCLIBuilder.create(jdk);
+    }
+
+    public JfrCLIBuilder jfr() {
+        return JfrCLIBuilder.create(jdk);
+    }
+
+    public JinfoCLIBuilder jinfo() {
+        return JinfoCLIBuilder.create(jdk);
+    }
+
+    public JlinkCLIBuilder jlink() {
+        return JlinkCLIBuilder.create(jdk);
+    }
+
+    public JmapCLIBuilder jmap() {
+        return JmapCLIBuilder.create(jdk);
+    }
+
+    public JmodCLIBuilder jmod() {
+        return JmodCLIBuilder.create(jdk);
+    }
+
+    public JpackageCLIBuilder jpackage() {
+        return JpackageCLIBuilder.create(jdk);
+    }
+
+    public JpsCLIBuilder jps() {
+        return JpsCLIBuilder.create(jdk);
+    }
+
+    public JshellCLIBuilder jshell() {
+        return JshellCLIBuilder.create(jdk);
+    }
+
+    public JstackCLIBuilder jstack() {
+        return JstackCLIBuilder.create(jdk);
+    }
+
+    public JstatCLIBuilder jstat() {
+        return JstatCLIBuilder.create(jdk);
+    }
+
+    public JstatdCLIBuilder jstatd() {
+        return JstatdCLIBuilder.create(jdk);
+    }
+
+    public KeytoolCLIBuilder keytool() {
+        return KeytoolCLIBuilder.create(jdk);
+    }
+
+    public RmicCLIBuilder rmic() {
+        return RmicCLIBuilder.create(jdk);
+    }
+
+    public RmidCLIBuilder rmid() {
+        return RmidCLIBuilder.create(jdk);
+    }
+
+    public RmiregistryCLIBuilder rmiregistry() {
+        return RmiregistryCLIBuilder.create(jdk);
+    }
+
+    public SerialverCLIBuilder serialver() {
+        return SerialverCLIBuilder.create(jdk);
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/JDKCLI.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/JDKCLI.java
@@ -6,119 +6,270 @@ import dev.railroadide.railroad.java.cli.impl.*;
 import java.nio.file.Path;
 import java.util.Objects;
 
+/**
+ * Provides a fluent API for accessing and executing command-line tools within a specific {@link JDK}.
+ * This class acts as a factory for creating specialized {@link CLIBuilder} instances for various JDK executables
+ * like {@code java}, {@code jar}, {@code javadoc}, etc.
+ *
+ * @param jdk The {@link JDK} instance this CLI toolset is bound to.
+ */
 public record JDKCLI(JDK jdk) {
     public JDKCLI(JDK jdk) {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a builder for launching a Java application from a compiled class file.
+     *
+     * @param mainClassPath The path to the main {@code .class} file.
+     * @return A new {@link JavaExecutableCLIBuilder} instance.
+     */
     public JavaExecutableCLIBuilder launchMainClass(Path mainClassPath) {
         return JavaExecutableCLIBuilder.classFile(jdk, mainClassPath);
     }
 
+    /**
+     * Creates a builder for launching a Java application from an executable JAR file.
+     *
+     * @param jarFilePath The path to the {@code .jar} file.
+     * @return A new {@link JavaExecutableCLIBuilder} instance.
+     */
     public JavaExecutableCLIBuilder launchJar(Path jarFilePath) {
         return JavaExecutableCLIBuilder.jarFile(jdk, jarFilePath);
     }
 
+    /**
+     * Creates a builder for launching a Java application from a module.
+     *
+     * @param moduleName The name of the module to launch.
+     * @return A new {@link JavaExecutableCLIBuilder} instance.
+     */
     public JavaExecutableCLIBuilder launchModule(String moduleName) {
         return JavaExecutableCLIBuilder.module(jdk, moduleName);
     }
 
+    /**
+     * Creates a builder for launching a single-file Java source-code program.
+     *
+     * @param sourceFilePath The path to the {@code .java} source file.
+     * @return A new {@link JavaExecutableCLIBuilder} instance.
+     */
     public JavaExecutableCLIBuilder launchSourceFile(Path sourceFilePath) {
         return JavaExecutableCLIBuilder.sourceFile(jdk, sourceFilePath);
     }
 
+    /**
+     * Returns a builder that exercises the {@code jar} tool to create, update, or inspect archive files.
+     *
+     * @return a new {@link JarCLIBuilder}
+     */
     public JarCLIBuilder jar() {
         return JarCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for the {@code jarsigner} tool to sign or verify Java archives.
+     *
+     * @return a new {@link JarsignerCLIBuilder}
+     */
     public JarsignerCLIBuilder jarsigner() {
         return JarsignerCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder that runs {@code javadoc} to generate API documentation from source files.
+     *
+     * @return a new {@link JavadocCLIBuilder}
+     */
     public JavadocCLIBuilder javadoc() {
         return JavadocCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code javap} to disassemble class files and inspect their signatures.
+     *
+     * @return a new {@link JavapCLIBuilder}
+     */
     public JavapCLIBuilder javap() {
         return JavapCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code jcmd} to issue diagnostic commands to a running JVM.
+     *
+     * @return a new {@link JcmdCLIBuilder}
+     */
     public JcmdCLIBuilder jcmd() {
         return JcmdCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code jdb} to attach a debugger to a JVM session.
+     *
+     * @return a new {@link JdbCLIBuilder}
+     */
     public JdbCLIBuilder jdb() {
         return JdbCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder that runs {@code jdeprscan} to scan for deprecated API usage.
+     *
+     * @return a new {@link JdeprscanCLIBuilder}
+     */
     public JdeprscanCLIBuilder jdeprscan() {
         return JdeprscanCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code jdeps} to analyze module and package dependencies.
+     *
+     * @return a new {@link JdepsCLIBuilder}
+     */
     public JdepsCLIBuilder jdeps() {
         return JdepsCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder that interacts with {@code jfr} to manage Java Flight Recorder sessions.
+     *
+     * @return a new {@link JfrCLIBuilder}
+     */
     public JfrCLIBuilder jfr() {
         return JfrCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code jinfo} to print JVM configuration and system properties.
+     *
+     * @return a new {@link JinfoCLIBuilder}
+     */
     public JinfoCLIBuilder jinfo() {
         return JinfoCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder that drives {@code jlink} to create custom runtime images.
+     *
+     * @return a new {@link JlinkCLIBuilder}
+     */
     public JlinkCLIBuilder jlink() {
         return JlinkCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code jmap} to inspect heap and memory maps of a JVM.
+     *
+     * @return a new {@link JmapCLIBuilder}
+     */
     public JmapCLIBuilder jmap() {
         return JmapCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code jmod} to create, describe, or verify modules.
+     *
+     * @return a new {@link JmodCLIBuilder}
+     */
     public JmodCLIBuilder jmod() {
         return JmodCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code jpackage} to package self-contained applications.
+     *
+     * @return a new {@link JpackageCLIBuilder}
+     */
     public JpackageCLIBuilder jpackage() {
         return JpackageCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code jps} to list the Java processes running on the machine.
+     *
+     * @return a new {@link JpsCLIBuilder}
+     */
     public JpsCLIBuilder jps() {
         return JpsCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder that launches {@code jshell} for interactive REPL sessions.
+     *
+     * @return a new {@link JshellCLIBuilder}
+     */
     public JshellCLIBuilder jshell() {
         return JshellCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code jstack} to capture thread stack traces from a JVM.
+     *
+     * @return a new {@link JstackCLIBuilder}
+     */
     public JstackCLIBuilder jstack() {
         return JstackCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code jstat} to query runtime statistics of a JVM.
+     *
+     * @return a new {@link JstatCLIBuilder}
+     */
     public JstatCLIBuilder jstat() {
         return JstatCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder that starts {@code jstatd} for remote JVM monitoring.
+     *
+     * @return a new {@link JstatdCLIBuilder}
+     */
     public JstatdCLIBuilder jstatd() {
         return JstatdCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code keytool} to manage keystores and certificates.
+     *
+     * @return a new {@link KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder keytool() {
         return KeytoolCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code rmic} to generate RMI stubs and skeletons.
+     *
+     * @return a new {@link RmicCLIBuilder}
+     */
     public RmicCLIBuilder rmic() {
         return RmicCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code rmid} to launch the RMI activation daemon.
+     *
+     * @return a new {@link RmidCLIBuilder}
+     */
     public RmidCLIBuilder rmid() {
         return RmidCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder that starts {@code rmiregistry} on a specified port.
+     *
+     * @return a new {@link RmiregistryCLIBuilder}
+     */
     public RmiregistryCLIBuilder rmiregistry() {
         return RmiregistryCLIBuilder.create(jdk);
     }
 
+    /**
+     * Returns a builder for {@code serialver} to obtain {@code serialVersionUID} values for classes.
+     *
+     * @return a new {@link SerialverCLIBuilder}
+     */
     public SerialverCLIBuilder serialver() {
         return SerialverCLIBuilder.create(jdk);
     }

--- a/src/main/java/dev/railroadide/railroad/java/cli/ProcessExecution.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/ProcessExecution.java
@@ -4,10 +4,23 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A utility class for managing external {@link Process} instances, primarily for enforcing execution timeouts.
+ */
 public final class ProcessExecution {
     private ProcessExecution() {
     }
 
+    /**
+     * Waits for a process to complete, enforcing a specified timeout. If the process does not
+     * finish within the given duration, it is forcibly terminated.
+     *
+     * @param process  The {@link Process} to monitor.
+     * @param duration The maximum time to wait. If zero or negative, no timeout is enforced.
+     * @param unit     The {@link TimeUnit} for the duration.
+     * @param toolName The name of the tool being executed, used for logging and error messages.
+     * @throws RuntimeException if the process times out or the waiting thread is interrupted.
+     */
     public static void enforceTimeout(Process process, long duration, TimeUnit unit, String toolName) {
         Objects.requireNonNull(process, "Process cannot be null");
         Objects.requireNonNull(toolName, "Tool name cannot be null");
@@ -31,6 +44,11 @@ public final class ProcessExecution {
         }
     }
 
+    /**
+     * Forcefully terminates a process, trying a graceful destruction first, followed by a forcible one if it remains alive.
+     *
+     * @param process The process to destroy.
+     */
     private static void destroyProcess(Process process) {
         process.destroy();
         if (process.isAlive()) {

--- a/src/main/java/dev/railroadide/railroad/java/cli/ProcessExecution.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/ProcessExecution.java
@@ -1,0 +1,40 @@
+package dev.railroadide.railroad.java.cli;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public final class ProcessExecution {
+    private ProcessExecution() {
+    }
+
+    public static void enforceTimeout(Process process, long duration, TimeUnit unit, String toolName) {
+        Objects.requireNonNull(process, "Process cannot be null");
+        Objects.requireNonNull(toolName, "Tool name cannot be null");
+        if (duration <= 0)
+            return;
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        boolean finished;
+        try {
+            finished = process.waitFor(duration, unit);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            destroyProcess(process);
+            throw new RuntimeException("Interrupted while waiting for " + toolName + " process to finish.", exception);
+        }
+
+        if (!finished) {
+            destroyProcess(process);
+            throw new RuntimeException(toolName + " process timed out after "
+                + duration + " " + unit.toString().toLowerCase(Locale.ROOT));
+        }
+    }
+
+    private static void destroyProcess(Process process) {
+        process.destroy();
+        if (process.isAlive()) {
+            process.destroyForcibly();
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JarCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JarCLIBuilder.java
@@ -11,6 +11,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A fluent builder for creating and executing {@code jar} commands.
+ * <p>
+ * This builder provides methods for specifying all major operations of the {@code jar} tool,
+ * such as creating, updating, listing, and extracting archives. It supports setting various
+ * options like the main class, manifest, module version, and file entries.
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jar.html">jar command documentation</a>
+ */
 public class JarCLIBuilder implements CLIBuilder<Process, JarCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jar.exe" : "jar";
 
@@ -29,6 +38,12 @@ public class JarCLIBuilder implements CLIBuilder<Process, JarCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@link JarCLIBuilder} for the specified JDK.
+     *
+     * @param jdk The JDK to use for running the {@code jar} command.
+     * @return A new builder instance.
+     */
     public static JarCLIBuilder create(JDK jdk) {
         return new JarCLIBuilder(jdk);
     }
@@ -80,48 +95,102 @@ public class JarCLIBuilder implements CLIBuilder<Process, JarCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the operation mode to create a new archive ({@code --create}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder createArchive() {
         return operation(OperationMode.CREATE);
     }
 
+    /**
+     * Sets the operation mode to list the contents of an archive ({@code --list}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder listContents() {
         return operation(OperationMode.LIST);
     }
 
+    /**
+     * Sets the operation mode to update an existing archive ({@code --update}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder updateArchive() {
         return operation(OperationMode.UPDATE);
     }
 
+    /**
+     * Sets the operation mode to extract files from an archive ({@code --extract}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder extractArchive() {
         return operation(OperationMode.EXTRACT);
     }
 
+    /**
+     * Sets the operation mode to describe the module details of an archive ({@code --describe-module}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder describeModule() {
         return operation(OperationMode.DESCRIBE_MODULE);
     }
 
+    /**
+     * Sets the operation mode to validate an archive ({@code --validate}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder validateArchive() {
         return operation(OperationMode.VALIDATE);
     }
 
+    /**
+     * Sets the operation mode to generate index information for a set of JAR files ({@code --generate-index}).
+     *
+     * @param jarFile The main JAR file for which the index is generated.
+     * @return This builder instance.
+     */
     public JarCLIBuilder generateIndex(Path jarFile) {
         Objects.requireNonNull(jarFile, "JAR file path cannot be null");
         this.generateIndexTarget = jarFile.toString();
         return operation(OperationMode.GENERATE_INDEX);
     }
 
+    /**
+     * Specifies the archive file name ({@code --file}).
+     *
+     * @param jarFile The path to the JAR file.
+     * @return This builder instance.
+     */
     public JarCLIBuilder archiveFile(Path jarFile) {
         Objects.requireNonNull(jarFile, "Archive file path cannot be null");
         this.arguments.add("--file " + jarFile);
         return this;
     }
 
+    /**
+     * Specifies the archive file name ({@code --file}).
+     *
+     * @param jarFile The path to the JAR file as a string.
+     * @return This builder instance.
+     */
     public JarCLIBuilder archiveFile(String jarFile) {
         Objects.requireNonNull(jarFile, "Archive file path cannot be null");
         this.arguments.add("--file " + jarFile);
         return this;
     }
 
+    /**
+     * Adds multi-release versioned entries to the JAR ({@code --release}).
+     *
+     * @param version The release version (must be 9 or greater).
+     * @return This builder instance.
+     */
     public JarCLIBuilder releaseEntries(int version) {
         if (version < 9)
             throw new IllegalArgumentException("Release version must be 9 or greater");
@@ -130,119 +199,238 @@ public class JarCLIBuilder implements CLIBuilder<Process, JarCLIBuilder> {
         return this;
     }
 
+    /**
+     * Enables verbose output ({@code --verbose}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder verbose() {
         this.arguments.add("--verbose");
         return this;
     }
 
+    /**
+     * Sets the main class for an executable JAR ({@code --main-class}).
+     *
+     * @param className The fully qualified name of the main class.
+     * @return This builder instance.
+     */
     public JarCLIBuilder mainClass(String className) {
         Objects.requireNonNull(className, "Main class cannot be null");
         this.arguments.add("--main-class " + className);
         return this;
     }
 
+    /**
+     * Includes a custom manifest file ({@code --manifest}).
+     *
+     * @param manifestPath The path to the manifest file.
+     * @return This builder instance.
+     */
     public JarCLIBuilder manifest(Path manifestPath) {
         Objects.requireNonNull(manifestPath, "Manifest path cannot be null");
         this.arguments.add("--manifest " + manifestPath);
         return this;
     }
 
+    /**
+     * Includes a custom manifest file ({@code --manifest}).
+     *
+     * @param manifestPath The path to the manifest file as a string.
+     * @return This builder instance.
+     */
     public JarCLIBuilder manifest(String manifestPath) {
         Objects.requireNonNull(manifestPath, "Manifest path cannot be null");
         this.arguments.add("--manifest " + manifestPath);
         return this;
     }
 
+    /**
+     * Prevents the creation of a manifest file for the entries ({@code --no-manifest}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder noManifest() {
         this.arguments.add("--no-manifest");
         return this;
     }
 
+    /**
+     * Sets the module version for a modular JAR ({@code --module-version}).
+     *
+     * @param version The module version string.
+     * @return This builder instance.
+     */
     public JarCLIBuilder moduleVersion(String version) {
         Objects.requireNonNull(version, "Module version cannot be null");
         this.arguments.add("--module-version " + version);
         return this;
     }
 
+    /**
+     * Computes and records hashes of modules matched by the given pattern ({@code --hash-modules}).
+     *
+     * @param pattern The module hashing pattern.
+     * @return This builder instance.
+     */
     public JarCLIBuilder hashModules(String pattern) {
         Objects.requireNonNull(pattern, "Module hash pattern cannot be null");
         this.arguments.add("--hash-modules " + pattern);
         return this;
     }
 
+    /**
+     * Specifies the module path ({@code --module-path}).
+     *
+     * @param modulePaths An array of paths to modules.
+     * @return This builder instance.
+     */
     public JarCLIBuilder modulePath(String... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module paths cannot be null");
         this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
         return this;
     }
 
+    /**
+     * Specifies the module path ({@code --module-path}).
+     *
+     * @param modulePaths An array of paths to modules.
+     * @return This builder instance.
+     */
     public JarCLIBuilder modulePath(Path... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module paths cannot be null");
         String[] pathStrings = Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new);
         return modulePath(pathStrings);
     }
 
+    /**
+     * Reads additional arguments from a file ({@code @file}).
+     *
+     * @param argFilePath The path to the argument file.
+     * @return This builder instance.
+     */
     public JarCLIBuilder argumentFile(Path argFilePath) {
         Objects.requireNonNull(argFilePath, "Argument file path cannot be null");
         this.arguments.add("@" + argFilePath);
         return this;
     }
 
+    /**
+     * Disables compression for the archive ({@code --no-compress}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder noCompress() {
         this.arguments.add("--no-compress");
         return this;
     }
 
+    /**
+     * Sets a timestamp for all entries in the archive ({@code --date}).
+     *
+     * @param isoTimestamp The timestamp in ISO-8601 format.
+     * @return This builder instance.
+     */
     public JarCLIBuilder entryTimestamp(String isoTimestamp) {
         Objects.requireNonNull(isoTimestamp, "Timestamp cannot be null");
         this.arguments.add("--date " + isoTimestamp);
         return this;
     }
 
+    /**
+     * Displays the help message ({@code --help}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder help() {
         this.arguments.add("--help");
         return this;
     }
 
+    /**
+     * Displays the compatibility help message ({@code --help:compat}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder helpCompat() {
         this.arguments.add("--help:compat");
         return this;
     }
 
+    /**
+     * Displays extra help information ({@code --help-extra}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder helpExtra() {
         this.arguments.add("--help-extra");
         return this;
     }
 
+    /**
+     * Displays the version information ({@code --version}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder versionInfo() {
         this.arguments.add("--version");
         return this;
     }
 
+    /**
+     * Changes the directory during execution ({@code -C}).
+     *
+     * @param directory The directory to change to.
+     * @return This builder instance.
+     */
     public JarCLIBuilder changeDirectory(Path directory) {
         Objects.requireNonNull(directory, "Directory cannot be null");
         this.fileEntries.add("-C " + directory);
         return this;
     }
 
+    /**
+     * Changes the directory during execution ({@code -C}).
+     *
+     * @param directory The directory to change to.
+     * @return This builder instance.
+     */
     public JarCLIBuilder changeDirectory(String directory) {
         Objects.requireNonNull(directory, "Directory cannot be null");
         this.fileEntries.add("-C " + directory);
         return this;
     }
 
+    /**
+     * Adds a file to be included in the archive.
+     *
+     * @param filePath The path to the file.
+     * @return This builder instance.
+     */
     public JarCLIBuilder addFile(Path filePath) {
         Objects.requireNonNull(filePath, "File path cannot be null");
         this.fileEntries.add(filePath.toString());
         return this;
     }
 
+    /**
+     * Adds a file to be included in the archive.
+     *
+     * @param filePath The path to the file as a string.
+     * @return This builder instance.
+     */
     public JarCLIBuilder addFile(String filePath) {
         Objects.requireNonNull(filePath, "File path cannot be null");
         this.fileEntries.add(filePath);
         return this;
     }
 
+    /**
+     * Adds multiple files to be included in the archive.
+     *
+     * @param files An array of file paths.
+     * @return This builder instance.
+     */
     public JarCLIBuilder addFiles(String... files) {
         Objects.requireNonNull(files, "Files cannot be null");
         for (String file : files) {
@@ -252,6 +440,12 @@ public class JarCLIBuilder implements CLIBuilder<Process, JarCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds multiple files to be included in the archive.
+     *
+     * @param files An array of file paths.
+     * @return This builder instance.
+     */
     public JarCLIBuilder addFiles(Path... files) {
         Objects.requireNonNull(files, "Files cannot be null");
         for (Path file : files) {
@@ -261,18 +455,35 @@ public class JarCLIBuilder implements CLIBuilder<Process, JarCLIBuilder> {
         return this;
     }
 
+    /**
+     * Specifies the destination directory for extracted files ({@code --dir}).
+     *
+     * @param directory The destination directory.
+     * @return This builder instance.
+     */
     public JarCLIBuilder destinationDirectory(Path directory) {
         Objects.requireNonNull(directory, "Directory cannot be null");
         this.arguments.add("--dir " + directory);
         return this;
     }
 
+    /**
+     * Specifies the destination directory for extracted files ({@code --dir}).
+     *
+     * @param directory The destination directory as a string.
+     * @return This builder instance.
+     */
     public JarCLIBuilder destinationDirectory(String directory) {
         Objects.requireNonNull(directory, "Directory cannot be null");
         this.arguments.add("--dir " + directory);
         return this;
     }
 
+    /**
+     * Keeps existing files when extracting ({@code --keep-old-files}).
+     *
+     * @return This builder instance.
+     */
     public JarCLIBuilder keepOldFiles() {
         this.arguments.add("--keep-old-files");
         return this;
@@ -321,14 +532,38 @@ public class JarCLIBuilder implements CLIBuilder<Process, JarCLIBuilder> {
         }
     }
 
+    /**
+     * Represents the primary operation modes for the {@code jar} command.
+     */
     @Getter
     public enum OperationMode {
+        /**
+         * Corresponds to the {@code --create} flag.
+         */
         CREATE("--create"),
+        /**
+         * Corresponds to the {@code --list} flag.
+         */
         LIST("--list"),
+        /**
+         * Corresponds to the {@code --update} flag.
+         */
         UPDATE("--update"),
+        /**
+         * Corresponds to the {@code --extract} flag.
+         */
         EXTRACT("--extract"),
+        /**
+         * Corresponds to the {@code --validate} flag.
+         */
         VALIDATE("--validate"),
+        /**
+         * Corresponds to the {@code --describe-module} flag.
+         */
         DESCRIBE_MODULE("--describe-module"),
+        /**
+         * Corresponds to the {@code --generate-index} flag.
+         */
         GENERATE_INDEX("--generate-index");
 
         private final String flag;

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JarCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JarCLIBuilder.java
@@ -1,0 +1,340 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+import lombok.Getter;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JarCLIBuilder implements CLIBuilder<Process, JarCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jar.exe" : "jar";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<String> fileEntries = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private OperationMode operationMode;
+    private String generateIndexTarget;
+
+    private JarCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JarCLIBuilder create(JDK jdk) {
+        return new JarCLIBuilder(jdk);
+    }
+
+    @Override
+    public JarCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JarCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JarCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JarCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JarCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    private JarCLIBuilder operation(OperationMode mode) {
+        this.operationMode = Objects.requireNonNull(mode, "Operation mode cannot be null");
+        if (mode != OperationMode.GENERATE_INDEX) {
+            this.generateIndexTarget = null;
+        }
+
+        return this;
+    }
+
+    public JarCLIBuilder createArchive() {
+        return operation(OperationMode.CREATE);
+    }
+
+    public JarCLIBuilder listContents() {
+        return operation(OperationMode.LIST);
+    }
+
+    public JarCLIBuilder updateArchive() {
+        return operation(OperationMode.UPDATE);
+    }
+
+    public JarCLIBuilder extractArchive() {
+        return operation(OperationMode.EXTRACT);
+    }
+
+    public JarCLIBuilder describeModule() {
+        return operation(OperationMode.DESCRIBE_MODULE);
+    }
+
+    public JarCLIBuilder validateArchive() {
+        return operation(OperationMode.VALIDATE);
+    }
+
+    public JarCLIBuilder generateIndex(Path jarFile) {
+        Objects.requireNonNull(jarFile, "JAR file path cannot be null");
+        this.generateIndexTarget = jarFile.toString();
+        return operation(OperationMode.GENERATE_INDEX);
+    }
+
+    public JarCLIBuilder archiveFile(Path jarFile) {
+        Objects.requireNonNull(jarFile, "Archive file path cannot be null");
+        this.arguments.add("--file " + jarFile);
+        return this;
+    }
+
+    public JarCLIBuilder archiveFile(String jarFile) {
+        Objects.requireNonNull(jarFile, "Archive file path cannot be null");
+        this.arguments.add("--file " + jarFile);
+        return this;
+    }
+
+    public JarCLIBuilder releaseEntries(int version) {
+        if (version < 9)
+            throw new IllegalArgumentException("Release version must be 9 or greater");
+
+        this.fileEntries.add("--release " + version);
+        return this;
+    }
+
+    public JarCLIBuilder verbose() {
+        this.arguments.add("--verbose");
+        return this;
+    }
+
+    public JarCLIBuilder mainClass(String className) {
+        Objects.requireNonNull(className, "Main class cannot be null");
+        this.arguments.add("--main-class " + className);
+        return this;
+    }
+
+    public JarCLIBuilder manifest(Path manifestPath) {
+        Objects.requireNonNull(manifestPath, "Manifest path cannot be null");
+        this.arguments.add("--manifest " + manifestPath);
+        return this;
+    }
+
+    public JarCLIBuilder manifest(String manifestPath) {
+        Objects.requireNonNull(manifestPath, "Manifest path cannot be null");
+        this.arguments.add("--manifest " + manifestPath);
+        return this;
+    }
+
+    public JarCLIBuilder noManifest() {
+        this.arguments.add("--no-manifest");
+        return this;
+    }
+
+    public JarCLIBuilder moduleVersion(String version) {
+        Objects.requireNonNull(version, "Module version cannot be null");
+        this.arguments.add("--module-version " + version);
+        return this;
+    }
+
+    public JarCLIBuilder hashModules(String pattern) {
+        Objects.requireNonNull(pattern, "Module hash pattern cannot be null");
+        this.arguments.add("--hash-modules " + pattern);
+        return this;
+    }
+
+    public JarCLIBuilder modulePath(String... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module paths cannot be null");
+        this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
+        return this;
+    }
+
+    public JarCLIBuilder modulePath(Path... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module paths cannot be null");
+        String[] pathStrings = Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new);
+        return modulePath(pathStrings);
+    }
+
+    public JarCLIBuilder argumentFile(Path argFilePath) {
+        Objects.requireNonNull(argFilePath, "Argument file path cannot be null");
+        this.arguments.add("@" + argFilePath);
+        return this;
+    }
+
+    public JarCLIBuilder noCompress() {
+        this.arguments.add("--no-compress");
+        return this;
+    }
+
+    public JarCLIBuilder entryTimestamp(String isoTimestamp) {
+        Objects.requireNonNull(isoTimestamp, "Timestamp cannot be null");
+        this.arguments.add("--date " + isoTimestamp);
+        return this;
+    }
+
+    public JarCLIBuilder help() {
+        this.arguments.add("--help");
+        return this;
+    }
+
+    public JarCLIBuilder helpCompat() {
+        this.arguments.add("--help:compat");
+        return this;
+    }
+
+    public JarCLIBuilder helpExtra() {
+        this.arguments.add("--help-extra");
+        return this;
+    }
+
+    public JarCLIBuilder versionInfo() {
+        this.arguments.add("--version");
+        return this;
+    }
+
+    public JarCLIBuilder changeDirectory(Path directory) {
+        Objects.requireNonNull(directory, "Directory cannot be null");
+        this.fileEntries.add("-C " + directory);
+        return this;
+    }
+
+    public JarCLIBuilder changeDirectory(String directory) {
+        Objects.requireNonNull(directory, "Directory cannot be null");
+        this.fileEntries.add("-C " + directory);
+        return this;
+    }
+
+    public JarCLIBuilder addFile(Path filePath) {
+        Objects.requireNonNull(filePath, "File path cannot be null");
+        this.fileEntries.add(filePath.toString());
+        return this;
+    }
+
+    public JarCLIBuilder addFile(String filePath) {
+        Objects.requireNonNull(filePath, "File path cannot be null");
+        this.fileEntries.add(filePath);
+        return this;
+    }
+
+    public JarCLIBuilder addFiles(String... files) {
+        Objects.requireNonNull(files, "Files cannot be null");
+        for (String file : files) {
+            addFile(file);
+        }
+
+        return this;
+    }
+
+    public JarCLIBuilder addFiles(Path... files) {
+        Objects.requireNonNull(files, "Files cannot be null");
+        for (Path file : files) {
+            addFile(file);
+        }
+
+        return this;
+    }
+
+    public JarCLIBuilder destinationDirectory(Path directory) {
+        Objects.requireNonNull(directory, "Directory cannot be null");
+        this.arguments.add("--dir " + directory);
+        return this;
+    }
+
+    public JarCLIBuilder destinationDirectory(String directory) {
+        Objects.requireNonNull(directory, "Directory cannot be null");
+        this.arguments.add("--dir " + directory);
+        return this;
+    }
+
+    public JarCLIBuilder keepOldFiles() {
+        this.arguments.add("--keep-old-files");
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        if (operationMode == null)
+            throw new IllegalStateException("An operation mode must be specified before running the jar command.");
+
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+
+        if (operationMode == OperationMode.GENERATE_INDEX) {
+            if (generateIndexTarget == null)
+                throw new IllegalStateException("Generate-index operation requires a target jar file.");
+
+            command.add(operationMode.getFlag() + "=" + generateIndexTarget);
+        } else {
+            command.add(operationMode.getFlag());
+        }
+
+        command.addAll(arguments);
+        command.addAll(fileEntries);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jar");
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jar process", exception);
+        }
+    }
+
+    @Getter
+    public enum OperationMode {
+        CREATE("--create"),
+        LIST("--list"),
+        UPDATE("--update"),
+        EXTRACT("--extract"),
+        VALIDATE("--validate"),
+        DESCRIBE_MODULE("--describe-module"),
+        GENERATE_INDEX("--generate-index");
+
+        private final String flag;
+
+        OperationMode(String flag) {
+            this.flag = flag;
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JarsignerCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JarsignerCLIBuilder.java
@@ -1,0 +1,483 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+import lombok.Getter;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jarsigner.exe" : "jarsigner";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<String> verifyAliases = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private OperationMode operationMode = OperationMode.SIGN;
+    private String jarFile;
+    private String signingAlias;
+
+    private JarsignerCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JarsignerCLIBuilder create(JDK jdk) {
+        return new JarsignerCLIBuilder(jdk);
+    }
+
+    @Override
+    public JarsignerCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JarsignerCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JarsignerCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JarsignerCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JarsignerCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JarsignerCLIBuilder sign(Path jarFile, String alias) {
+        Objects.requireNonNull(jarFile, "JAR file cannot be null");
+        Objects.requireNonNull(alias, "Alias cannot be null");
+        this.operationMode = OperationMode.SIGN;
+        this.jarFile = jarFile.toString();
+        this.signingAlias = alias;
+        this.verifyAliases.clear();
+        return this;
+    }
+
+    public JarsignerCLIBuilder sign(String jarFile, String alias) {
+        Objects.requireNonNull(jarFile, "JAR file cannot be null");
+        Objects.requireNonNull(alias, "Alias cannot be null");
+        this.operationMode = OperationMode.SIGN;
+        this.jarFile = jarFile;
+        this.signingAlias = alias;
+        this.verifyAliases.clear();
+        return this;
+    }
+
+    public JarsignerCLIBuilder verify(Path jarFile, String... aliases) {
+        Objects.requireNonNull(jarFile, "JAR file cannot be null");
+        this.operationMode = OperationMode.VERIFY;
+        this.jarFile = jarFile.toString();
+        this.signingAlias = null;
+        this.verifyAliases.clear();
+        if (aliases != null) {
+            for (String alias : aliases) {
+                addVerifyAlias(alias);
+            }
+        }
+
+        return this;
+    }
+
+    public JarsignerCLIBuilder verify(String jarFile, String... aliases) {
+        Objects.requireNonNull(jarFile, "JAR file cannot be null");
+        this.operationMode = OperationMode.VERIFY;
+        this.jarFile = jarFile;
+        this.signingAlias = null;
+        this.verifyAliases.clear();
+        if (aliases != null) {
+            for (String alias : aliases) {
+                addVerifyAlias(alias);
+            }
+        }
+
+        return this;
+    }
+
+    public JarsignerCLIBuilder version() {
+        this.operationMode = OperationMode.VERSION;
+        this.jarFile = null;
+        this.signingAlias = null;
+        this.verifyAliases.clear();
+        return this;
+    }
+
+    public JarsignerCLIBuilder jarFile(Path jarFile) {
+        Objects.requireNonNull(jarFile, "JAR file cannot be null");
+        this.jarFile = jarFile.toString();
+        return this;
+    }
+
+    public JarsignerCLIBuilder jarFile(String jarFile) {
+        Objects.requireNonNull(jarFile, "JAR file cannot be null");
+        this.jarFile = jarFile;
+        return this;
+    }
+
+    public JarsignerCLIBuilder signingAlias(String alias) {
+        Objects.requireNonNull(alias, "Alias cannot be null");
+        this.signingAlias = alias;
+        return this;
+    }
+
+    public JarsignerCLIBuilder addVerifyAlias(String alias) {
+        Objects.requireNonNull(alias, "Alias cannot be null");
+        this.verifyAliases.add(alias);
+        return this;
+    }
+
+    public JarsignerCLIBuilder addVerifyAliases(String... aliases) {
+        Objects.requireNonNull(aliases, "Aliases cannot be null");
+        for (String alias : aliases) {
+            addVerifyAlias(alias);
+        }
+
+        return this;
+    }
+
+    public JarsignerCLIBuilder keystore(Path keystorePath) {
+        Objects.requireNonNull(keystorePath, "Keystore path cannot be null");
+        return keystore(keystorePath.toString());
+    }
+
+    public JarsignerCLIBuilder keystore(String location) {
+        Objects.requireNonNull(location, "Keystore location cannot be null");
+        this.arguments.add("-keystore " + location);
+        return this;
+    }
+
+    public JarsignerCLIBuilder storePassword(String password) {
+        return addPasswordArgument("-storepass", PasswordSource.DIRECT, password);
+    }
+
+    public JarsignerCLIBuilder storePasswordFromEnv(String envVariable) {
+        return addPasswordArgument("-storepass", PasswordSource.ENVIRONMENT, envVariable);
+    }
+
+    public JarsignerCLIBuilder storePasswordFromFile(Path file) {
+        Objects.requireNonNull(file, "Password file cannot be null");
+        return addPasswordArgument("-storepass", PasswordSource.FILE, file.toString());
+    }
+
+    public JarsignerCLIBuilder storePasswordFromFile(String file) {
+        return addPasswordArgument("-storepass", PasswordSource.FILE, file);
+    }
+
+    public JarsignerCLIBuilder storeType(String storeType) {
+        Objects.requireNonNull(storeType, "Store type cannot be null");
+        this.arguments.add("-storetype " + storeType);
+        return this;
+    }
+
+    public JarsignerCLIBuilder keyPassword(String password) {
+        return addPasswordArgument("-keypass", PasswordSource.DIRECT, password);
+    }
+
+    public JarsignerCLIBuilder keyPasswordFromEnv(String envVariable) {
+        return addPasswordArgument("-keypass", PasswordSource.ENVIRONMENT, envVariable);
+    }
+
+    public JarsignerCLIBuilder keyPasswordFromFile(Path file) {
+        Objects.requireNonNull(file, "Password file cannot be null");
+        return addPasswordArgument("-keypass", PasswordSource.FILE, file.toString());
+    }
+
+    public JarsignerCLIBuilder keyPasswordFromFile(String file) {
+        return addPasswordArgument("-keypass", PasswordSource.FILE, file);
+    }
+
+    public JarsignerCLIBuilder certificateChain(Path certChainFile) {
+        Objects.requireNonNull(certChainFile, "Certificate chain file cannot be null");
+        this.arguments.add("-certchain " + certChainFile);
+        return this;
+    }
+
+    public JarsignerCLIBuilder certificateChain(String certChainFile) {
+        Objects.requireNonNull(certChainFile, "Certificate chain file cannot be null");
+        this.arguments.add("-certchain " + certChainFile);
+        return this;
+    }
+
+    public JarsignerCLIBuilder signatureFile(String baseName) {
+        Objects.requireNonNull(baseName, "Signature file base name cannot be null");
+        this.arguments.add("-sigfile " + baseName);
+        return this;
+    }
+
+    public JarsignerCLIBuilder signedJar(Path signedJarPath) {
+        Objects.requireNonNull(signedJarPath, "Signed JAR path cannot be null");
+        this.arguments.add("-signedjar " + signedJarPath);
+        return this;
+    }
+
+    public JarsignerCLIBuilder signedJar(String signedJarPath) {
+        Objects.requireNonNull(signedJarPath, "Signed JAR path cannot be null");
+        this.arguments.add("-signedjar " + signedJarPath);
+        return this;
+    }
+
+    public JarsignerCLIBuilder digestAlgorithm(String algorithm) {
+        Objects.requireNonNull(algorithm, "Digest algorithm cannot be null");
+        this.arguments.add("-digestalg " + algorithm);
+        return this;
+    }
+
+    public JarsignerCLIBuilder signatureAlgorithm(String algorithm) {
+        Objects.requireNonNull(algorithm, "Signature algorithm cannot be null");
+        this.arguments.add("-sigalg " + algorithm);
+        return this;
+    }
+
+    public JarsignerCLIBuilder verbose() {
+        this.arguments.add("-verbose");
+        return this;
+    }
+
+    public JarsignerCLIBuilder verbose(VerboseDetail detail) {
+        Objects.requireNonNull(detail, "Verbose detail cannot be null");
+        if (detail == VerboseDetail.ALL) {
+            this.arguments.add("-verbose");
+        } else {
+            this.arguments.add("-verbose:" + detail.getToken());
+        }
+
+        return this;
+    }
+
+    public JarsignerCLIBuilder includeCertificateDetails() {
+        this.arguments.add("-certs");
+        return this;
+    }
+
+    public JarsignerCLIBuilder enableRevocationCheck() {
+        this.arguments.add("-revCheck");
+        return this;
+    }
+
+    public JarsignerCLIBuilder timestampAuthority(String url) {
+        Objects.requireNonNull(url, "TSA URL cannot be null");
+        this.arguments.add("-tsa " + url);
+        return this;
+    }
+
+    public JarsignerCLIBuilder timestampAuthorityCertificate(String alias) {
+        Objects.requireNonNull(alias, "TSA certificate alias cannot be null");
+        this.arguments.add("-tsacert " + alias);
+        return this;
+    }
+
+    public JarsignerCLIBuilder timestampPolicyId(String policyId) {
+        Objects.requireNonNull(policyId, "Policy ID cannot be null");
+        this.arguments.add("-tsapolicyid " + policyId);
+        return this;
+    }
+
+    public JarsignerCLIBuilder timestampDigestAlgorithm(String algorithm) {
+        Objects.requireNonNull(algorithm, "Timestamp digest algorithm cannot be null");
+        this.arguments.add("-tsadigestalg " + algorithm);
+        return this;
+    }
+
+    public JarsignerCLIBuilder includeSignatureFileInBlock() {
+        this.arguments.add("-internalsf");
+        return this;
+    }
+
+    public JarsignerCLIBuilder sectionsOnly() {
+        this.arguments.add("-sectionsonly");
+        return this;
+    }
+
+    public JarsignerCLIBuilder protectedAuthentication(boolean required) {
+        this.arguments.add("-protected " + required);
+        return this;
+    }
+
+    public JarsignerCLIBuilder providerName(String providerName) {
+        Objects.requireNonNull(providerName, "Provider name cannot be null");
+        this.arguments.add("-providerName " + providerName);
+        return this;
+    }
+
+    public JarsignerCLIBuilder addProvider(String providerName) {
+        Objects.requireNonNull(providerName, "Provider name cannot be null");
+        this.arguments.add("-addprovider " + providerName);
+        return this;
+    }
+
+    public JarsignerCLIBuilder addProvider(String providerName, String providerArg) {
+        Objects.requireNonNull(providerName, "Provider name cannot be null");
+        this.arguments.add("-addprovider " + providerName);
+        Objects.requireNonNull(providerArg, "Provider argument cannot be null");
+        this.arguments.add("-providerArg " + providerArg);
+        return this;
+    }
+
+    public JarsignerCLIBuilder providerClass(String className) {
+        Objects.requireNonNull(className, "Provider class cannot be null");
+        this.arguments.add("-providerClass " + className);
+        return this;
+    }
+
+    public JarsignerCLIBuilder providerClass(String className, String providerArg) {
+        Objects.requireNonNull(className, "Provider class cannot be null");
+        this.arguments.add("-providerClass " + className);
+        Objects.requireNonNull(providerArg, "Provider argument cannot be null");
+        this.arguments.add("-providerArg " + providerArg);
+        return this;
+    }
+
+    public JarsignerCLIBuilder providerPath(String classpath) {
+        Objects.requireNonNull(classpath, "Provider path cannot be null");
+        this.arguments.add("-providerPath " + classpath);
+        return this;
+    }
+
+    public JarsignerCLIBuilder javaOption(String option) {
+        Objects.requireNonNull(option, "Java option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    public JarsignerCLIBuilder strictMode() {
+        this.arguments.add("-strict");
+        return this;
+    }
+
+    public JarsignerCLIBuilder configurationFile(String url) {
+        Objects.requireNonNull(url, "Configuration URL cannot be null");
+        this.arguments.add("-conf " + url);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        if (operationMode == OperationMode.SIGN) {
+            if (jarFile == null)
+                throw new IllegalStateException("A JAR file must be specified when signing.");
+            if (signingAlias == null)
+                throw new IllegalStateException("An alias must be provided when signing.");
+        } else if (operationMode == OperationMode.VERIFY) {
+            if (jarFile == null)
+                throw new IllegalStateException("A JAR file must be specified when verifying.");
+        }
+
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        if (operationMode.getFlag() != null) {
+            command.add(operationMode.getFlag());
+        }
+
+        command.addAll(arguments);
+        if (operationMode != OperationMode.VERSION && jarFile != null) {
+            command.add(jarFile);
+            if (operationMode == OperationMode.SIGN) {
+                command.add(signingAlias);
+            } else if (operationMode == OperationMode.VERIFY && !verifyAliases.isEmpty()) {
+                command.addAll(verifyAliases);
+            }
+        }
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jarsigner");
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jarsigner process", exception);
+        }
+    }
+
+    private JarsignerCLIBuilder addPasswordArgument(String option, PasswordSource source, String value) {
+        Objects.requireNonNull(option, "Option cannot be null");
+        Objects.requireNonNull(source, "Password source cannot be null");
+        Objects.requireNonNull(value, "Password value cannot be null");
+        StringBuilder builder = new StringBuilder(option);
+        if (!source.getSuffix().isEmpty()) {
+            builder.append(source.getSuffix());
+        }
+
+        builder.append(" ").append(value);
+        this.arguments.add(builder.toString());
+        return this;
+    }
+
+    @Getter
+    public enum VerboseDetail {
+        ALL("all"),
+        GROUPED("grouped"),
+        SUMMARY("summary");
+
+        private final String token;
+
+        VerboseDetail(String token) {
+            this.token = token;
+        }
+    }
+
+    @Getter
+    private enum PasswordSource {
+        DIRECT(""),
+        ENVIRONMENT(":env"),
+        FILE(":file");
+
+        private final String suffix;
+
+        PasswordSource(String suffix) {
+            this.suffix = suffix;
+        }
+    }
+
+    @Getter
+    private enum OperationMode {
+        SIGN(null),
+        VERIFY("-verify"),
+        VERSION("-version");
+
+        private final String flag;
+
+        OperationMode(String flag) {
+            this.flag = flag;
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JarsignerCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JarsignerCLIBuilder.java
@@ -10,6 +10,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A fluent builder for constructing and executing {@code jarsigner} commands.
+ * <p>
+ * This builder provides methods to configure various options for signing and verifying JAR files,
+ * including keystore details, passwords, algorithms, and verbose output.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jarsigner.html">jarsigner command documentation</a>
+ */
 public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jarsigner.exe" : "jarsigner";
 
@@ -29,6 +38,12 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@code JarsignerCLIBuilder} instance.
+     *
+     * @param jdk The JDK to use for executing the {@code jarsigner} command.
+     * @return A new builder instance.
+     */
     public static JarsignerCLIBuilder create(JDK jdk) {
         return new JarsignerCLIBuilder(jdk);
     }
@@ -71,6 +86,13 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Configures the builder to sign a JAR file with a specified alias.
+     *
+     * @param jarFile The path to the JAR file to sign.
+     * @param alias   The alias of the signer in the keystore.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder sign(Path jarFile, String alias) {
         Objects.requireNonNull(jarFile, "JAR file cannot be null");
         Objects.requireNonNull(alias, "Alias cannot be null");
@@ -81,6 +103,13 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Configures the builder to sign a JAR file with a specified alias.
+     *
+     * @param jarFile The path to the JAR file to sign.
+     * @param alias   The alias of the signer in the keystore.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder sign(String jarFile, String alias) {
         Objects.requireNonNull(jarFile, "JAR file cannot be null");
         Objects.requireNonNull(alias, "Alias cannot be null");
@@ -91,6 +120,13 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Configures the builder to verify a JAR file.
+     *
+     * @param jarFile The path to the JAR file to verify.
+     * @param aliases Optional aliases to verify against.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder verify(Path jarFile, String... aliases) {
         Objects.requireNonNull(jarFile, "JAR file cannot be null");
         this.operationMode = OperationMode.VERIFY;
@@ -106,6 +142,13 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Configures the builder to verify a JAR file.
+     *
+     * @param jarFile The path to the JAR file to verify.
+     * @param aliases Optional aliases to verify against.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder verify(String jarFile, String... aliases) {
         Objects.requireNonNull(jarFile, "JAR file cannot be null");
         this.operationMode = OperationMode.VERIFY;
@@ -121,6 +164,11 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Configures the builder to display version information for {@code jarsigner}.
+     *
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder version() {
         this.operationMode = OperationMode.VERSION;
         this.jarFile = null;
@@ -129,30 +177,60 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Sets the JAR file to be signed or verified.
+     *
+     * @param jarFile The path to the JAR file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder jarFile(Path jarFile) {
         Objects.requireNonNull(jarFile, "JAR file cannot be null");
         this.jarFile = jarFile.toString();
         return this;
     }
 
+    /**
+     * Sets the JAR file to be signed or verified.
+     *
+     * @param jarFile The path to the JAR file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder jarFile(String jarFile) {
         Objects.requireNonNull(jarFile, "JAR file cannot be null");
         this.jarFile = jarFile;
         return this;
     }
 
+    /**
+     * Sets the alias of the signer in the keystore.
+     *
+     * @param alias The alias of the signer.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder signingAlias(String alias) {
         Objects.requireNonNull(alias, "Alias cannot be null");
         this.signingAlias = alias;
         return this;
     }
 
+    /**
+     * Adds an alias to verify against when in verify mode.
+     *
+     * @param alias The alias to add.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder addVerifyAlias(String alias) {
         Objects.requireNonNull(alias, "Alias cannot be null");
         this.verifyAliases.add(alias);
         return this;
     }
 
+    /**
+     * Adds multiple aliases to verify against when in verify mode.
+     *
+     * @param aliases The aliases to add.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder addVerifyAliases(String... aliases) {
         Objects.requireNonNull(aliases, "Aliases cannot be null");
         for (String alias : aliases) {
@@ -162,104 +240,223 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Specifies the keystore to use. Corresponds to the {@code -keystore} option.
+     *
+     * @param keystorePath The path to the keystore file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder keystore(Path keystorePath) {
         Objects.requireNonNull(keystorePath, "Keystore path cannot be null");
         return keystore(keystorePath.toString());
     }
 
+    /**
+     * Specifies the keystore to use. Corresponds to the {@code -keystore} option.
+     *
+     * @param location The location of the keystore.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder keystore(String location) {
         Objects.requireNonNull(location, "Keystore location cannot be null");
         this.arguments.add("-keystore " + location);
         return this;
     }
 
+    /**
+     * Sets the password for the keystore. Corresponds to the {@code -storepass} option.
+     *
+     * @param password The keystore password.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder storePassword(String password) {
         return addPasswordArgument("-storepass", PasswordSource.DIRECT, password);
     }
 
+    /**
+     * Sets the keystore password from an environment variable. Corresponds to the {@code -storepass:env} option.
+     *
+     * @param envVariable The name of the environment variable.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder storePasswordFromEnv(String envVariable) {
         return addPasswordArgument("-storepass", PasswordSource.ENVIRONMENT, envVariable);
     }
 
+    /**
+     * Sets the keystore password from a file. Corresponds to the {@code -storepass:file} option.
+     *
+     * @param file The path to the password file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder storePasswordFromFile(Path file) {
         Objects.requireNonNull(file, "Password file cannot be null");
         return addPasswordArgument("-storepass", PasswordSource.FILE, file.toString());
     }
 
+    /**
+     * Sets the keystore password from a file. Corresponds to the {@code -storepass:file} option.
+     *
+     * @param file The path to the password file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder storePasswordFromFile(String file) {
         return addPasswordArgument("-storepass", PasswordSource.FILE, file);
     }
 
+    /**
+     * Sets the keystore type. Corresponds to the {@code -storetype} option.
+     *
+     * @param storeType The keystore type.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder storeType(String storeType) {
         Objects.requireNonNull(storeType, "Store type cannot be null");
         this.arguments.add("-storetype " + storeType);
         return this;
     }
 
+    /**
+     * Sets the password for the private key. Corresponds to the {@code -keypass} option.
+     *
+     * @param password The private key password.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder keyPassword(String password) {
         return addPasswordArgument("-keypass", PasswordSource.DIRECT, password);
     }
 
+    /**
+     * Sets the private key password from an environment variable. Corresponds to the {@code -keypass:env} option.
+     *
+     * @param envVariable The name of the environment variable.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder keyPasswordFromEnv(String envVariable) {
         return addPasswordArgument("-keypass", PasswordSource.ENVIRONMENT, envVariable);
     }
 
+    /**
+     * Sets the private key password from a file. Corresponds to the {@code -keypass:file} option.
+     *
+     * @param file The path to the password file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder keyPasswordFromFile(Path file) {
         Objects.requireNonNull(file, "Password file cannot be null");
         return addPasswordArgument("-keypass", PasswordSource.FILE, file.toString());
     }
 
+    /**
+     * Sets the private key password from a file. Corresponds to the {@code -keypass:file} option.
+     *
+     * @param file The path to the password file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder keyPasswordFromFile(String file) {
         return addPasswordArgument("-keypass", PasswordSource.FILE, file);
     }
 
+    /**
+     * Specifies an alternative certificate chain file. Corresponds to the {@code -certchain} option.
+     *
+     * @param certChainFile The path to the certificate chain file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder certificateChain(Path certChainFile) {
         Objects.requireNonNull(certChainFile, "Certificate chain file cannot be null");
         this.arguments.add("-certchain " + certChainFile);
         return this;
     }
 
+    /**
+     * Specifies an alternative certificate chain file. Corresponds to the {@code -certchain} option.
+     *
+     * @param certChainFile The path to the certificate chain file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder certificateChain(String certChainFile) {
         Objects.requireNonNull(certChainFile, "Certificate chain file cannot be null");
         this.arguments.add("-certchain " + certChainFile);
         return this;
     }
 
+    /**
+     * Specifies the base name for the signature file. Corresponds to the {@code -sigfile} option.
+     *
+     * @param baseName The base name for the signature file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder signatureFile(String baseName) {
         Objects.requireNonNull(baseName, "Signature file base name cannot be null");
         this.arguments.add("-sigfile " + baseName);
         return this;
     }
 
+    /**
+     * Specifies the name of the signed JAR file. Corresponds to the {@code -signedjar} option.
+     *
+     * @param signedJarPath The path to the signed JAR file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder signedJar(Path signedJarPath) {
         Objects.requireNonNull(signedJarPath, "Signed JAR path cannot be null");
         this.arguments.add("-signedjar " + signedJarPath);
         return this;
     }
 
+    /**
+     * Specifies the name of the signed JAR file. Corresponds to the {@code -signedjar} option.
+     *
+     * @param signedJarPath The path to the signed JAR file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder signedJar(String signedJarPath) {
         Objects.requireNonNull(signedJarPath, "Signed JAR path cannot be null");
         this.arguments.add("-signedjar " + signedJarPath);
         return this;
     }
 
+    /**
+     * Specifies the digest algorithm to use. Corresponds to the {@code -digestalg} option.
+     *
+     * @param algorithm The digest algorithm.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder digestAlgorithm(String algorithm) {
         Objects.requireNonNull(algorithm, "Digest algorithm cannot be null");
         this.arguments.add("-digestalg " + algorithm);
         return this;
     }
 
+    /**
+     * Specifies the signature algorithm to use. Corresponds to the {@code -sigalg} option.
+     *
+     * @param algorithm The signature algorithm.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder signatureAlgorithm(String algorithm) {
         Objects.requireNonNull(algorithm, "Signature algorithm cannot be null");
         this.arguments.add("-sigalg " + algorithm);
         return this;
     }
 
+    /**
+     * Enables verbose output. Corresponds to the {@code -verbose} option.
+     *
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder verbose() {
         this.arguments.add("-verbose");
         return this;
     }
 
+    /**
+     * Enables verbose output with a specified detail level. Corresponds to the {@code -verbose:detail} option.
+     *
+     * @param detail The level of verbose detail.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder verbose(VerboseDetail detail) {
         Objects.requireNonNull(detail, "Verbose detail cannot be null");
         if (detail == VerboseDetail.ALL) {
@@ -271,67 +468,136 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Includes certificate details in the output. Corresponds to the {@code -certs} option.
+     *
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder includeCertificateDetails() {
         this.arguments.add("-certs");
         return this;
     }
 
+    /**
+     * Enables revocation checking. Corresponds to the {@code -revCheck} option.
+     *
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder enableRevocationCheck() {
         this.arguments.add("-revCheck");
         return this;
     }
 
+    /**
+     * Specifies the URL of the Timestamping Authority (TSA). Corresponds to the {@code -tsa} option.
+     *
+     * @param url The URL of the TSA.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder timestampAuthority(String url) {
         Objects.requireNonNull(url, "TSA URL cannot be null");
         this.arguments.add("-tsa " + url);
         return this;
     }
 
+    /**
+     * Specifies the alias of the Timestamping Authority (TSA) certificate. Corresponds to the {@code -tsacert} option.
+     *
+     * @param alias The alias of the TSA certificate.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder timestampAuthorityCertificate(String alias) {
         Objects.requireNonNull(alias, "TSA certificate alias cannot be null");
         this.arguments.add("-tsacert " + alias);
         return this;
     }
 
+    /**
+     * Specifies the timestamp policy ID. Corresponds to the {@code -tsapolicyid} option.
+     *
+     * @param policyId The timestamp policy ID.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder timestampPolicyId(String policyId) {
         Objects.requireNonNull(policyId, "Policy ID cannot be null");
         this.arguments.add("-tsapolicyid " + policyId);
         return this;
     }
 
+    /**
+     * Specifies the digest algorithm for the timestamp. Corresponds to the {@code -tsadigestalg} option.
+     *
+     * @param algorithm The timestamp digest algorithm.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder timestampDigestAlgorithm(String algorithm) {
         Objects.requireNonNull(algorithm, "Timestamp digest algorithm cannot be null");
         this.arguments.add("-tsadigestalg " + algorithm);
         return this;
     }
 
+    /**
+     * Includes the signature file in the signature block. Corresponds to the {@code -internalsf} option.
+     *
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder includeSignatureFileInBlock() {
         this.arguments.add("-internalsf");
         return this;
     }
 
+    /**
+     * Only signs or verifies sections of the JAR file. Corresponds to the {@code -sectionsonly} option.
+     *
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder sectionsOnly() {
         this.arguments.add("-sectionsonly");
         return this;
     }
 
+    /**
+     * Specifies whether protected authentication is required. Corresponds to the {@code -protected} option.
+     *
+     * @param required {@code true} if protected authentication is required, {@code false} otherwise.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder protectedAuthentication(boolean required) {
         this.arguments.add("-protected " + required);
         return this;
     }
 
+    /**
+     * Specifies the name of the cryptographic service provider. Corresponds to the {@code -providerName} option.
+     *
+     * @param providerName The name of the provider.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder providerName(String providerName) {
         Objects.requireNonNull(providerName, "Provider name cannot be null");
         this.arguments.add("-providerName " + providerName);
         return this;
     }
 
+    /**
+     * Adds a cryptographic service provider by name. Corresponds to the {@code -addprovider} option.
+     *
+     * @param providerName The name of the provider to add.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder addProvider(String providerName) {
         Objects.requireNonNull(providerName, "Provider name cannot be null");
         this.arguments.add("-addprovider " + providerName);
         return this;
     }
 
+    /**
+     * Adds a cryptographic service provider by name and an argument. Corresponds to the {@code -addprovider} and {@code -providerArg} options.
+     *
+     * @param providerName The name of the provider to add.
+     * @param providerArg  An argument for the provider.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder addProvider(String providerName, String providerArg) {
         Objects.requireNonNull(providerName, "Provider name cannot be null");
         this.arguments.add("-addprovider " + providerName);
@@ -340,12 +606,25 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Specifies the class name of the cryptographic service provider. Corresponds to the {@code -providerClass} option.
+     *
+     * @param className The class name of the provider.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder providerClass(String className) {
         Objects.requireNonNull(className, "Provider class cannot be null");
         this.arguments.add("-providerClass " + className);
         return this;
     }
 
+    /**
+     * Specifies the class name of the cryptographic service provider and an argument. Corresponds to the {@code -providerClass} and {@code -providerArg} options.
+     *
+     * @param className   The class name of the provider.
+     * @param providerArg An argument for the provider.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder providerClass(String className, String providerArg) {
         Objects.requireNonNull(className, "Provider class cannot be null");
         this.arguments.add("-providerClass " + className);
@@ -354,23 +633,46 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Specifies the classpath for the provider. Corresponds to the {@code -providerPath} option.
+     *
+     * @param classpath The classpath for the provider.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder providerPath(String classpath) {
         Objects.requireNonNull(classpath, "Provider path cannot be null");
         this.arguments.add("-providerPath " + classpath);
         return this;
     }
 
+    /**
+     * Passes an option to the Java Virtual Machine. Corresponds to the {@code -J} option.
+     *
+     * @param option The option to pass to the JVM.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder javaOption(String option) {
         Objects.requireNonNull(option, "Java option cannot be null");
         this.arguments.add("-J" + option);
         return this;
     }
 
+    /**
+     * Enables strict mode for verification. Corresponds to the {@code -strict} option.
+     *
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder strictMode() {
         this.arguments.add("-strict");
         return this;
     }
 
+    /**
+     * Specifies a configuration file. Corresponds to the {@code -conf} option.
+     *
+     * @param url The URL of the configuration file.
+     * @return This builder instance.
+     */
     public JarsignerCLIBuilder configurationFile(String url) {
         Objects.requireNonNull(url, "Configuration URL cannot be null");
         this.arguments.add("-conf " + url);
@@ -428,6 +730,14 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         }
     }
 
+    /**
+     * Adds a password argument to the command.
+     *
+     * @param option The command-line option for the password (e.g., "-storepass", "-keypass").
+     * @param source The source of the password (direct, environment variable, or file).
+     * @param value  The password value, environment variable name, or file path.
+     * @return This builder instance.
+     */
     private JarsignerCLIBuilder addPasswordArgument(String option, PasswordSource source, String value) {
         Objects.requireNonNull(option, "Option cannot be null");
         Objects.requireNonNull(source, "Password source cannot be null");
@@ -442,6 +752,9 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         return this;
     }
 
+    /**
+     * Represents the level of detail for verbose output.
+     */
     @Getter
     public enum VerboseDetail {
         ALL("all"),
@@ -455,6 +768,9 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         }
     }
 
+    /**
+     * Represents the source of a password argument.
+     */
     @Getter
     private enum PasswordSource {
         DIRECT(""),
@@ -468,6 +784,9 @@ public class JarsignerCLIBuilder implements CLIBuilder<Process, JarsignerCLIBuil
         }
     }
 
+    /**
+     * Represents the operation mode for the {@code jarsigner} command.
+     */
     @Getter
     private enum OperationMode {
         SIGN(null),

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JavaExecutableCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JavaExecutableCLIBuilder.java
@@ -14,6 +14,18 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+/**
+ * A fluent builder for creating and executing {@code java} commands.
+ * <p>
+ * This comprehensive builder supports a wide array of standard, extended (-X), and advanced (-XX)
+ * options for the Java launcher. It allows for detailed configuration of the classpath, module path,
+ * garbage collection, memory management, JIT compilation, and much more.
+ * <p>
+ * Methods in this builder correspond to specific command-line flags. Version-specific options
+ * will throw an {@link UnsupportedOperationException} if used with an incompatible JDK version.
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html">java command documentation</a>
+ */
 // NOTE: Some options are version-specific; ensure compatibility with the selected JDK version
 public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecutableCLIBuilder> {
     private final JDK jdk;
@@ -33,6 +45,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         this.primaryArgument = Objects.requireNonNull(primaryArgument, "Primary argument cannot be null");
     }
 
+    /**
+     * Creates a builder to launch a {@code .class} file.
+     *
+     * @param jdk           The JDK to use.
+     * @param classFilePath The path to the class file.
+     * @return A new builder instance.
+     */
     public static JavaExecutableCLIBuilder classFile(JDK jdk, Path classFilePath) {
         Objects.requireNonNull(classFilePath, "Class file path cannot be null");
         if (!classFilePath.toString().endsWith(".class"))
@@ -40,6 +59,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return new JavaExecutableCLIBuilder(LaunchType.CLASS_FILE, jdk, classFilePath.toString());
     }
 
+    /**
+     * Creates a builder to launch an executable {@code .jar} file.
+     *
+     * @param jdk         The JDK to use.
+     * @param jarFilePath The path to the JAR file.
+     * @return A new builder instance.
+     */
     public static JavaExecutableCLIBuilder jarFile(JDK jdk, Path jarFilePath) {
         Objects.requireNonNull(jarFilePath, "JAR file path cannot be null");
         if (!jarFilePath.toString().endsWith(".jar"))
@@ -48,11 +74,25 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return new JavaExecutableCLIBuilder(LaunchType.JAR_FILE, jdk, jarFilePath.toString());
     }
 
+    /**
+     * Creates a builder to launch a module.
+     *
+     * @param jdk        The JDK to use.
+     * @param moduleName The name of the module to launch.
+     * @return A new builder instance.
+     */
     public static JavaExecutableCLIBuilder module(JDK jdk, String moduleName) {
         Objects.requireNonNull(moduleName, "Module name cannot be null");
         return new JavaExecutableCLIBuilder(LaunchType.MODULE, jdk, moduleName);
     }
 
+    /**
+     * Creates a builder to launch a single-file {@code .java} source program.
+     *
+     * @param jdk            The JDK to use.
+     * @param sourceFilePath The path to the source file.
+     * @return A new builder instance.
+     */
     public static JavaExecutableCLIBuilder sourceFile(JDK jdk, Path sourceFilePath) {
         Objects.requireNonNull(sourceFilePath, "Source file path cannot be null");
         if (!sourceFilePath.toString().endsWith(".java"))
@@ -99,11 +139,25 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * On Windows, specifies whether to use {@code java.exe} (with a console) or {@code javaw.exe} (without a console).
+     * This setting has no effect on other operating systems.
+     *
+     * @param enableConsole {@code true} to use {@code java.exe}, {@code false} to use {@code javaw.exe}.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableConsole(boolean enableConsole) {
         this.enableConsole = enableConsole;
         return this;
     }
 
+    /**
+     * Loads a native agent library (e.g., for profiling or debugging). Corresponds to the {@code -agentlib} flag.
+     *
+     * @param agentLib The name of the agent library.
+     * @param options  Optional arguments for the agent.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder agentlib(String agentLib, String... options) {
         Objects.requireNonNull(agentLib, "Agent library cannot be null");
         Objects.requireNonNull(options, "Options array cannot be null");
@@ -117,6 +171,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Loads a native agent library by its full path. Corresponds to the {@code -agentpath} flag.
+     *
+     * @param agentPath The path to the agent library.
+     * @param options   Optional arguments for the agent.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder agentpath(Path agentPath, String... options) {
         Objects.requireNonNull(agentPath, "Agent path cannot be null");
         Objects.requireNonNull(options, "Options array cannot be null");
@@ -130,17 +191,34 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the class search path. Corresponds to the {@code -cp} or {@code -classpath} flag.
+     *
+     * @param classpathEntries The entries for the classpath.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder classpath(String... classpathEntries) {
         Objects.requireNonNull(classpathEntries, "Classpath entries cannot be null");
         this.arguments.add("-cp " + String.join(File.pathSeparator, classpathEntries));
         return this;
     }
 
+    /**
+     * Disables the use of argument files ({@code @files}).
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableAtFiles() {
         this.arguments.add("--disable-@files");
         return this;
     }
 
+    /**
+     * Enables preview language features. Corresponds to the {@code --enable-preview} flag.
+     *
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if the JDK version is less than 12.
+     */
     public JavaExecutableCLIBuilder enablePreviewFeatures() {
         if (jdk.version().major() < 12)
             throw new UnsupportedOperationException("Preview features are only supported in JDK 12 and above.");
@@ -149,6 +227,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables native access for a specific module. Corresponds to the {@code --enable-native-access} flag.
+     *
+     * @param moduleName The name of the module to grant native access to.
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if the JDK version is less than 16.
+     */
     public JavaExecutableCLIBuilder enableNativeAccess(String moduleName) {
         if (jdk.version().major() < 16)
             throw new UnsupportedOperationException("Enabling native access is only supported in JDK 16 and above.");
@@ -158,10 +243,22 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables native access for all unnamed modules.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableNativeAccess() {
         return enableNativeAccess("ALL-UNNAMED");
     }
 
+    /**
+     * Sets the behavior for illegal native access. Corresponds to the {@code --illegal-native-access} flag.
+     *
+     * @param mode The access mode to set.
+     * @return This builder instance.
+     * @deprecated As of Java 25, this flag is for removal.
+     */
     @Deprecated(forRemoval = true, since = "Java 25")
     public JavaExecutableCLIBuilder illegalNativeAccess(AccessMode mode) {
         if (jdk.version().major() < 24)
@@ -174,6 +271,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables or disables finalization. Corresponds to the {@code --finalization} flag.
+     *
+     * @param state The desired state of finalization.
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if the JDK version is less than 18.
+     */
     public JavaExecutableCLIBuilder finalization(EnabledDisabled state) {
         if (jdk.version().major() < 18)
             throw new UnsupportedOperationException("Controlling finalization is only supported in JDK 18 and above.");
@@ -183,51 +287,103 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the module path. Corresponds to the {@code --module-path} or {@code -p} flag.
+     *
+     * @param modulePaths The entries for the module path.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder modulePath(String... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
         this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
         return this;
     }
 
+    /**
+     * Sets the upgrade module path. Corresponds to the {@code --upgrade-module-path} flag.
+     *
+     * @param upgradeModulePaths The entries for the upgrade module path.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder upgradeModulePath(String... upgradeModulePaths) {
         Objects.requireNonNull(upgradeModulePaths, "Upgrade module path entries cannot be null");
         this.arguments.add("--upgrade-module-path " + String.join(File.pathSeparator, upgradeModulePaths));
         return this;
     }
 
+    /**
+     * Adds a set of root modules to the initial resolution. Corresponds to the {@code --add-modules} flag.
+     *
+     * @param modules The names of the modules to add.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder addModules(String... modules) {
         Objects.requireNonNull(modules, "Modules cannot be null");
         this.arguments.add("--add-modules " + String.join(",", modules));
         return this;
     }
 
+    /**
+     * Adds a predefined set of root modules (e.g., all system modules).
+     *
+     * @param rootModule The predefined set of modules to add.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder addModules(RootModule rootModule) {
         Objects.requireNonNull(rootModule, "Root module cannot be null");
         this.arguments.add("--add-modules " + rootModule.getModule());
         return this;
     }
 
+    /**
+     * Lists the observable modules and exits. Corresponds to the {@code --list-modules} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder listModules() {
         this.arguments.add("--list-modules");
         return this;
     }
 
+    /**
+     * Describes a given module and exits. Corresponds to the {@code --describe-module} flag.
+     *
+     * @param moduleName The name of the module to describe.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder describeModule(String moduleName) {
         Objects.requireNonNull(moduleName, "Module name cannot be null");
         this.arguments.add("--describe-module " + moduleName);
         return this;
     }
 
+    /**
+     * Performs a dry run of the module system and exits. Corresponds to the {@code --dry-run} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder dryRun() {
         this.arguments.add("--dry-run");
         return this;
     }
 
+    /**
+     * Validates the module graph and exits. Corresponds to the {@code --validate-modules} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder validateModules() {
         this.arguments.add("--validate-modules");
         return this;
     }
 
+    /**
+     * Sets a system property. Corresponds to the {@code -Dkey=value} flag.
+     *
+     * @param key   The property key.
+     * @param value The property value.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder systemProperty(String key, String value) {
         Objects.requireNonNull(key, "System property key cannot be null");
         Objects.requireNonNull(value, "System property value cannot be null");
@@ -236,51 +392,110 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Disables assertions for all classes. Corresponds to the {@code -da} or {@code -disableassertions} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableAssertions() {
         this.arguments.add("-da");
         return this;
     }
 
+    /**
+     * Disables assertions for a specific package or class.
+     *
+     * @param packageOrClassName The name of the package or class.
+     * @param subpackages        If {@code true}, also applies to subpackages.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableAssertions(String packageOrClassName, boolean subpackages) {
         Objects.requireNonNull(packageOrClassName, "Package or class name cannot be null");
         this.arguments.add("-da:" + packageOrClassName + (subpackages ? "..." : ""));
         return this;
     }
 
+    /**
+     * Disables assertions for a specific package or class.
+     *
+     * @param packageOrClassName The name of the package or class.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableAssertions(String packageOrClassName) {
         return disableAssertions(packageOrClassName, false);
     }
 
+    /**
+     * Disables assertions in all system classes. Corresponds to the {@code -dsa} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableSystemAssertions() {
         this.arguments.add("-dsa");
         return this;
     }
 
+    /**
+     * Enables assertions for all classes. Corresponds to the {@code -ea} or {@code -enableassertions} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableAssertions() {
         this.arguments.add("-ea");
         return this;
     }
 
+    /**
+     * Enables assertions for a specific package or class.
+     *
+     * @param packageOrClassName The name of the package or class.
+     * @param subpackages        If {@code true}, also applies to subpackages.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableAssertions(String packageOrClassName, boolean subpackages) {
         Objects.requireNonNull(packageOrClassName, "Package or class name cannot be null");
         this.arguments.add("-ea:" + packageOrClassName + (subpackages ? "..." : ""));
         return this;
     }
 
+    /**
+     * Enables assertions for a specific package or class.
+     *
+     * @param packageOrClassName The name of the package or class.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableAssertions(String packageOrClassName) {
         return enableAssertions(packageOrClassName, false);
     }
 
+    /**
+     * Enables assertions in all system classes. Corresponds to the {@code -esa} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableSystemAssertions() {
         this.arguments.add("-esa");
         return this;
     }
 
+    /**
+     * Prints the help message. Corresponds to the {@code -help} or {@code --help} flag.
+     *
+     * @param errorOutput If {@code true}, prints to standard error.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder help(boolean errorOutput) {
         this.arguments.add(errorOutput ? "-help" : "--help");
         return this;
     }
 
+    /**
+     * Loads a Java programming language agent. Corresponds to the {@code -javaagent} flag.
+     *
+     * @param javaAgentPath The path to the agent JAR file.
+     * @param options       Optional arguments for the agent.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder javaagent(String javaAgentPath, String... options) {
         Objects.requireNonNull(javaAgentPath, "Java agent path cannot be null");
         Objects.requireNonNull(options, "Options array cannot be null");
@@ -294,155 +509,321 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Loads a Java programming language agent. Corresponds to the {@code -javaagent} flag.
+     *
+     * @param javaAgentPath The path to the agent JAR file.
+     * @param options       Optional arguments for the agent.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder javaagent(Path javaAgentPath, String... options) {
         Objects.requireNonNull(javaAgentPath, "Java agent path cannot be null");
         return javaagent(javaAgentPath.toString(), options);
     }
 
+    /**
+     * Shows version information and continues execution. Corresponds to the {@code -showversion} or {@code --showversion} flag.
+     *
+     * @param errorOutput If {@code true}, prints to standard error.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder showVersion(boolean errorOutput) {
         this.arguments.add(errorOutput ? "-showversion" : "--showversion");
         return this;
     }
 
+    /**
+     * Shows the module resolution output. Corresponds to the {@code --show-module-resolution} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder showModuleResolution() {
         this.arguments.add("--show-module-resolution");
         return this;
     }
 
+    /**
+     * Shows the splash screen with a specified image. Corresponds to the {@code --splash} flag.
+     *
+     * @param splashImagePath The path to the splash screen image.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder splashScreen(String splashImagePath) {
         Objects.requireNonNull(splashImagePath, "Splash image path cannot be null");
         this.arguments.add("--splash:" + splashImagePath);
         return this;
     }
 
+    /**
+     * Shows the splash screen with a specified image. Corresponds to the {@code --splash} flag.
+     *
+     * @param splashImagePath The path to the splash screen image.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder splashScreen(Path splashImagePath) {
         Objects.requireNonNull(splashImagePath, "Splash image path cannot be null");
         return splashScreen(splashImagePath.toString());
     }
 
+    /**
+     * Enables verbose output for a specific component. Corresponds to the {@code -verbose} flag.
+     *
+     * @param component The component to make verbose (e.g., gc, class, jni).
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder verbose(VerboseComponent component) {
         Objects.requireNonNull(component, "Verbose component cannot be null");
         this.arguments.add("-verbose:" + component.getComponent());
         return this;
     }
 
+    /**
+     * Prints version information and exits. Corresponds to the {@code -version} or {@code --version} flag.
+     *
+     * @param errorOutput If {@code true}, prints to standard error.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder version(boolean errorOutput) {
         this.arguments.add(errorOutput ? "-version" : "--version");
         return this;
     }
 
+    /**
+     * Shows help on extra non-standard options. Corresponds to the {@code -X} or {@code --help-extra} flag.
+     *
+     * @param errorOutput If {@code true}, prints to standard error.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder extraOptionsHelp(boolean errorOutput) {
         this.arguments.add(errorOutput ? "-X" : "--help-extra");
         return this;
     }
 
+    /**
+     * Reads additional arguments from a file.
+     *
+     * @param argFilePath The path to the argument file.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder addArgFile(Path argFilePath) {
         Objects.requireNonNull(argFilePath, "Argument file path cannot be null");
         this.arguments.add("@" + argFilePath);
         return this;
     }
 
+    /**
+     * Disables background compilation. Corresponds to the {@code -Xbatch} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableBackgroundCompilation() {
         this.arguments.add("-Xbatch");
         return this;
     }
 
+    /**
+     * Appends entries to the bootstrap class path. Corresponds to the {@code -Xbootclasspath/a:} flag.
+     *
+     * @param bootClassPathEntries The entries to append.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder appendBootClassPath(String... bootClassPathEntries) {
         Objects.requireNonNull(bootClassPathEntries, "Boot class path entries cannot be null");
         this.arguments.add("-Xbootclasspath/a:" + String.join(File.pathSeparator, bootClassPathEntries));
         return this;
     }
 
+    /**
+     * Performs additional, more rigorous JNI checks. Corresponds to the {@code -Xcheck:jni} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder performAdditionalJNIChecks() {
         this.arguments.add("-Xcheck:jni");
         return this;
     }
 
+    /**
+     * Forces compilation of all methods on first invocation. Corresponds to the {@code -Xcomp} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder exerciseJITCompiler() {
         this.arguments.add("-Xcomp");
         return this;
     }
 
+    /**
+     * Enables debugging support.
+     *
+     * @return This builder instance.
+     * @deprecated As of Java 5, use {@code -agentlib:jdwp} instead.
+     */
     @Deprecated(forRemoval = true, since = "Java 5")
     public JavaExecutableCLIBuilder enableDebuggingSupport() {
         this.arguments.add("-Xdebug");
         return this;
     }
 
+    /**
+     * Enables additional diagnostic messages. Corresponds to the {@code -Xdiag} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder additionalDiagnosticMessages() {
         this.arguments.add("-Xdiag");
         return this;
     }
 
+    /**
+     * Runs the application in interpreted-only mode. Corresponds to the {@code -Xint} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder interpretOnlyMode() {
         this.arguments.add("-Xint");
         return this;
     }
 
+    /**
+     * Prints internal version information. Corresponds to the {@code -Xinternalversion} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder internalVersionInfo() {
         this.arguments.add("-Xinternalversion");
         return this;
     }
 
+    /**
+     * Configures or disables logging. Corresponds to the {@code -Xlog} flag.
+     *
+     * @param loggingOptions The raw logging configuration string.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder configureLogging(String loggingOptions) {
         Objects.requireNonNull(loggingOptions, "Logging options cannot be null");
         this.arguments.add("-Xlog:" + loggingOptions);
         return this;
     }
 
+    /**
+     * Configures logging using a fluent builder.
+     *
+     * @param configuration The logging configuration object.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder configureLogging(LoggingConfiguration configuration) {
         Objects.requireNonNull(configuration, "Logging configuration cannot be null");
         return configureLogging(configuration.asArgument());
     }
 
+    /**
+     * Creates a new logging configuration builder.
+     *
+     * @return A new {@link LoggingConfiguration} instance.
+     */
     public static LoggingConfiguration loggingConfiguration() {
         return new LoggingConfiguration();
     }
 
+    /**
+     * Runs the application in mixed mode (compiled and interpreted). Corresponds to the {@code -Xmixed} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder mixedMode() {
         this.arguments.add("-Xmixed");
         return this;
     }
 
+    /**
+     * Sets the size of the young generation heap. Corresponds to the {@code -Xmn} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size (e.g., MEGABYTES).
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder generationalMaxHeapSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Heap size cannot be null");
         this.arguments.add("-Xmn" + size + unit.getUnit());
         return this;
     }
 
+    /**
+     * Sets the initial heap size. Corresponds to the {@code -Xms} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder minimumHeapSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Heap size cannot be null");
         this.arguments.add("-Xms" + size + unit.getUnit());
         return this;
     }
 
+    /**
+     * Sets the maximum heap size. Corresponds to the {@code -Xmx} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maximumHeapSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Heap size cannot be null");
         this.arguments.add("-Xmx" + size + unit.getUnit());
         return this;
     }
 
+    /**
+     * Disables garbage collection of classes. Corresponds to the {@code -Xnoclassgc} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableClassGC() {
         this.arguments.add("-Xnoclassgc");
         return this;
     }
 
+    /**
+     * Reduces the use of OS signals by the JVM. Corresponds to the {@code -Xrs} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder reduceSignalUsage() {
         this.arguments.add("-Xrs");
         return this;
     }
 
+    /**
+     * Sets the class data sharing mode. Corresponds to the {@code -Xshare} flag.
+     *
+     * @param mode The desired mode (auto, on, off).
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder setClassDataSharingMode(AutoOnOff mode) {
         Objects.requireNonNull(mode, "Class Data Sharing mode cannot be null");
         this.arguments.add("-Xshare:class" + mode.getMode());
         return this;
     }
 
+    /**
+     * Shows all JVM settings and exits. Corresponds to the {@code -XshowSettings} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder showSettings() {
         this.arguments.add("-XshowSettings");
         return this;
     }
 
+    /**
+     * Shows settings for a specific category and exits.
+     *
+     * @param category The category of settings to show.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder showSettings(SettingCategory category) {
         Objects.requireNonNull(category, "Setting category cannot be null");
         if (category == SettingCategory.SYSTEM && !OperatingSystem.isLinux())
@@ -452,12 +833,26 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the thread stack size. Corresponds to the {@code -Xss} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder threadStackSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Stack size unit cannot be null");
         this.arguments.add("-Xss" + size + unit.getUnit());
         return this;
     }
 
+    /**
+     * Adds a read edge from a source module to target modules. Corresponds to the {@code --add-reads} flag.
+     *
+     * @param sourceModule  The source module.
+     * @param targetModules The target modules.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder addReads(String sourceModule, String... targetModules) {
         Objects.requireNonNull(sourceModule, "Source module cannot be null");
         Objects.requireNonNull(targetModules, "Target modules cannot be null");
@@ -466,10 +861,24 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Adds a read edge from a source module to all unnamed modules.
+     *
+     * @param sourceModule The source module.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder addReadsAllUnnamed(String sourceModule) {
         return addReads(sourceModule, "ALL-UNNAMED");
     }
 
+    /**
+     * Adds an export of a package from a source module to target modules. Corresponds to the {@code --add-exports} flag.
+     *
+     * @param sourceModule  The source module.
+     * @param packageName   The package to export.
+     * @param targetModules The target modules.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder addExports(String sourceModule, String packageName, String... targetModules) {
         Objects.requireNonNull(sourceModule, "Source module cannot be null");
         Objects.requireNonNull(packageName, "Package name cannot be null");
@@ -479,10 +888,25 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Adds an export of a package from a source module to all unnamed modules.
+     *
+     * @param sourceModule The source module.
+     * @param packageName  The package to export.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder addExportsAllUnnamed(String sourceModule, String packageName) {
         return addExports(sourceModule, packageName, "ALL-UNNAMED");
     }
 
+    /**
+     * Adds an open of a package from a source module to target modules. Corresponds to the {@code --add-opens} flag.
+     *
+     * @param sourceModule  The source module.
+     * @param packageName   The package to open.
+     * @param targetModules The target modules.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder addOpens(String sourceModule, String packageName, String... targetModules) {
         Objects.requireNonNull(sourceModule, "Source module cannot be null");
         Objects.requireNonNull(packageName, "Package name cannot be null");
@@ -492,16 +916,36 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Adds an open of a package from a source module to all unnamed modules.
+     *
+     * @param sourceModule The source module.
+     * @param packageName  The package to open.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder addOpensAllUnnamed(String sourceModule, String packageName) {
         return addOpens(sourceModule, packageName, "ALL-UNNAMED");
     }
 
+    /**
+     * Limits the universe of observable modules. Corresponds to the {@code --limit-modules} flag.
+     *
+     * @param modules The modules to limit to.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder limitModules(String... modules) {
         Objects.requireNonNull(modules, "Modules cannot be null");
         this.arguments.add("--limit-modules " + String.join(",", modules));
         return this;
     }
 
+    /**
+     * Patches a module with classes and resources from specified paths. Corresponds to the {@code --patch-module} flag.
+     *
+     * @param moduleName The module to patch.
+     * @param patchPaths The paths to the patch content.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder patchModule(String moduleName, String... patchPaths) {
         Objects.requireNonNull(moduleName, "Module name cannot be null");
         Objects.requireNonNull(patchPaths, "Patch paths cannot be null");
@@ -509,6 +953,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the source version for single-file source-code programs. Corresponds to the {@code --source} flag.
+     *
+     * @param version The source version.
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not launching a source file.
+     */
     public JavaExecutableCLIBuilder sourceVersion(String version) {
         if (launchType != LaunchType.SOURCE_FILE)
             throw new UnsupportedOperationException("Setting source version is only supported when launching a source file.");
@@ -518,12 +969,24 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the access mode for {@code sun.misc.Unsafe} memory access. Corresponds to the {@code --sun-misc-unsafe-memory-access} flag.
+     *
+     * @param mode The access mode.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder sunMiscUnsafeMemoryAccess(AccessMode mode) {
         Objects.requireNonNull(mode, "Unsafe memory access mode cannot be null");
         this.arguments.add("--sun-misc-unsafe-memory-access=" + mode.getMode());
         return this;
     }
 
+    /**
+     * Ensures the main thread is the first thread on macOS. Corresponds to the {@code -XstartOnFirstThread} flag.
+     *
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not on macOS.
+     */
     public JavaExecutableCLIBuilder startOnFirstThread() {
         if (!OperatingSystem.isMac())
             throw new UnsupportedOperationException("Starting on first thread is only supported on macOS.");
@@ -532,6 +995,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the application name in the macOS dock. Corresponds to the {@code -Xdock:name} flag.
+     *
+     * @param appName The application name.
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not on macOS.
+     */
     public JavaExecutableCLIBuilder dockName(String appName) {
         if (!OperatingSystem.isMac())
             throw new UnsupportedOperationException("Setting dock name is only supported on macOS.");
@@ -541,6 +1011,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the application icon in the macOS dock. Corresponds to the {@code -Xdock:icon} flag.
+     *
+     * @param iconPath The path to the icon file.
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not on macOS.
+     */
     public JavaExecutableCLIBuilder dockIcon(Path iconPath) {
         if (!OperatingSystem.isMac())
             throw new UnsupportedOperationException("Setting dock icon is only supported on macOS.");
@@ -550,16 +1027,32 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Unlocks diagnostic VM options. Corresponds to the {@code -XX:+UnlockDiagnosticVMOptions} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder unlockDiagnosticVMOptions() {
         this.arguments.add("-XX:+UnlockDiagnosticVMOptions");
         return this;
     }
 
+    /**
+     * Unlocks experimental VM options. Corresponds to the {@code -XX:+UnlockExperimentalVMOptions} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder unlockExperimentalVMOptions() {
         this.arguments.add("-XX:+UnlockExperimentalVMOptions");
         return this;
     }
 
+    /**
+     * Sets the number of active processors for the VM to use. Corresponds to the {@code -XX:ActiveProcessorCount} flag.
+     *
+     * @param count The number of processors.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder activeProcessorCount(int count) {
         if (count <= 0)
             throw new IllegalArgumentException("Active processor count must be positive.");
@@ -568,28 +1061,56 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Specifies a path for NUMA interleaving memory allocation. Corresponds to the {@code -XX:AllocateHeapAt} flag.
+     *
+     * @param path The allocation path.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder allocateHeapAt(Path path) {
         Objects.requireNonNull(path, "Heap allocation path cannot be null");
         this.arguments.add("-XX:AllocateHeapAt=" + path);
         return this;
     }
 
+    /**
+     * Disables the use of compact strings. Corresponds to the {@code -XX:-CompactStrings} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableCompactStrings() {
         this.arguments.add("-XX:-CompactStrings");
         return this;
     }
 
+    /**
+     * Sets the path for writing fatal error logs. Corresponds to the {@code -XX:ErrorFile} flag.
+     *
+     * @param errorFilePath The path to the error file.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder errorFile(Path errorFilePath) {
         Objects.requireNonNull(errorFilePath, "Error file path cannot be null");
         this.arguments.add("-XX:ErrorFile=" + errorFilePath);
         return this;
     }
 
+    /**
+     * Enables extensive error reports. Corresponds to the {@code -XX:+ExtensiveErrorReports} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableExtensiveErrorReports() {
         this.arguments.add("-XX:+ExtensiveErrorReports");
         return this;
     }
 
+    /**
+     * Configures Java Flight Recorder (JFR) options. Corresponds to the {@code -XX:FlightRecorderOptions} flag.
+     *
+     * @param options The JFR options to set.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder flightRecorderOptions(FlightRecorderOption... options) {
         Objects.requireNonNull(options, "Flight recorder options cannot be null");
         List<String> optionStrings = new ArrayList<>();
@@ -601,29 +1122,62 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the large page size. Corresponds to the {@code -XX:LargePageSizeInBytes} flag.
+     *
+     * @param size The page size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder largePageSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Page size unit cannot be null");
         this.arguments.add("-XX:LargePageSizeInBytes=" + size + unit.getUnit());
         return this;
     }
 
+    /**
+     * Sets the maximum size for direct memory allocation. Corresponds to the {@code -XX:MaxDirectMemorySize} flag.
+     *
+     * @param size The memory size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxDirectMemorySize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Direct memory size unit cannot be null");
         this.arguments.add("-XX:MaxDirectMemorySize=" + size + unit.getUnit());
         return this;
     }
 
+    /**
+     * Disables the limit on the number of file descriptors. Corresponds to the {@code -XX:-MaxFDLimit} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableMaxFileDescriptorLimit() {
         this.arguments.add("-XX:-MaxFDLimit");
         return this;
     }
 
+    /**
+     * Configures native memory tracking. Corresponds to the {@code -XX:NativeMemoryTracking} flag.
+     *
+     * @param tracking The tracking mode.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder nativeMemoryTracking(NativeMemoryTracking tracking) {
         Objects.requireNonNull(tracking, "Native memory tracking mode cannot be null");
         this.arguments.add("-XX:NativeMemoryTracking=" + tracking.getState());
         return this;
     }
 
+    /**
+     * Sets the interval for trimming the native heap on Linux. Corresponds to the {@code -XX:TrimNativeHeapInterval} flag.
+     *
+     * @param interval The interval duration.
+     * @param unit     The time unit of the interval.
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not on Linux.
+     */
     public JavaExecutableCLIBuilder trimNativeHeapInterval(long interval, TimeUnit unit) {
         if (!OperatingSystem.isLinux())
             throw new UnsupportedOperationException("TrimNativeHeapInterval is only supported on Linux systems.");
@@ -636,11 +1190,22 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Emulates the client VM. Corresponds to the {@code -XX:+NeverActAsServerClassMachine} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableClientVMEmulation() {
         this.arguments.add("-XX:+NeverActAsServerClassMachine");
         return this;
     }
 
+    /**
+     * Sets the object alignment in bytes. Corresponds to the {@code -XX:ObjectAlignmentInBytes} flag.
+     *
+     * @param alignment The alignment value (must be a power of two between 8 and 256).
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder objectAlignmentInBytes(int alignment) {
         if (alignment <= 0 || (alignment & (alignment - 1)) != 0)
             throw new IllegalArgumentException("Object alignment must be a positive power of two.");
@@ -652,45 +1217,92 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Specifies a command to run on a fatal error. Corresponds to the {@code -XX:OnError} flag.
+     *
+     * @param command The command to execute.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder onError(String command) {
         Objects.requireNonNull(command, "OnError command cannot be null");
         this.arguments.add("-XX:OnError=\"" + command + "\"");
         return this;
     }
 
+    /**
+     * Specifies a command to run on an OutOfMemoryError. Corresponds to the {@code -XX:OnOutOfMemoryError} flag.
+     *
+     * @param command The command to execute.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder onOutOfMemoryError(String command) {
         Objects.requireNonNull(command, "OnOutOfMemoryError command cannot be null");
         this.arguments.add("-XX:OnOutOfMemoryError=\"" + command + "\"");
         return this;
     }
 
+    /**
+     * Enables printing of command-line flags. Corresponds to the {@code -XX:+PrintCommandLineFlags} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enablePrintingCommandLineFlags() {
         this.arguments.add("-XX:+PrintCommandLineFlags");
         return this;
     }
 
+    /**
+     * Enables or disables preserving the frame pointer. Corresponds to the {@code -XX:+/-PreserveFramePointer} flag.
+     *
+     * @param preserve {@code true} to preserve, {@code false} to omit.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder preserveFramePointer(boolean preserve) {
         this.arguments.add(preserve ? "-XX:+PreserveFramePointer" : "-XX:-PreserveFramePointer");
         return this;
     }
 
+    /**
+     * Enables printing of native memory tracking statistics. Corresponds to the {@code -XX:+PrintNMTStatistics} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enablePrintingNMTStatistics() {
         this.arguments.add("-XX:+PrintNMTStatistics");
         return this;
     }
 
+    /**
+     * Specifies the path to the shared archive file. Corresponds to the {@code -XX:SharedArchiveFile} flag.
+     *
+     * @param archivePath The path to the archive.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder sharedArchiveFile(Path archivePath) {
         Objects.requireNonNull(archivePath, "Shared archive file path cannot be null");
         this.arguments.add("-XX:SharedArchiveFile=" + archivePath);
         return this;
     }
 
+    /**
+     * Specifies the path to the dynamic shared archive file.
+     *
+     * @param dynamicArchivePath The path to the dynamic archive.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder sharedArchiveFileDynamic(Path dynamicArchivePath) {
         Objects.requireNonNull(dynamicArchivePath, "Dynamic shared archive file path cannot be null");
         this.arguments.add("-XX:SharedArchiveFile=," + dynamicArchivePath);
         return this;
     }
 
+    /**
+     * Specifies paths to both static and dynamic shared archive files.
+     *
+     * @param staticArchivePath  The path to the static archive.
+     * @param dynamicArchivePath The path to the dynamic archive.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder sharedArchiveFile(Path staticArchivePath, Path dynamicArchivePath) {
         Objects.requireNonNull(staticArchivePath, "Static shared archive file path cannot be null");
         Objects.requireNonNull(dynamicArchivePath, "Dynamic shared archive file path cannot be null");
@@ -698,39 +1310,78 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Verifies shared spaces. Corresponds to the {@code -XX:+VerifySharedSpaces} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder verifySharedSpaces() {
         this.arguments.add("-XX:+VerifySharedSpaces");
         return this;
     }
 
+    /**
+     * Specifies the shared archive configuration file. Corresponds to the {@code -XX:SharedArchiveConfigFile} flag.
+     *
+     * @param configFilePath The path to the config file.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder sharedArchiveConfigFile(Path configFilePath) {
         Objects.requireNonNull(configFilePath, "Shared archive config file path cannot be null");
         this.arguments.add("-XX:SharedArchiveConfigFile=" + configFilePath);
         return this;
     }
 
+    /**
+     * Specifies the shared class list file for creating a CDS archive. Corresponds to the {@code -XX:SharedClassListFile} flag.
+     *
+     * @param classListFilePath The path to the class list file.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder sharedClassListFile(Path classListFilePath) {
         Objects.requireNonNull(classListFilePath, "Shared class list file path cannot be null");
         this.arguments.add("-XX:SharedClassListFile=" + classListFilePath);
         return this;
     }
 
+    /**
+     * Shows detailed code information in exception messages. Corresponds to the {@code -XX:+ShowCodeDetailsInExceptionMessages} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder showCodeDetailsInExceptionMessages() {
         this.arguments.add("-XX:+ShowCodeDetailsInExceptionMessages");
         return this;
     }
 
+    /**
+     * Shows a message box on a fatal error. Corresponds to the {@code -XX:+ShowMessageBoxOnError} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder showMessageBoxOnError() {
         this.arguments.add("-XX:+ShowMessageBoxOnError");
         return this;
     }
 
+    /**
+     * Starts a Java Flight Recorder (JFR) recording. Corresponds to the {@code -XX:StartFlightRecording} flag.
+     *
+     * @param parameters The JFR parameters.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder startFlightRecording(FlightRecorderParameters parameters) {
         Objects.requireNonNull(parameters, "Flight recorder parameters cannot be null");
         this.arguments.add("-XX:StartFlightRecording=" + parameters);
         return this;
     }
 
+    /**
+     * Sets the thread stack size in kilobytes. Corresponds to the {@code -Xss} flag.
+     *
+     * @param sizeInKB The stack size in kilobytes.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder threadStackSize(int sizeInKB) {
         if (sizeInKB <= 0)
             throw new IllegalArgumentException("Stack size must be positive.");
@@ -739,6 +1390,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Uses compact object headers. Corresponds to the {@code -XX:+UseCompactObjectHeaders} flag.
+     *
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if the JDK version is less than 25.
+     */
     public JavaExecutableCLIBuilder useCompactObjectHeaders() {
         if (jdk.version().major() < 25)
             throw new UnsupportedOperationException("Compact object headers are only supported in JDK 25 and above.");
@@ -747,11 +1404,22 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Disables compressed object pointers. Corresponds to the {@code -XX:-UseCompressedOops} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableCompressedPointers() {
         this.arguments.add("-XX:-UseCompressedOops");
         return this;
     }
 
+    /**
+     * Disables container support on Linux. Corresponds to the {@code -XX:-UseContainerSupport} flag.
+     *
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not on Linux.
+     */
     public JavaExecutableCLIBuilder disableContainerSupport() {
         if (!OperatingSystem.isLinux())
             throw new UnsupportedOperationException("Disabling container support is only supported on Linux systems.");
@@ -760,11 +1428,22 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables the use of large pages for memory allocation. Corresponds to the {@code -XX:+UseLargePages} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder useLargePages() {
         this.arguments.add("-XX:+UseLargePages");
         return this;
     }
 
+    /**
+     * Enables the use of transparent huge pages on Linux. Corresponds to the {@code -XX:+UseTransparentHugePages} flag.
+     *
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not on Linux.
+     */
     public JavaExecutableCLIBuilder useTransparentHugePages() {
         if (!OperatingSystem.isLinux())
             throw new UnsupportedOperationException("UseTransparentHugePages is only supported on Linux systems.");
@@ -773,6 +1452,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Allows user-defined signal handlers. Corresponds to the {@code -XX:+AllowUserSignalHandlers} flag.
+     *
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if on Windows.
+     */
     public JavaExecutableCLIBuilder allowInstallingSignalHandlers() {
         if (OperatingSystem.isWindows())
             throw new UnsupportedOperationException("Installing signal handlers is not supported on Windows systems.");
@@ -781,12 +1466,25 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Specifies a file from which to load VM options. Corresponds to the {@code -XX:VMOptionsFile} flag.
+     *
+     * @param vmOptionsFilePath The path to the VM options file.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder vmOptionsFile(Path vmOptionsFilePath) {
         Objects.requireNonNull(vmOptionsFilePath, "VM options file path cannot be null");
         this.arguments.add("-XX:VMOptionsFile=" + vmOptionsFilePath);
         return this;
     }
 
+    /**
+     * Sets the branch protection mode on AArch64 Linux. Corresponds to the {@code -XX:BranchProtection} flag.
+     *
+     * @param mode The branch protection mode.
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not on AArch64 Linux.
+     */
     public JavaExecutableCLIBuilder branchProtectionMode(BranchProtectionMode mode) {
         if (!OperatingSystem.isLinux())
             throw new UnsupportedOperationException("Branch protection mode is only supported on Linux (AArch64) systems.");
@@ -796,6 +1494,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the number of cache lines to prefetch on instance allocation. Corresponds to the {@code -XX:AllocateInstancePrefetchLines} flag.
+     *
+     * @param lineCount The number of lines.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder allocateInstancePrefetchLines(int lineCount) {
         if (lineCount < 0)
             throw new IllegalArgumentException("Line count cannot be negative.");
@@ -804,6 +1508,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the prefetch distance for object allocation. Corresponds to the {@code -XX:AllocatePrefetchDistance} flag.
+     *
+     * @param distance The distance.
+     * @param unit     The unit of distance.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder allocatePrefetchDistance(long distance, ByteUnit unit) {
         Objects.requireNonNull(unit, "Prefetch distance unit cannot be null");
         if (distance < -1)
@@ -813,6 +1524,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the prefetch instruction type for allocation. Corresponds to the {@code -XX:AllocatePrefetchInstr} flag.
+     *
+     * @param instructionType The instruction type (0-3).
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder allocatePrefetchInstruction(byte instructionType) {
         if (instructionType < 0 || instructionType > 3)
             throw new IllegalArgumentException("Instruction type must be 0, 1, 2, or 3.");
@@ -821,6 +1538,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the number of cache lines to prefetch ahead of the current allocation pointer. Corresponds to the {@code -XX:AllocatePrefetchLines} flag.
+     *
+     * @param lineCount The number of lines.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder allocatePrefetchLines(int lineCount) {
         if (lineCount < 0)
             throw new IllegalArgumentException("Line count cannot be negative.");
@@ -829,6 +1552,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the prefetch step size. Corresponds to the {@code -XX:AllocatePrefetchStepSize} flag.
+     *
+     * @param stepSize The step size.
+     * @param unit     The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder allocatePrefetchStepSize(int stepSize, ByteUnit unit) {
         Objects.requireNonNull(unit, "Step size unit cannot be null");
         if (stepSize < 0)
@@ -838,17 +1568,34 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the prefetch style for allocation. Corresponds to the {@code -XX:AllocatePrefetchStyle} flag.
+     *
+     * @param style The prefetch style.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder allocatePrefetchStyle(PrefetchStyle style) {
         Objects.requireNonNull(style, "Prefetch style cannot be null");
         this.arguments.add("-XX:AllocatePrefetchStyle=" + style.asInt());
         return this;
     }
 
+    /**
+     * Enables background compilation. Corresponds to the {@code -XX:+BackgroundCompilation} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableBackgroundCompilation() {
         this.arguments.add("-XX:+BackgroundCompilation");
         return this;
     }
 
+    /**
+     * Sets the number of compiler threads for compilation. Corresponds to the {@code -XX:CompilerThreadsForCompilation} flag.
+     *
+     * @param threadCount The number of threads.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder compilerThreadsForCompilation(int threadCount) {
         if (threadCount <= 0)
             throw new IllegalArgumentException("Thread count must be positive.");
@@ -857,11 +1604,23 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables dynamic adjustment of the number of compiler threads. Corresponds to the {@code -XX:+UseDynamicNumberOfCompilerThreads} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder useDynamicNumberOfCompilerThreads() {
         this.arguments.add("-XX:+UseDynamicNumberOfCompilerThreads");
         return this;
     }
 
+    /**
+     * Specifies a command to be executed on a method. Corresponds to the {@code -XX:CompileCommand} flag.
+     *
+     * @param command     The compile command (e.g., quiet, print, exclude).
+     * @param methodSpecs The method specifications.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder compileCommand(CompileCommand command, String... methodSpecs) {
         Objects.requireNonNull(command, "Compile command cannot be null");
         Objects.requireNonNull(methodSpecs, "Method specifications cannot be null");
@@ -870,23 +1629,46 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Specifies a file from which to read JIT compiler commands. Corresponds to the {@code -XX:CompileCommandFile} flag.
+     *
+     * @param commandFilePath The path to the command file.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder compileCommandFile(Path commandFilePath) {
         Objects.requireNonNull(commandFilePath, "Command file path cannot be null");
         this.arguments.add("-XX:CompileCommandFile=" + commandFilePath);
         return this;
     }
 
+    /**
+     * Specifies a file from which to read JIT compiler directives. Corresponds to the {@code -XX:CompilerDirectivesFile} flag.
+     *
+     * @param directivesFilePath The path to the directives file.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder compilerDirectivesFile(Path directivesFilePath) {
         Objects.requireNonNull(directivesFilePath, "Directives file path cannot be null");
         this.arguments.add("-XX:CompilerDirectivesFile=" + directivesFilePath);
         return this;
     }
 
+    /**
+     * Enables printing of compiler directives. Corresponds to the {@code -XX:+PrintCompilerDirectives} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder shouldPrintCompilerDirectives() {
         this.arguments.add("-XX:+PrintCompilerDirectives");
         return this;
     }
 
+    /**
+     * Compiles only the specified methods. Corresponds to the {@code -XX:CompileOnly} flag.
+     *
+     * @param methodSpecs The method specifications.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder compileOnly(String... methodSpecs) {
         Objects.requireNonNull(methodSpecs, "Method specifications cannot be null");
 
@@ -894,6 +1676,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Scales the compilation threshold. Corresponds to the {@code -XX:CompileThresholdScale} flag.
+     *
+     * @param scale The scale factor.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder compileThresholdScale(int scale) {
         if (scale <= 0)
             throw new IllegalArgumentException("Scale must be positive.");
@@ -902,11 +1690,24 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables or disables escape analysis. Corresponds to the {@code -XX:+/-DoEscapeAnalysis} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableEscapeAnalysis(boolean enable) {
         this.arguments.add(enable ? "-XX:+DoEscapeAnalysis" : "-XX:-DoEscapeAnalysis");
         return this;
     }
 
+    /**
+     * Sets the initial code cache size. Corresponds to the {@code -XX:InitialCodeCacheSize} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder initialCodeCacheSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Code cache size unit cannot be null");
 
@@ -917,11 +1718,24 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables or disables method inlining. Corresponds to the {@code -XX:+/-Inline} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableMethodInlining(boolean enable) {
         this.arguments.add(enable ? "-XX:+Inline" : "-XX:-Inline");
         return this;
     }
 
+    /**
+     * Sets the maximum size of a method to be inlined. Corresponds to the {@code -XX:InlineSmallCode} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder inlineSmallCode(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Code size unit cannot be null");
 
@@ -932,11 +1746,23 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables logging of compilation activity to a {@code hotspot.log} file. Corresponds to the {@code -XX:+LogCompilation} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableCompilationLogging() {
         this.arguments.add("-XX:+LogCompilation");
         return this;
     }
 
+    /**
+     * Sets the maximum bytecode size of a frequently executed method to be inlined. Corresponds to the {@code -XX:FreqInlineSize} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder hotMethodInlineSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Code size unit cannot be null");
 
@@ -947,6 +1773,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum bytecode size of a method to be inlined. Corresponds to the {@code -XX:MaxInlineSize} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxInlineSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Code size unit cannot be null");
 
@@ -957,6 +1790,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum bytecode size for a C1-compiled method to be inlined. Corresponds to the {@code -XX:C1MaxInlineSize} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder c1MaxInlineSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Code size unit cannot be null");
 
@@ -967,6 +1807,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum bytecode size of a trivial method to be inlined. Corresponds to the {@code -XX:MaxTrivialSize} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxTrivialSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Code size unit cannot be null");
 
@@ -977,6 +1824,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum bytecode size for a trivial C1-compiled method to be inlined. Corresponds to the {@code -XX:C1MaxTrivialSize} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder c1MaxTrivialSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Code size unit cannot be null");
 
@@ -987,6 +1841,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum number of nodes for a method to be compiled. Corresponds to the {@code -XX:MaxNodeLimit} flag.
+     *
+     * @param limit The node limit.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxNodeLimit(int limit) {
         if (limit < 0)
             throw new IllegalArgumentException("Max node limit cannot be negative.");
@@ -995,6 +1855,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the size of the non-method code heap. Corresponds to the {@code -XX:NonNMethodCodeHeapSize} flag.
+     *
+     * @param sizeInBytes The size in bytes.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder nonmethodCodeHeapSize(long sizeInBytes) {
         if (sizeInBytes < 0)
             throw new IllegalArgumentException("Non-method code heap size cannot be negative.");
@@ -1003,6 +1869,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the size of the non-profiled code heap. Corresponds to the {@code -XX:NonProfiledCodeHeapSize} flag.
+     *
+     * @param sizeInBytes The size in bytes.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder nonprofiledCodeHeapSize(long sizeInBytes) {
         if (sizeInBytes < 0)
             throw new IllegalArgumentException("Non-profiled code heap size cannot be negative.");
@@ -1011,16 +1883,33 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables or disables the optimization of string concatenation. Corresponds to the {@code -XX:+/-OptimizeStringConcat} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableOptimizingStringConcat(boolean enable) {
         this.arguments.add(enable ? "-XX:+OptimizeStringConcat" : "-XX:-OptimizeStringConcat");
         return this;
     }
 
+    /**
+     * Enables printing of assembly code for compiled methods. Corresponds to the {@code -XX:+PrintAssembly} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enablePrintingAssemblyCode() {
         this.arguments.add("-XX:+PrintAssembly");
         return this;
     }
 
+    /**
+     * Sets the size of the profiled code heap. Corresponds to the {@code -XX:ProfiledCodeHeapSize} flag.
+     *
+     * @param sizeInBytes The size in bytes.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder profiledCodeHeapSize(long sizeInBytes) {
         if (sizeInBytes < 0)
             throw new IllegalArgumentException("Profiled code heap size cannot be negative.");
@@ -1029,16 +1918,33 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables printing of method compilation information. Corresponds to the {@code -XX:+PrintCompilation} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableMethodCompilationPrinting() {
         this.arguments.add("-XX:+PrintCompilation");
         return this;
     }
 
+    /**
+     * Enables printing of inlining decisions. Corresponds to the {@code -XX:+PrintInlining} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableInliningInfoPrinting() {
         this.arguments.add("-XX:+PrintInlining");
         return this;
     }
 
+    /**
+     * Sets the reserved code cache size. Corresponds to the {@code -XX:ReservedCodeCacheSize} flag.
+     *
+     * @param size The size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder reserveCodeCacheSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Code cache size unit cannot be null");
 
@@ -1052,11 +1958,22 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables the use of a segmented code cache. Corresponds to the {@code -XX:+SegmentedCodeCache} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableSegmentedCodeCache() {
         this.arguments.add("-XX:+SegmentedCodeCache");
         return this;
     }
 
+    /**
+     * Sets the percentage of heap occupancy at which to start aggressive sweeping. Corresponds to the {@code -XX:AggressiveHeapSweepingAt} flag.
+     *
+     * @param percentage The percentage (0-100).
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder startAggressiveSweepingAt(int percentage) {
         if (percentage < 0 || percentage > 100)
             throw new IllegalArgumentException("Percentage must be between 0 and 100.");
@@ -1065,160 +1982,310 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Disables tiered compilation. Corresponds to the {@code -XX:-TieredCompilation} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableTieredCompilation() {
         this.arguments.add("-XX:-TieredCompilation");
         return this;
     }
 
+    /**
+     * Sets the version of the SSE instruction set to use. Corresponds to the {@code -XX:UseSSE} flag.
+     *
+     * @param version The SSE version.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder sseInstructionSetVersion(String version) {
         Objects.requireNonNull(version, "SSE instruction set version cannot be null");
         this.arguments.add("-XX:UseSSE=" + version);
         return this;
     }
 
+    /**
+     * Sets the version of the AVX instruction set to use. Corresponds to the {@code -XX:UseAVX} flag.
+     *
+     * @param version The AVX version.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder avxInstructionSetVersion(String version) {
         Objects.requireNonNull(version, "AVX instruction set version cannot be null");
         this.arguments.add("-XX:UseAVX=" + version);
         return this;
     }
 
+    /**
+     * Enables or disables hardware-based AES intrinsics. Corresponds to the {@code -XX:+/-UseAES} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableAES(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseAES" : "-XX:-UseAES");
         return this;
     }
 
+    /**
+     * Enables or disables AES intrinsics. Corresponds to the {@code -XX:+/-UseAESIntrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableAESIntrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseAESIntrinsics" : "-XX:-UseAESIntrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables AES/CTR intrinsics. Corresponds to the {@code -XX:+/-UseAESCTRIntrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableAESCTRIntrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseAESCTRIntrinsics" : "-XX:-UseAESCTRIntrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables GHASH intrinsics. Corresponds to the {@code -XX:+/-UseGHASHIntrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableGHASHIntrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseGHASHIntrinsics" : "-XX:-UseGHASHIntrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables ChaCha20 intrinsics. Corresponds to the {@code -XX:+/-UseChaCha20Intrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableChaCha20Intrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseChaCha20Intrinsics" : "-XX:-UseChaCha20Intrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables Poly1305 intrinsics. Corresponds to the {@code -XX:+/-UsePoly1305Intrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enablePoly1305Intrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UsePoly1305Intrinsics" : "-XX:-UsePoly1305Intrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables BASE64 intrinsics. Corresponds to the {@code -XX:+/-UseBASE64Intrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableBASE64Intrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseBASE64Intrinsics" : "-XX:-UseBASE64Intrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables Adler32 intrinsics. Corresponds to the {@code -XX:+/-UseAdler32Intrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableAdler32Intrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseAdler32Intrinsics" : "-XX:-UseAdler32Intrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables CRC32 intrinsics. Corresponds to the {@code -XX:+/-UseCRC32Intrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableCRC32Intrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseCRC32Intrinsics" : "-XX:-UseCRC32Intrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables CRC32C intrinsics. Corresponds to the {@code -XX:+/-UseCRC32CIntrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableCRC32CIntrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseCRC32CIntrinsics" : "-XX:-UseCRC32CIntrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables hardware-based SHA crypto intrinsics. Corresponds to the {@code -XX:+/-UseSHA} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableSHA(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseSHA" : "-XX:-UseSHA");
         return this;
     }
 
+    /**
+     * Enables or disables SHA-1 intrinsics. Corresponds to the {@code -XX:+/-UseSHA1Intrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableSHA1Intrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseSHA1Intrinsics" : "-XX:-UseSHA1Intrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables SHA-256 intrinsics. Corresponds to the {@code -XX:+/-UseSHA256Intrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableSHA256Intrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseSHA256Intrinsics" : "-XX:-UseSHA256Intrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables SHA-512 intrinsics. Corresponds to the {@code -XX:+/-UseSHA512Intrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableSHA512Intrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseSHA512Intrinsics" : "-XX:-UseSHA512Intrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables {@code Math.exact} intrinsics. Corresponds to the {@code -XX:+/-UseMathExactIntrinsics} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableMathExactIntrinsics(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseMathExactIntrinsics" : "-XX:-UseMathExactIntrinsics");
         return this;
     }
 
+    /**
+     * Enables or disables the {@code multiplyToLen} intrinsic. Corresponds to the {@code -XX:+/-UseMultiplyToLenIntrinsic} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableMultiplyToLenIntrinsic(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseMultiplyToLenIntrinsic" : "-XX:-UseMultiplyToLenIntrinsic");
         return this;
     }
 
+    /**
+     * Enables or disables the {@code squareToLen} intrinsic. Corresponds to the {@code -XX:+/-UseSquareToLenIntrinsic} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableSquareToLenIntrinsic(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseSquareToLenIntrinsic" : "-XX:-UseSquareToLenIntrinsic");
         return this;
     }
 
+    /**
+     * Enables or disables the {@code mulAdd} intrinsic. Corresponds to the {@code -XX:+/-UseMulAddIntrinsic} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableMulAddIntrinsic(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseMulAddIntrinsic" : "-XX:-UseMulAddIntrinsic");
         return this;
     }
 
+    /**
+     * Enables or disables the Montgomery multiply intrinsic. Corresponds to the {@code -XX:+/-UseMontgomeryMultiplyIntrinsic} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableMontgomeryMultiplyIntrinsic(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseMontgomeryMultiplyIntrinsic" : "-XX:-UseMontgomeryMultiplyIntrinsic");
         return this;
     }
 
+    /**
+     * Enables or disables the Montgomery square intrinsic. Corresponds to the {@code -XX:+/-UseMontgomerySquareIntrinsic} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableMontgomerySquareIntrinsic(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseMontgomerySquareIntrinsic" : "-XX:-UseMontgomerySquareIntrinsic");
         return this;
     }
 
-    // -XX:+UseCMoveUnconditionally
-    //Generates CMove (scalar and vector) instructions regardless of profitability analysis.
-    //-XX:+UseCodeCacheFlushing
-    //Enables flushing of the code cache before shutting down the compiler. This option is enabled by default. To disable flushing of the code cache before shutting down the compiler, specify -XX:-UseCodeCacheFlushing.
-    //-XX:+UseCondCardMark
-    //Enables checking if the card is already marked before updating the card table. This option is disabled by default. It should be used only on machines with multiple sockets, where it increases the performance of Java applications that rely on concurrent operations.
-    //-XX:+UseCountedLoopSafepoints
-    //Keeps safepoints in counted loops. Its default value depends on whether the selected garbage collector requires low latency safepoints.
-    //-XX:LoopStripMiningIter=number_of_iterations
-    //Controls the number of iterations in the inner strip mined loop. Strip mining transforms counted loops into two level nested loops. Safepoints are kept in the outer loop while the inner loop can execute at full speed. This option controls the maximum number of iterations in the inner loop. The default value is 1,000.
-    //-XX:LoopStripMiningIterShortLoop=number_of_iterations
-    //Controls loop strip mining optimization. Loops with the number of iterations less than specified will not have safepoints in them. Default value is 1/10th of -XX:LoopStripMiningIter.
-    //-XX:+UseFMA
-    //Enables hardware-based FMA intrinsics for hardware where FMA instructions are available (such as, Intel and ARM64). FMA intrinsics are generated for the java.lang.Math.fma(a, b, c) methods that calculate the value of ( a * b + c ) expressions.
-    //-XX:+UseSuperWord
-    //Enables the transformation of scalar operations into superword operations. Superword is a vectorization optimization. This option is enabled by default. To disable the transformation of scalar operations into superword operations, specify -XX:-UseSuperWord.
-
+    /**
+     * Enables or disables the unconditional use of CMove instructions. Corresponds to the {@code -XX:+/-UseCMoveUnconditionally} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableCMoveUnconditionally(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseCMoveUnconditionally" : "-XX:-UseCMoveUnconditionally");
         return this;
     }
 
+    /**
+     * Enables or disables code cache flushing. Corresponds to the {@code -XX:+/-UseCodeCacheFlushing} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableCodeCacheFlushing(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseCodeCacheFlushing" : "-XX:-UseCodeCacheFlushing");
         return this;
     }
 
+    /**
+     * Enables or disables conditional card marking. Corresponds to the {@code -XX:+/-UseCondCardMark} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableCondCardMark(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseCondCardMark" : "-XX:-UseCondCardMark");
         return this;
     }
 
+    /**
+     * Enables or disables counted loop safepoints. Corresponds to the {@code -XX:+/-UseCountedLoopSafepoints} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableCountedLoopSafepoints(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseCountedLoopSafepoints" : "-XX:-UseCountedLoopSafepoints");
         return this;
     }
 
+    /**
+     * Sets the number of iterations for loop strip mining. Corresponds to the {@code -XX:LoopStripMiningIter} flag.
+     *
+     * @param iterationCount The number of iterations.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder loopStripMiningIterations(int iterationCount) {
         if (iterationCount <= 0)
             throw new IllegalArgumentException("Iteration count must be positive.");
@@ -1227,6 +2294,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the number of iterations for loop strip mining in short loops. Corresponds to the {@code -XX:LoopStripMiningIterShortLoop} flag.
+     *
+     * @param iterationCount The number of iterations.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder loopStripMiningIterationsForShortLoops(int iterationCount) {
         if (iterationCount <= 0)
             throw new IllegalArgumentException("Iteration count must be positive.");
@@ -1235,21 +2308,44 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables or disables the use of Fused Multiply-Add instructions. Corresponds to the {@code -XX:+/-UseFMA} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableFMA(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseFMA" : "-XX:-UseFMA");
         return this;
     }
 
+    /**
+     * Enables or disables the use of superword optimizations. Corresponds to the {@code -XX:+/-UseSuperWord} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableSuperWord(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseSuperWord" : "-XX:-UseSuperWord");
         return this;
     }
 
+    /**
+     * Disables the attach mechanism. Corresponds to the {@code -XX:+DisableAttachMechanism} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableAttachMechanism() {
         this.arguments.add("-XX:+DisableAttachMechanism");
         return this;
     }
 
+    /**
+     * Enables DTrace allocation probes. Corresponds to the {@code -XX:+DTraceAllocProbes} flag.
+     *
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not on macOS or Linux.
+     */
     public JavaExecutableCLIBuilder enableDTraceAllocProbes() {
         if (!OperatingSystem.isLinux() && !OperatingSystem.isMac())
             throw new UnsupportedOperationException("DTrace allocation probes are only supported on macOS and Linux systems.");
@@ -1258,6 +2354,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables DTrace method probes. Corresponds to the {@code -XX:+DTraceMethodProbes} flag.
+     *
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not on macOS or Linux.
+     */
     public JavaExecutableCLIBuilder enableDTraceMethodProbes() {
         if (!OperatingSystem.isLinux() && !OperatingSystem.isMac())
             throw new UnsupportedOperationException("DTrace method probes are only supported on macOS and Linux systems.");
@@ -1266,6 +2368,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables DTrace monitor probes. Corresponds to the {@code -XX:+DTraceMonitorProbes} flag.
+     *
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if not on macOS or Linux.
+     */
     public JavaExecutableCLIBuilder enableDTraceMonitorProbes() {
         if (!OperatingSystem.isLinux() && !OperatingSystem.isMac())
             throw new UnsupportedOperationException("DTrace monitor probes are only supported on macOS and Linux systems.");
@@ -1274,58 +2382,117 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables dumping of the heap to a file on an {@link OutOfMemoryError}. Corresponds to the {@code -XX:+HeapDumpOnOutOfMemoryError} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableDumpingHeapOnOutOfMemoryError() {
         this.arguments.add("-XX:+HeapDumpOnOutOfMemoryError");
         return this;
     }
 
+    /**
+     * Sets the path for the heap dump file. Corresponds to the {@code -XX:HeapDumpPath} flag.
+     *
+     * @param dumpPath The path to the heap dump file.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder heapDumpPath(Path dumpPath) {
         Objects.requireNonNull(dumpPath, "Heap dump path cannot be null");
         this.arguments.add("-XX:HeapDumpPath=" + dumpPath);
         return this;
     }
 
+    /**
+     * Sets the path for the log file. Corresponds to the {@code -XX:LogFile} flag.
+     *
+     * @param logFilePath The path to the log file.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder logFile(Path logFilePath) {
         Objects.requireNonNull(logFilePath, "Log file path cannot be null");
         this.arguments.add("-XX:LogFile=" + logFilePath);
         return this;
     }
 
+    /**
+     * Enables printing of a class instance histogram after a {@code Control+C} event. Corresponds to the {@code -XX:+PrintClassHistogram} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enablePrintingClassHistogram() {
         this.arguments.add("-XX:+PrintClassHistogram");
         return this;
     }
 
+    /**
+     * Enables printing of concurrent locks after a {@code Control+C} event. Corresponds to the {@code -XX:+PrintConcurrentLocks} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder printConcurrentLocks() {
         this.arguments.add("-XX:+PrintConcurrentLocks");
         return this;
     }
 
+    /**
+     * Prints the ranges of all VM flags. Corresponds to the {@code -XX:+PrintFlagRanges} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder printFlagRanges() {
         this.arguments.add("-XX:+PrintFlagRanges");
         return this;
     }
 
+    /**
+     * Saves performance data to a file on exit. Corresponds to the {@code -XX:+PerfDataSaveToFile} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder perfDataSaveToFile() {
         this.arguments.add("-XX:+PerfDataSaveToFile");
         return this;
     }
 
+    /**
+     * Enables or disables the use of performance data. Corresponds to the {@code -XX:+/-UsePerfData} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableUsingPerfData(boolean enable) {
         this.arguments.add(enable ? "-XX:+UsePerfData" : "-XX:-UsePerfData");
         return this;
     }
 
+    /**
+     * Enables aggressive heap management. Corresponds to the {@code -XX:+AggressiveHeap} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableAggressiveHeap() {
         this.arguments.add("-XX:+AggressiveHeap");
         return this;
     }
 
+    /**
+     * Pre-touches all pages of the heap during initialization. Corresponds to the {@code -XX:+AlwaysPreTouch} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder alwaysPreTouch() {
         this.arguments.add("-XX:+AlwaysPreTouch");
         return this;
     }
 
+    /**
+     * Sets the number of threads for concurrent garbage collection. Corresponds to the {@code -XX:ConcGCThreads} flag.
+     *
+     * @param threadCount The number of threads.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder concurrentGCThreads(int threadCount) {
         if (threadCount <= 0)
             throw new IllegalArgumentException("Thread count must be positive.");
@@ -1334,16 +2501,32 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Disables explicit garbage collection calls (e.g., from {@code System.gc()}). Corresponds to the {@code -XX:+DisableExplicitGC} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder disableExplicitGC() {
         this.arguments.add("-XX:+DisableExplicitGC");
         return this;
     }
 
+    /**
+     * Enables concurrent invocation of explicit garbage collection. Corresponds to the {@code -XX:+ExplicitGCInvokesConcurrent} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableConcurrentExplicitGCInvokes() {
         this.arguments.add("-XX:+ExplicitGCInvokesConcurrent");
         return this;
     }
 
+    /**
+     * Sets the number of initial samples for G1 adaptive IHOP. Corresponds to the {@code -XX:G1AdaptiveIHOPNumInitialSamples} flag.
+     *
+     * @param sampleCount The number of samples.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder G1AdaptiveIHOPNumInitialSamples(int sampleCount) {
         if (sampleCount < 0)
             throw new IllegalArgumentException("Sample count cannot be negative.");
@@ -1352,6 +2535,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the size of a G1 heap region. Corresponds to the {@code -XX:G1HeapRegionSize} flag.
+     *
+     * @param size The size of the region.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder G1HeapRegionSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Heap region size unit cannot be null");
 
@@ -1362,6 +2552,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the percentage of heap waste allowed for G1 GC. Corresponds to the {@code -XX:G1HeapWastePercent} flag.
+     *
+     * @param percent The percentage of heap waste.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder G1HeapWastePercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Heap waste percent must be between 0 and 100.");
@@ -1370,6 +2566,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum percentage of the heap to be used for the young generation with G1 GC. Corresponds to the {@code -XX:G1MaxNewSizePercent} flag.
+     *
+     * @param percent The percentage of the heap.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder G1MaxNewSizePercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Max new size percent must be between 0 and 100.");
@@ -1378,6 +2580,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the target number of mixed GCs after a marking cycle for G1 GC. Corresponds to the {@code -XX:G1MixedGCCountTarget} flag.
+     *
+     * @param targetCount The target number of mixed GCs.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder G1MixedGCCountTarget(int targetCount) {
         if (targetCount < 0)
             throw new IllegalArgumentException("Target count cannot be negative.");
@@ -1386,6 +2594,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the live threshold percentage for a region to be included in a mixed GC cycle with G1 GC. Corresponds to the {@code -XX:G1MixedGCLiveThresholdPercent} flag.
+     *
+     * @param percent The live threshold percentage.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder G1MixedGCLiveThresholdPercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Live threshold percent must be between 0 and 100.");
@@ -1394,6 +2608,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the percentage of the heap to use for the young generation with G1 GC. Corresponds to the {@code -XX:G1NewSizePercent} flag.
+     *
+     * @param percent The percentage of the heap.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder G1NewSizePercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("New size percent must be between 0 and 100.");
@@ -1402,6 +2622,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the threshold percentage for including old regions in a G1 collection set. Corresponds to the {@code -XX:G1OldCSetRegionThresholdPercent} flag.
+     *
+     * @param percent The threshold percentage.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder G1OldCSetRegionThresholdPercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Old CSet region threshold percent must be between 0 and 100.");
@@ -1410,6 +2636,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the percentage of the heap to reserve for G1 GC to reduce the risk of promotion failure. Corresponds to the {@code -XX:G1ReservePercent} flag.
+     *
+     * @param percent The percentage of the heap to reserve.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder G1ReservePercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Reserve percent must be between 0 and 100.");
@@ -1418,11 +2650,23 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables G1 adaptive IHOP. Corresponds to the {@code -XX:+G1UseAdaptiveIHOP} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableG1AdaptiveIHOP() {
         this.arguments.add("-XX:+G1UseAdaptiveIHOP");
         return this;
     }
 
+    /**
+     * Sets the initial heap size. Corresponds to the {@code -XX:InitialHeapSize} flag.
+     *
+     * @param size The initial heap size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder initialHeapSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Heap size unit cannot be null");
 
@@ -1436,6 +2680,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the initial survivor space ratio. Corresponds to the {@code -XX:InitialSurvivorRatio} flag.
+     *
+     * @param ratio The initial survivor space ratio.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder initialSurvivorRatio(int ratio) {
         if (ratio <= 0)
             throw new IllegalArgumentException("Initial survivor ratio must be positive.");
@@ -1444,6 +2694,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the heap occupancy percentage at which to start a concurrent GC cycle. Corresponds to the {@code -XX:InitiatingHeapOccupancyPercent} flag.
+     *
+     * @param percent The heap occupancy percentage.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder initiatingHeapOccupancyPercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Initiating heap occupancy percent must be between 0 and 100.");
@@ -1452,6 +2708,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum GC pause time goal. Corresponds to the {@code -XX:MaxGCPauseMillis} flag.
+     *
+     * @param time The maximum pause time.
+     * @param unit The unit of time.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxGCPause(long time, TimeUnit unit) {
         Objects.requireNonNull(unit, "Time unit cannot be null");
 
@@ -1462,6 +2725,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum heap size. Corresponds to the {@code -XX:MaxHeapSize} flag.
+     *
+     * @param size The maximum heap size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxHeapSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Heap size unit cannot be null");
 
@@ -1475,6 +2745,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum percentage of free heap space after a GC to avoid shrinking. Corresponds to the {@code -XX:MaxHeapFreeRatio} flag.
+     *
+     * @param percent The maximum free heap ratio percentage.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxHeapFreeRatioPercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Max heap free ratio percent must be between 0 and 100.");
@@ -1483,6 +2759,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum metaspace size. Corresponds to the {@code -XX:MaxMetaspaceSize} flag.
+     *
+     * @param size The maximum metaspace size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxMetaspaceSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Metaspace size unit cannot be null");
 
@@ -1493,6 +2776,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum size of the young generation. Corresponds to the {@code -XX:MaxNewSize} flag.
+     *
+     * @param size The maximum size of the young generation.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxNewSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "New size unit cannot be null");
 
@@ -1503,6 +2793,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum RAM to be used by the JVM. Corresponds to the {@code -XX:MaxRAM} flag.
+     *
+     * @param size The maximum RAM size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxRAM(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "RAM size unit cannot be null");
 
@@ -1516,6 +2813,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum percentage of RAM to be used by the JVM. Corresponds to the {@code -XX:MaxRAMPercentage} flag.
+     *
+     * @param percent The maximum RAM percentage.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxRAMPercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Max RAM percent must be between 0 and 100.");
@@ -1524,6 +2827,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum tenuring threshold for promoting objects to the old generation. Corresponds to the {@code -XX:MaxTenuringThreshold} flag.
+     *
+     * @param threshold The maximum tenuring threshold.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxTenuringThreshold(int threshold) {
         if (threshold < 0)
             throw new IllegalArgumentException("Max tenuring threshold cannot be negative.");
@@ -1535,6 +2844,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the initial metaspace size. Corresponds to the {@code -XX:MetaspaceSize} flag.
+     *
+     * @param size The initial metaspace size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder metaspaceSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "Metaspace size unit cannot be null");
 
@@ -1545,6 +2861,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the minimum percentage of free heap space after a GC to avoid expansion. Corresponds to the {@code -XX:MinHeapFreeRatio} flag.
+     *
+     * @param percent The minimum free heap ratio percentage.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder minHeapFreeRatioPercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Min heap free ratio percent must be between 0 and 100.");
@@ -1553,6 +2875,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the ratio between the young and old generation sizes. Corresponds to the {@code -XX:NewRatio} flag.
+     *
+     * @param ratio The ratio of the young to the old generation.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder newRatio(int ratio) {
         if (ratio <= 0)
             throw new IllegalArgumentException("New ratio must be positive.");
@@ -1561,6 +2889,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the initial size of the young generation. Corresponds to the {@code -XX:NewSize} flag.
+     *
+     * @param size The initial size of the young generation.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder newSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "New size unit cannot be null");
 
@@ -1571,6 +2906,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the number of threads for parallel garbage collection. Corresponds to the {@code -XX:ParallelGCThreads} flag.
+     *
+     * @param threadCount The number of threads.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder parallelGCThreads(int threadCount) {
         if (threadCount <= 0)
             throw new IllegalArgumentException("Thread count must be positive.");
@@ -1579,16 +2920,34 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables or disables parallel reference processing. Corresponds to the {@code -XX:+/-ParallelRefProcEnabled} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableParallelRefProc(boolean enable) {
         this.arguments.add(enable ? "-XX:+ParallelRefProcEnabled" : "-XX:-ParallelRefProcEnabled");
         return this;
     }
 
+    /**
+     * Enables printing of adaptive generation sizing information. Corresponds to the {@code -XX:+PrintAdaptiveSizePolicy} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enablePrintingAdaptiveSizePolicy() {
         this.arguments.add("-XX:+PrintAdaptiveSizePolicy");
         return this;
     }
 
+    /**
+     * Sets the amount of time a softly reachable object will be kept alive for each megabyte of free heap space. Corresponds to the {@code -XX:SoftRefLRUPolicyMSPerMB} flag.
+     *
+     * @param time The time to keep softly reachable objects alive.
+     * @param unit The unit of time.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder softRefLRUPolicyMSPerMB(long time, TimeUnit unit) {
         Objects.requireNonNull(unit, "Time unit cannot be null");
 
@@ -1599,11 +2958,22 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Incrementally reduces the Java heap size. Corresponds to the {@code -XX:-ShrinkHeapInSteps} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder incrementallyReduceJavaHeapSize() {
         this.arguments.add("-XX:-ShrinkHeapInSteps");
         return this;
     }
 
+    /**
+     * Sets the age threshold for string deduplication. Corresponds to the {@code -XX:StringDeduplicationAgeThreshold} flag.
+     *
+     * @param threshold The age threshold.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder stringDeduplicationAgeThreshold(int threshold) {
         if (threshold < 0)
             throw new IllegalArgumentException("String deduplication age threshold cannot be negative.");
@@ -1612,6 +2982,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the ratio of survivor space to eden space. Corresponds to the {@code -XX:SurvivorRatio} flag.
+     *
+     * @param ratio The survivor space ratio.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder survivorRatio(int ratio) {
         if (ratio <= 0)
             throw new IllegalArgumentException("Survivor ratio must be positive.");
@@ -1620,6 +2996,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the target survivor space occupancy percentage after a young GC. Corresponds to the {@code -XX:TargetSurvivorRatio} flag.
+     *
+     * @param percent The target survivor ratio percentage.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder targetSurvivorRatioPercent(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Target survivor ratio percent must be between 0 and 100.");
@@ -1628,6 +3010,13 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the size of a thread-local allocation buffer (TLAB). Corresponds to the {@code -XX:TLABSize} flag.
+     *
+     * @param size The TLAB size.
+     * @param unit The unit of size.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder TLABSize(long size, ByteUnit unit) {
         Objects.requireNonNull(unit, "TLAB size unit cannot be null");
 
@@ -1638,56 +3027,117 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables or disables adaptive generation sizing. Corresponds to the {@code -XX:+/-UseAdaptiveSizePolicy} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableAdaptiveSizePolicy(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseAdaptiveSizePolicy" : "-XX:-UseAdaptiveSizePolicy");
         return this;
     }
 
+    /**
+     * Enables the G1 garbage collector. Corresponds to the {@code -XX:+UseG1GC} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableG1GC() {
         this.arguments.add("-XX:+UseG1GC");
         return this;
     }
 
+    /**
+     * Enables the GC overhead limit. Corresponds to the {@code -XX:+UseGCOverheadLimit} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableGCOverheadLimit() {
         this.arguments.add("-XX:+UseGCOverheadLimit");
         return this;
     }
 
+    /**
+     * Enables NUMA-aware memory allocation. Corresponds to the {@code -XX:+UseNUMA} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableNUMA() {
         this.arguments.add("-XX:+UseNUMA");
         return this;
     }
 
+    /**
+     * Enables the parallel garbage collector. Corresponds to the {@code -XX:+UseParallelGC} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableParallelGC() {
         this.arguments.add("-XX:+UseParallelGC");
         return this;
     }
 
+    /**
+     * Enables the serial garbage collector. Corresponds to the {@code -XX:+UseSerialGC} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableSerialGC() {
         this.arguments.add("-XX:+UseSerialGC");
         return this;
     }
 
+    /**
+     * Enables or disables string deduplication. Corresponds to the {@code -XX:+/-UseStringDeduplication} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableStringDeduplication(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseStringDeduplication" : "-XX:-UseStringDeduplication");
         return this;
     }
 
+    /**
+     * Enables or disables thread-local allocation buffers (TLABs). Corresponds to the {@code -XX:+/-UseTLAB} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableTLAB(boolean enable) {
         this.arguments.add(enable ? "-XX:+UseTLAB" : "-XX:-UseTLAB");
         return this;
     }
 
+    /**
+     * Enables the Z garbage collector (ZGC). Corresponds to the {@code -XX:+UseZGC} flag.
+     *
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableZGC() {
         this.arguments.add("-XX:+UseZGC");
         return this;
     }
 
+    /**
+     * Sets the allocation spike tolerance for ZGC. Corresponds to the {@code -XX:ZAllocationSpikeTolerance} flag.
+     *
+     * @param tolerance The allocation spike tolerance.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder allocationSpikeToleranceForZGC(float tolerance) {
         this.arguments.add("-XX:ZAllocationSpikeTolerance=" + tolerance);
         return this;
     }
 
+    /**
+     * Sets the maximum collection interval for ZGC. Corresponds to the {@code -XX:ZCollectionInterval} flag.
+     *
+     * @param time The maximum collection interval.
+     * @param unit The unit of time.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxCollectionIntervalForZGC(long time, TimeUnit unit) {
         Objects.requireNonNull(unit, "Time unit cannot be null");
 
@@ -1698,6 +3148,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Sets the maximum fragmentation limit percentage for ZGC. Corresponds to the {@code -XX:ZFragmentationLimit} flag.
+     *
+     * @param percent The maximum fragmentation limit percentage.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder maxFragmentationLimitPercentForZGC(int percent) {
         if (percent < 0 || percent > 100)
             throw new IllegalArgumentException("Max fragmentation limit percent must be between 0 and 100.");
@@ -1706,16 +3162,35 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return this;
     }
 
+    /**
+     * Enables or disables proactive GC cycles for ZGC. Corresponds to the {@code -XX:+/-ZProactiveGCCycles} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableProactiveGCCyclesForZGC(boolean enable) {
         this.arguments.add(enable ? "-XX:+ZProactiveGCCycles" : "-XX:-ZProactiveGCCycles");
         return this;
     }
 
+    /**
+     * Enables or disables uncommitting unused memory for ZGC. Corresponds to the {@code -XX:+/-ZUncommit} flag.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder enableUncommitForZGC(boolean enable) {
         this.arguments.add(enable ? "-XX:+ZUncommit" : "-XX:-ZUncommit");
         return this;
     }
 
+    /**
+     * Sets the uncommit delay for ZGC. Corresponds to the {@code -XX:ZUncommitDelay} flag.
+     *
+     * @param time The uncommit delay.
+     * @param unit The unit of time.
+     * @return This builder instance.
+     */
     public JavaExecutableCLIBuilder uncommitDelayForZGC(long time, TimeUnit unit) {
         Objects.requireNonNull(unit, "Time unit cannot be null");
 
@@ -1760,6 +3235,12 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Resolves the name of the Java executable based on the operating system and console enablement.
+     *
+     * @param enableConsole {@code true} if a console is enabled (Windows only), {@code false} otherwise.
+     * @return The name of the executable (e.g., "java.exe", "javaw.exe", "java").
+     */
     private static String resolveExecutableName(boolean enableConsole) {
         if (OperatingSystem.isWindows() && !enableConsole)
             return "javaw.exe";
@@ -1767,6 +3248,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         return JDKManager.JAVA_EXECUTABLE_NAME;
     }
 
+    /**
+     * Represents the different ways a Java application can be launched.
+     */
     @Getter
     public enum LaunchType {
         CLASS_FILE,
@@ -1785,6 +3269,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents different access modes for certain VM options.
+     */
     @Getter
     public enum AccessMode {
         ALLOW("allow"),
@@ -1799,6 +3286,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents an enabled or disabled state.
+     */
     @Getter
     public enum EnabledDisabled {
         ENABLED,
@@ -1811,6 +3301,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents predefined sets of root modules.
+     */
     @Getter
     public enum RootModule {
         ALL_DEFAULT,
@@ -1824,6 +3317,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents components for which verbose output can be enabled.
+     */
     @Getter
     public enum VerboseComponent {
         CLASS,
@@ -1838,6 +3334,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * A builder for configuring logging options for the JVM.
+     */
     public static final class LoggingConfiguration {
         private final List<LogSelection> selections = new ArrayList<>();
         private LogOutput output;
@@ -1883,8 +3382,8 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
             boolean hasDecorators = !decorators.isEmpty();
             boolean hasOutputOptions = hasOutput && output.hasOptions();
 
-            if (hasOutput || hasDecorators || hasOutputOptions) {
-                if (builder.length() > 0)
+            if (hasOutput || hasDecorators) {
+                if (!builder.isEmpty())
                     builder.append(":");
 
                 if (hasOutput) {
@@ -1907,6 +3406,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents a selection of log tags and a log level for logging configuration.
+     */
     public static final class LogSelection {
         private final List<String> tags = new ArrayList<>();
         private LogLevel level = LogLevel.INFO;
@@ -1952,6 +3454,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents different logging levels.
+     */
     public enum LogLevel {
         TRACE("trace"),
         DEBUG("debug"),
@@ -1971,6 +3476,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents different decorators for log output.
+     */
     public enum LogDecorator {
         TIME("time"),
         UPTIME("uptime"),
@@ -1995,6 +3503,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents the output destination for logging.
+     */
     public static final class LogOutput {
         private final String destination;
         private final List<String> options = new ArrayList<>();
@@ -2051,6 +3562,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents different byte units for specifying sizes.
+     */
     @Getter
     public enum ByteUnit {
         BYTES(""),
@@ -2076,6 +3590,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents an auto, on, or off state.
+     */
     @Getter
     public enum AutoOnOff {
         AUTO,
@@ -2089,6 +3606,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents different categories of JVM settings.
+     */
     @Getter
     public enum SettingCategory {
         ALL,
@@ -2108,6 +3628,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents an option for Java Flight Recorder (JFR).
+     */
     public record FlightRecorderOption(String name, String value) {
         public static FlightRecorderOption globalBufferSize(long size, ByteUnit unit) {
             Objects.requireNonNull(unit, "Byte unit cannot be null");
@@ -2176,6 +3699,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents parameters for starting a Java Flight Recorder (JFR) recording.
+     */
     public record FlightRecorderParameters(String name, String value) {
         public static FlightRecorderParameters delay(long duration, TimeUnit unit) {
             Objects.requireNonNull(unit, "TimeUnit cannot be null");
@@ -2267,6 +3793,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents different modes for native memory tracking.
+     */
     @Getter
     public enum NativeMemoryTracking {
         OFF,
@@ -2280,6 +3809,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents different branch protection modes for AArch64 Linux.
+     */
     @Getter
     public enum BranchProtectionMode {
         NONE("none"),
@@ -2293,6 +3825,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents different prefetch styles for allocation.
+     */
     public enum PrefetchStyle {
         DO_NOT(0),
         AFTER_ALLOCATE(1),
@@ -2310,6 +3845,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents different commands for the JIT compiler.
+     */
     @Getter
     public enum CompileCommand {
         BREAK("break"),
@@ -2330,6 +3868,9 @@ public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecuta
         }
     }
 
+    /**
+     * Represents different data models (32-bit or 64-bit).
+     */
     @Getter
     public enum DataModel {
         DATA_32("d32"),

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JavaExecutableCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JavaExecutableCLIBuilder.java
@@ -1,0 +1,2344 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.JDKManager;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+// NOTE: Some options are version-specific; ensure compatibility with the selected JDK version
+public class JavaExecutableCLIBuilder implements CLIBuilder<Process, JavaExecutableCLIBuilder> {
+    private final JDK jdk;
+    private final String primaryArgument;
+    private final List<String> arguments = new ArrayList<>();
+    private Path workingDirectory;
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private boolean enableConsole = false;
+    private final LaunchType launchType;
+
+    private JavaExecutableCLIBuilder(LaunchType launchType, JDK jdk, String primaryArgument) {
+        this.launchType = Objects.requireNonNull(launchType, "Launch type cannot be null");
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+        this.primaryArgument = Objects.requireNonNull(primaryArgument, "Primary argument cannot be null");
+    }
+
+    public static JavaExecutableCLIBuilder classFile(JDK jdk, Path classFilePath) {
+        Objects.requireNonNull(classFilePath, "Class file path cannot be null");
+        if (!classFilePath.toString().endsWith(".class"))
+            throw new IllegalArgumentException("Provided path is not a .class file: " + classFilePath);
+        return new JavaExecutableCLIBuilder(LaunchType.CLASS_FILE, jdk, classFilePath.toString());
+    }
+
+    public static JavaExecutableCLIBuilder jarFile(JDK jdk, Path jarFilePath) {
+        Objects.requireNonNull(jarFilePath, "JAR file path cannot be null");
+        if (!jarFilePath.toString().endsWith(".jar"))
+            throw new IllegalArgumentException("Provided path is not a .jar file: " + jarFilePath);
+
+        return new JavaExecutableCLIBuilder(LaunchType.JAR_FILE, jdk, jarFilePath.toString());
+    }
+
+    public static JavaExecutableCLIBuilder module(JDK jdk, String moduleName) {
+        Objects.requireNonNull(moduleName, "Module name cannot be null");
+        return new JavaExecutableCLIBuilder(LaunchType.MODULE, jdk, moduleName);
+    }
+
+    public static JavaExecutableCLIBuilder sourceFile(JDK jdk, Path sourceFilePath) {
+        Objects.requireNonNull(sourceFilePath, "Source file path cannot be null");
+        if (!sourceFilePath.toString().endsWith(".java"))
+            throw new IllegalArgumentException("Provided path is not a .java file: " + sourceFilePath);
+
+        return new JavaExecutableCLIBuilder(LaunchType.SOURCE_FILE, jdk, sourceFilePath.toString());
+    }
+
+    @Override
+    public JavaExecutableCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JavaExecutableCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JavaExecutableCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JavaExecutableCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JavaExecutableCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableConsole(boolean enableConsole) {
+        this.enableConsole = enableConsole;
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder agentlib(String agentLib, String... options) {
+        Objects.requireNonNull(agentLib, "Agent library cannot be null");
+        Objects.requireNonNull(options, "Options array cannot be null");
+        var agentArgument = new StringBuilder("-agentlib:").append(agentLib);
+        if (options.length > 0) {
+            agentArgument.append("=");
+            agentArgument.append(String.join(",", options));
+        }
+
+        this.arguments.addFirst(agentArgument.toString());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder agentpath(Path agentPath, String... options) {
+        Objects.requireNonNull(agentPath, "Agent path cannot be null");
+        Objects.requireNonNull(options, "Options array cannot be null");
+        var agentArgument = new StringBuilder("-agentpath:").append(agentPath);
+        if (options.length > 0) {
+            agentArgument.append("=");
+            agentArgument.append(String.join(",", options));
+        }
+
+        this.arguments.add(agentArgument.toString());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder classpath(String... classpathEntries) {
+        Objects.requireNonNull(classpathEntries, "Classpath entries cannot be null");
+        this.arguments.add("-cp " + String.join(File.pathSeparator, classpathEntries));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableAtFiles() {
+        this.arguments.add("--disable-@files");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enablePreviewFeatures() {
+        if (jdk.version().major() < 12)
+            throw new UnsupportedOperationException("Preview features are only supported in JDK 12 and above.");
+
+        this.arguments.add("--enable-preview");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableNativeAccess(String moduleName) {
+        if (jdk.version().major() < 16)
+            throw new UnsupportedOperationException("Enabling native access is only supported in JDK 16 and above.");
+
+        Objects.requireNonNull(moduleName, "Module name cannot be null");
+        this.arguments.add("--enable-native-access=" + moduleName);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableNativeAccess() {
+        return enableNativeAccess("ALL-UNNAMED");
+    }
+
+    @Deprecated(forRemoval = true, since = "Java 25")
+    public JavaExecutableCLIBuilder illegalNativeAccess(AccessMode mode) {
+        if (jdk.version().major() < 24)
+            throw new UnsupportedOperationException("Setting illegal native access mode is only supported in JDK 24 and above.");
+        if (mode == AccessMode.DEBUG)
+            throw new UnsupportedOperationException("DEBUG mode is not available for illegal native access.");
+
+        Objects.requireNonNull(mode, "Native access mode cannot be null");
+        this.arguments.add("--illegal-native-access=" + mode.getMode());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder finalization(EnabledDisabled state) {
+        if (jdk.version().major() < 18)
+            throw new UnsupportedOperationException("Controlling finalization is only supported in JDK 18 and above.");
+
+        Objects.requireNonNull(state, "Finalization state cannot be null");
+        this.arguments.add("--finalization=" + state.getState());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder modulePath(String... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
+        this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder upgradeModulePath(String... upgradeModulePaths) {
+        Objects.requireNonNull(upgradeModulePaths, "Upgrade module path entries cannot be null");
+        this.arguments.add("--upgrade-module-path " + String.join(File.pathSeparator, upgradeModulePaths));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder addModules(String... modules) {
+        Objects.requireNonNull(modules, "Modules cannot be null");
+        this.arguments.add("--add-modules " + String.join(",", modules));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder addModules(RootModule rootModule) {
+        Objects.requireNonNull(rootModule, "Root module cannot be null");
+        this.arguments.add("--add-modules " + rootModule.getModule());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder listModules() {
+        this.arguments.add("--list-modules");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder describeModule(String moduleName) {
+        Objects.requireNonNull(moduleName, "Module name cannot be null");
+        this.arguments.add("--describe-module " + moduleName);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder dryRun() {
+        this.arguments.add("--dry-run");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder validateModules() {
+        this.arguments.add("--validate-modules");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder systemProperty(String key, String value) {
+        Objects.requireNonNull(key, "System property key cannot be null");
+        Objects.requireNonNull(value, "System property value cannot be null");
+        String normalizedValue = value.startsWith("\"") && value.endsWith("\"") ? value : "\"" + value + "\"";
+        this.arguments.add("-D" + key + "=" + normalizedValue);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableAssertions() {
+        this.arguments.add("-da");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableAssertions(String packageOrClassName, boolean subpackages) {
+        Objects.requireNonNull(packageOrClassName, "Package or class name cannot be null");
+        this.arguments.add("-da:" + packageOrClassName + (subpackages ? "..." : ""));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableAssertions(String packageOrClassName) {
+        return disableAssertions(packageOrClassName, false);
+    }
+
+    public JavaExecutableCLIBuilder disableSystemAssertions() {
+        this.arguments.add("-dsa");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableAssertions() {
+        this.arguments.add("-ea");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableAssertions(String packageOrClassName, boolean subpackages) {
+        Objects.requireNonNull(packageOrClassName, "Package or class name cannot be null");
+        this.arguments.add("-ea:" + packageOrClassName + (subpackages ? "..." : ""));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableAssertions(String packageOrClassName) {
+        return enableAssertions(packageOrClassName, false);
+    }
+
+    public JavaExecutableCLIBuilder enableSystemAssertions() {
+        this.arguments.add("-esa");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder help(boolean errorOutput) {
+        this.arguments.add(errorOutput ? "-help" : "--help");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder javaagent(String javaAgentPath, String... options) {
+        Objects.requireNonNull(javaAgentPath, "Java agent path cannot be null");
+        Objects.requireNonNull(options, "Options array cannot be null");
+        var agentArgument = new StringBuilder("-javaagent:").append(javaAgentPath);
+        if (options.length > 0) {
+            agentArgument.append("=");
+            agentArgument.append(String.join(",", options));
+        }
+
+        this.arguments.addFirst(agentArgument.toString());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder javaagent(Path javaAgentPath, String... options) {
+        Objects.requireNonNull(javaAgentPath, "Java agent path cannot be null");
+        return javaagent(javaAgentPath.toString(), options);
+    }
+
+    public JavaExecutableCLIBuilder showVersion(boolean errorOutput) {
+        this.arguments.add(errorOutput ? "-showversion" : "--showversion");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder showModuleResolution() {
+        this.arguments.add("--show-module-resolution");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder splashScreen(String splashImagePath) {
+        Objects.requireNonNull(splashImagePath, "Splash image path cannot be null");
+        this.arguments.add("--splash:" + splashImagePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder splashScreen(Path splashImagePath) {
+        Objects.requireNonNull(splashImagePath, "Splash image path cannot be null");
+        return splashScreen(splashImagePath.toString());
+    }
+
+    public JavaExecutableCLIBuilder verbose(VerboseComponent component) {
+        Objects.requireNonNull(component, "Verbose component cannot be null");
+        this.arguments.add("-verbose:" + component.getComponent());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder version(boolean errorOutput) {
+        this.arguments.add(errorOutput ? "-version" : "--version");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder extraOptionsHelp(boolean errorOutput) {
+        this.arguments.add(errorOutput ? "-X" : "--help-extra");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder addArgFile(Path argFilePath) {
+        Objects.requireNonNull(argFilePath, "Argument file path cannot be null");
+        this.arguments.add("@" + argFilePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableBackgroundCompilation() {
+        this.arguments.add("-Xbatch");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder appendBootClassPath(String... bootClassPathEntries) {
+        Objects.requireNonNull(bootClassPathEntries, "Boot class path entries cannot be null");
+        this.arguments.add("-Xbootclasspath/a:" + String.join(File.pathSeparator, bootClassPathEntries));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder performAdditionalJNIChecks() {
+        this.arguments.add("-Xcheck:jni");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder exerciseJITCompiler() {
+        this.arguments.add("-Xcomp");
+        return this;
+    }
+
+    @Deprecated(forRemoval = true, since = "Java 5")
+    public JavaExecutableCLIBuilder enableDebuggingSupport() {
+        this.arguments.add("-Xdebug");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder additionalDiagnosticMessages() {
+        this.arguments.add("-Xdiag");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder interpretOnlyMode() {
+        this.arguments.add("-Xint");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder internalVersionInfo() {
+        this.arguments.add("-Xinternalversion");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder configureLogging(String loggingOptions) {
+        Objects.requireNonNull(loggingOptions, "Logging options cannot be null");
+        this.arguments.add("-Xlog:" + loggingOptions);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder configureLogging(LoggingConfiguration configuration) {
+        Objects.requireNonNull(configuration, "Logging configuration cannot be null");
+        return configureLogging(configuration.asArgument());
+    }
+
+    public static LoggingConfiguration loggingConfiguration() {
+        return new LoggingConfiguration();
+    }
+
+    public JavaExecutableCLIBuilder mixedMode() {
+        this.arguments.add("-Xmixed");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder generationalMaxHeapSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Heap size cannot be null");
+        this.arguments.add("-Xmn" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder minimumHeapSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Heap size cannot be null");
+        this.arguments.add("-Xms" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maximumHeapSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Heap size cannot be null");
+        this.arguments.add("-Xmx" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableClassGC() {
+        this.arguments.add("-Xnoclassgc");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder reduceSignalUsage() {
+        this.arguments.add("-Xrs");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder setClassDataSharingMode(AutoOnOff mode) {
+        Objects.requireNonNull(mode, "Class Data Sharing mode cannot be null");
+        this.arguments.add("-Xshare:class" + mode.getMode());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder showSettings() {
+        this.arguments.add("-XshowSettings");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder showSettings(SettingCategory category) {
+        Objects.requireNonNull(category, "Setting category cannot be null");
+        if (category == SettingCategory.SYSTEM && !OperatingSystem.isLinux())
+            throw new UnsupportedOperationException("Showing system settings is only supported on Linux systems.");
+
+        this.arguments.add("-XshowSettings:" + category.getCategoryName());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder threadStackSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Stack size unit cannot be null");
+        this.arguments.add("-Xss" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder addReads(String sourceModule, String... targetModules) {
+        Objects.requireNonNull(sourceModule, "Source module cannot be null");
+        Objects.requireNonNull(targetModules, "Target modules cannot be null");
+
+        this.arguments.add("--add-reads " + sourceModule + "=" + String.join(",", targetModules));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder addReadsAllUnnamed(String sourceModule) {
+        return addReads(sourceModule, "ALL-UNNAMED");
+    }
+
+    public JavaExecutableCLIBuilder addExports(String sourceModule, String packageName, String... targetModules) {
+        Objects.requireNonNull(sourceModule, "Source module cannot be null");
+        Objects.requireNonNull(packageName, "Package name cannot be null");
+        Objects.requireNonNull(targetModules, "Target modules cannot be null");
+
+        this.arguments.add("--add-exports " + sourceModule + "/" + packageName + "=" + String.join(",", targetModules));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder addExportsAllUnnamed(String sourceModule, String packageName) {
+        return addExports(sourceModule, packageName, "ALL-UNNAMED");
+    }
+
+    public JavaExecutableCLIBuilder addOpens(String sourceModule, String packageName, String... targetModules) {
+        Objects.requireNonNull(sourceModule, "Source module cannot be null");
+        Objects.requireNonNull(packageName, "Package name cannot be null");
+        Objects.requireNonNull(targetModules, "Target modules cannot be null");
+
+        this.arguments.add("--add-opens " + sourceModule + "/" + packageName + "=" + String.join(",", targetModules));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder addOpensAllUnnamed(String sourceModule, String packageName) {
+        return addOpens(sourceModule, packageName, "ALL-UNNAMED");
+    }
+
+    public JavaExecutableCLIBuilder limitModules(String... modules) {
+        Objects.requireNonNull(modules, "Modules cannot be null");
+        this.arguments.add("--limit-modules " + String.join(",", modules));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder patchModule(String moduleName, String... patchPaths) {
+        Objects.requireNonNull(moduleName, "Module name cannot be null");
+        Objects.requireNonNull(patchPaths, "Patch paths cannot be null");
+        this.arguments.add("--patch-module " + moduleName + "=" + String.join(File.pathSeparator, patchPaths));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder sourceVersion(String version) {
+        if (launchType != LaunchType.SOURCE_FILE)
+            throw new UnsupportedOperationException("Setting source version is only supported when launching a source file.");
+
+        Objects.requireNonNull(version, "Source version cannot be null");
+        this.arguments.add("--source " + version);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder sunMiscUnsafeMemoryAccess(AccessMode mode) {
+        Objects.requireNonNull(mode, "Unsafe memory access mode cannot be null");
+        this.arguments.add("--sun-misc-unsafe-memory-access=" + mode.getMode());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder startOnFirstThread() {
+        if (!OperatingSystem.isMac())
+            throw new UnsupportedOperationException("Starting on first thread is only supported on macOS.");
+
+        this.arguments.add("-XstartOnFirstThread");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder dockName(String appName) {
+        if (!OperatingSystem.isMac())
+            throw new UnsupportedOperationException("Setting dock name is only supported on macOS.");
+
+        Objects.requireNonNull(appName, "Application name cannot be null");
+        this.arguments.add("-Xdock:name=" + appName);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder dockIcon(Path iconPath) {
+        if (!OperatingSystem.isMac())
+            throw new UnsupportedOperationException("Setting dock icon is only supported on macOS.");
+
+        Objects.requireNonNull(iconPath, "Icon path cannot be null");
+        this.arguments.add("-Xdock:icon=" + iconPath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder unlockDiagnosticVMOptions() {
+        this.arguments.add("-XX:+UnlockDiagnosticVMOptions");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder unlockExperimentalVMOptions() {
+        this.arguments.add("-XX:+UnlockExperimentalVMOptions");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder activeProcessorCount(int count) {
+        if (count <= 0)
+            throw new IllegalArgumentException("Active processor count must be positive.");
+
+        this.arguments.add("-XX:ActiveProcessorCount=" + count);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder allocateHeapAt(Path path) {
+        Objects.requireNonNull(path, "Heap allocation path cannot be null");
+        this.arguments.add("-XX:AllocateHeapAt=" + path);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableCompactStrings() {
+        this.arguments.add("-XX:-CompactStrings");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder errorFile(Path errorFilePath) {
+        Objects.requireNonNull(errorFilePath, "Error file path cannot be null");
+        this.arguments.add("-XX:ErrorFile=" + errorFilePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableExtensiveErrorReports() {
+        this.arguments.add("-XX:+ExtensiveErrorReports");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder flightRecorderOptions(FlightRecorderOption... options) {
+        Objects.requireNonNull(options, "Flight recorder options cannot be null");
+        List<String> optionStrings = new ArrayList<>();
+        for (FlightRecorderOption option : options) {
+            optionStrings.add(option.name() + "=" + option.value());
+        }
+
+        this.arguments.add("-XX:FlightRecorderOptions:" + String.join(",", optionStrings));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder largePageSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Page size unit cannot be null");
+        this.arguments.add("-XX:LargePageSizeInBytes=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxDirectMemorySize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Direct memory size unit cannot be null");
+        this.arguments.add("-XX:MaxDirectMemorySize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableMaxFileDescriptorLimit() {
+        this.arguments.add("-XX:-MaxFDLimit");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder nativeMemoryTracking(NativeMemoryTracking tracking) {
+        Objects.requireNonNull(tracking, "Native memory tracking mode cannot be null");
+        this.arguments.add("-XX:NativeMemoryTracking=" + tracking.getState());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder trimNativeHeapInterval(long interval, TimeUnit unit) {
+        if (!OperatingSystem.isLinux())
+            throw new UnsupportedOperationException("TrimNativeHeapInterval is only supported on Linux systems.");
+
+        if (interval < 0)
+            throw new IllegalArgumentException("Trim interval cannot be negative.");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.arguments.add("-XX:TrimNativeHeapInterval=" + unit.toMillis(interval));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableClientVMEmulation() {
+        this.arguments.add("-XX:+NeverActAsServerClassMachine");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder objectAlignmentInBytes(int alignment) {
+        if (alignment <= 0 || (alignment & (alignment - 1)) != 0)
+            throw new IllegalArgumentException("Object alignment must be a positive power of two.");
+
+        if (alignment < 8 || alignment > 256)
+            throw new IllegalArgumentException("Object alignment must be between 8 and 256 bytes.");
+
+        this.arguments.add("-XX:ObjectAlignmentInBytes=" + alignment);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder onError(String command) {
+        Objects.requireNonNull(command, "OnError command cannot be null");
+        this.arguments.add("-XX:OnError=\"" + command + "\"");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder onOutOfMemoryError(String command) {
+        Objects.requireNonNull(command, "OnOutOfMemoryError command cannot be null");
+        this.arguments.add("-XX:OnOutOfMemoryError=\"" + command + "\"");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enablePrintingCommandLineFlags() {
+        this.arguments.add("-XX:+PrintCommandLineFlags");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder preserveFramePointer(boolean preserve) {
+        this.arguments.add(preserve ? "-XX:+PreserveFramePointer" : "-XX:-PreserveFramePointer");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enablePrintingNMTStatistics() {
+        this.arguments.add("-XX:+PrintNMTStatistics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder sharedArchiveFile(Path archivePath) {
+        Objects.requireNonNull(archivePath, "Shared archive file path cannot be null");
+        this.arguments.add("-XX:SharedArchiveFile=" + archivePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder sharedArchiveFileDynamic(Path dynamicArchivePath) {
+        Objects.requireNonNull(dynamicArchivePath, "Dynamic shared archive file path cannot be null");
+        this.arguments.add("-XX:SharedArchiveFile=," + dynamicArchivePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder sharedArchiveFile(Path staticArchivePath, Path dynamicArchivePath) {
+        Objects.requireNonNull(staticArchivePath, "Static shared archive file path cannot be null");
+        Objects.requireNonNull(dynamicArchivePath, "Dynamic shared archive file path cannot be null");
+        this.arguments.add("-XX:SharedArchiveFile=" + staticArchivePath + File.pathSeparator + dynamicArchivePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder verifySharedSpaces() {
+        this.arguments.add("-XX:+VerifySharedSpaces");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder sharedArchiveConfigFile(Path configFilePath) {
+        Objects.requireNonNull(configFilePath, "Shared archive config file path cannot be null");
+        this.arguments.add("-XX:SharedArchiveConfigFile=" + configFilePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder sharedClassListFile(Path classListFilePath) {
+        Objects.requireNonNull(classListFilePath, "Shared class list file path cannot be null");
+        this.arguments.add("-XX:SharedClassListFile=" + classListFilePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder showCodeDetailsInExceptionMessages() {
+        this.arguments.add("-XX:+ShowCodeDetailsInExceptionMessages");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder showMessageBoxOnError() {
+        this.arguments.add("-XX:+ShowMessageBoxOnError");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder startFlightRecording(FlightRecorderParameters parameters) {
+        Objects.requireNonNull(parameters, "Flight recorder parameters cannot be null");
+        this.arguments.add("-XX:StartFlightRecording=" + parameters);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder threadStackSize(int sizeInKB) {
+        if (sizeInKB <= 0)
+            throw new IllegalArgumentException("Stack size must be positive.");
+
+        this.arguments.add("-Xss" + sizeInKB + "K");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder useCompactObjectHeaders() {
+        if (jdk.version().major() < 25)
+            throw new UnsupportedOperationException("Compact object headers are only supported in JDK 25 and above.");
+
+        this.arguments.add("-XX:+UseCompactObjectHeaders");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableCompressedPointers() {
+        this.arguments.add("-XX:-UseCompressedOops");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableContainerSupport() {
+        if (!OperatingSystem.isLinux())
+            throw new UnsupportedOperationException("Disabling container support is only supported on Linux systems.");
+
+        this.arguments.add("-XX:-UseContainerSupport");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder useLargePages() {
+        this.arguments.add("-XX:+UseLargePages");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder useTransparentHugePages() {
+        if (!OperatingSystem.isLinux())
+            throw new UnsupportedOperationException("UseTransparentHugePages is only supported on Linux systems.");
+
+        this.arguments.add("-XX:+UseTransparentHugePages");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder allowInstallingSignalHandlers() {
+        if (OperatingSystem.isWindows())
+            throw new UnsupportedOperationException("Installing signal handlers is not supported on Windows systems.");
+
+        this.arguments.add("-XX:+AllowUserSignalHandlers");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder vmOptionsFile(Path vmOptionsFilePath) {
+        Objects.requireNonNull(vmOptionsFilePath, "VM options file path cannot be null");
+        this.arguments.add("-XX:VMOptionsFile=" + vmOptionsFilePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder branchProtectionMode(BranchProtectionMode mode) {
+        if (!OperatingSystem.isLinux())
+            throw new UnsupportedOperationException("Branch protection mode is only supported on Linux (AArch64) systems.");
+
+        Objects.requireNonNull(mode, "Branch protection mode cannot be null");
+        this.arguments.add("-XX:BranchProtection=" + mode.getMode());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder allocateInstancePrefetchLines(int lineCount) {
+        if (lineCount < 0)
+            throw new IllegalArgumentException("Line count cannot be negative.");
+
+        this.arguments.add("-XX:AllocateInstancePrefetchLines=" + lineCount);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder allocatePrefetchDistance(long distance, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Prefetch distance unit cannot be null");
+        if (distance < -1)
+            throw new IllegalArgumentException("Prefetch distance cannot be negative.");
+
+        this.arguments.add("-XX:AllocatePrefetchDistance=" + distance + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder allocatePrefetchInstruction(byte instructionType) {
+        if (instructionType < 0 || instructionType > 3)
+            throw new IllegalArgumentException("Instruction type must be 0, 1, 2, or 3.");
+
+        this.arguments.add("-XX:AllocatePrefetchInstr=" + instructionType);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder allocatePrefetchLines(int lineCount) {
+        if (lineCount < 0)
+            throw new IllegalArgumentException("Line count cannot be negative.");
+
+        this.arguments.add("-XX:AllocatePrefetchLines=" + lineCount);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder allocatePrefetchStepSize(int stepSize, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Step size unit cannot be null");
+        if (stepSize < 0)
+            throw new IllegalArgumentException("Step size cannot be negative.");
+
+        this.arguments.add("-XX:AllocatePrefetchStepSize=" + stepSize + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder allocatePrefetchStyle(PrefetchStyle style) {
+        Objects.requireNonNull(style, "Prefetch style cannot be null");
+        this.arguments.add("-XX:AllocatePrefetchStyle=" + style.asInt());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableBackgroundCompilation() {
+        this.arguments.add("-XX:+BackgroundCompilation");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder compilerThreadsForCompilation(int threadCount) {
+        if (threadCount <= 0)
+            throw new IllegalArgumentException("Thread count must be positive.");
+
+        this.arguments.add("-XX:CompilerThreadsForCompilation=" + threadCount);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder useDynamicNumberOfCompilerThreads() {
+        this.arguments.add("-XX:+UseDynamicNumberOfCompilerThreads");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder compileCommand(CompileCommand command, String... methodSpecs) {
+        Objects.requireNonNull(command, "Compile command cannot be null");
+        Objects.requireNonNull(methodSpecs, "Method specifications cannot be null");
+
+        this.arguments.add("-XX:CompileCommand=\"" + command.getCommand() + "," + String.join(",", methodSpecs) + "\"");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder compileCommandFile(Path commandFilePath) {
+        Objects.requireNonNull(commandFilePath, "Command file path cannot be null");
+        this.arguments.add("-XX:CompileCommandFile=" + commandFilePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder compilerDirectivesFile(Path directivesFilePath) {
+        Objects.requireNonNull(directivesFilePath, "Directives file path cannot be null");
+        this.arguments.add("-XX:CompilerDirectivesFile=" + directivesFilePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder shouldPrintCompilerDirectives() {
+        this.arguments.add("-XX:+PrintCompilerDirectives");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder compileOnly(String... methodSpecs) {
+        Objects.requireNonNull(methodSpecs, "Method specifications cannot be null");
+
+        this.arguments.add("-XX:CompileOnly=" + String.join(",", methodSpecs));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder compileThresholdScale(int scale) {
+        if (scale <= 0)
+            throw new IllegalArgumentException("Scale must be positive.");
+
+        this.arguments.add("-XX:CompileThresholdScale=" + scale);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableEscapeAnalysis(boolean enable) {
+        this.arguments.add(enable ? "-XX:+DoEscapeAnalysis" : "-XX:-DoEscapeAnalysis");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder initialCodeCacheSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Code cache size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Initial code cache size cannot be negative.");
+
+        this.arguments.add("-XX:InitialCodeCacheSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableMethodInlining(boolean enable) {
+        this.arguments.add(enable ? "-XX:+Inline" : "-XX:-Inline");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder inlineSmallCode(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Code size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Inline small code size cannot be negative.");
+
+        this.arguments.add("-XX:InlineSmallCode=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableCompilationLogging() {
+        this.arguments.add("-XX:+LogCompilation");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder hotMethodInlineSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Code size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Hot method inline size cannot be negative.");
+
+        this.arguments.add("-XX:FreqInlineSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxInlineSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Code size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Max inline size cannot be negative.");
+
+        this.arguments.add("-XX:MaxInlineSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder c1MaxInlineSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Code size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("C1 max inline size cannot be negative.");
+
+        this.arguments.add("-XX:C1MaxInlineSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxTrivialSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Code size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Max trivial size cannot be negative.");
+
+        this.arguments.add("-XX:MaxTrivialSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder c1MaxTrivialSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Code size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("C1 max trivial size cannot be negative.");
+
+        this.arguments.add("-XX:C1MaxTrivialSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxNodeLimit(int limit) {
+        if (limit < 0)
+            throw new IllegalArgumentException("Max node limit cannot be negative.");
+
+        this.arguments.add("-XX:MaxNodeLimit=" + limit);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder nonmethodCodeHeapSize(long sizeInBytes) {
+        if (sizeInBytes < 0)
+            throw new IllegalArgumentException("Non-method code heap size cannot be negative.");
+
+        this.arguments.add("-XX:NonNMethodCodeHeapSize=" + sizeInBytes);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder nonprofiledCodeHeapSize(long sizeInBytes) {
+        if (sizeInBytes < 0)
+            throw new IllegalArgumentException("Non-profiled code heap size cannot be negative.");
+
+        this.arguments.add("-XX:NonProfiledCodeHeapSize=" + sizeInBytes);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableOptimizingStringConcat(boolean enable) {
+        this.arguments.add(enable ? "-XX:+OptimizeStringConcat" : "-XX:-OptimizeStringConcat");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enablePrintingAssemblyCode() {
+        this.arguments.add("-XX:+PrintAssembly");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder profiledCodeHeapSize(long sizeInBytes) {
+        if (sizeInBytes < 0)
+            throw new IllegalArgumentException("Profiled code heap size cannot be negative.");
+
+        this.arguments.add("-XX:ProfiledCodeHeapSize=" + sizeInBytes);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableMethodCompilationPrinting() {
+        this.arguments.add("-XX:+PrintCompilation");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableInliningInfoPrinting() {
+        this.arguments.add("-XX:+PrintInlining");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder reserveCodeCacheSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Code cache size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Reserved code cache size cannot be negative.");
+
+        if (unit.toBytes(size) > ByteUnit.GIGABYTES.toBytes(2))
+            throw new IllegalArgumentException("Reserved code cache size cannot exceed 2 GB.");
+
+        this.arguments.add("-XX:ReservedCodeCacheSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableSegmentedCodeCache() {
+        this.arguments.add("-XX:+SegmentedCodeCache");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder startAggressiveSweepingAt(int percentage) {
+        if (percentage < 0 || percentage > 100)
+            throw new IllegalArgumentException("Percentage must be between 0 and 100.");
+
+        this.arguments.add("-XX:AggressiveHeapSweepingAt=" + percentage);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableTieredCompilation() {
+        this.arguments.add("-XX:-TieredCompilation");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder sseInstructionSetVersion(String version) {
+        Objects.requireNonNull(version, "SSE instruction set version cannot be null");
+        this.arguments.add("-XX:UseSSE=" + version);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder avxInstructionSetVersion(String version) {
+        Objects.requireNonNull(version, "AVX instruction set version cannot be null");
+        this.arguments.add("-XX:UseAVX=" + version);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableAES(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseAES" : "-XX:-UseAES");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableAESIntrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseAESIntrinsics" : "-XX:-UseAESIntrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableAESCTRIntrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseAESCTRIntrinsics" : "-XX:-UseAESCTRIntrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableGHASHIntrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseGHASHIntrinsics" : "-XX:-UseGHASHIntrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableChaCha20Intrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseChaCha20Intrinsics" : "-XX:-UseChaCha20Intrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enablePoly1305Intrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UsePoly1305Intrinsics" : "-XX:-UsePoly1305Intrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableBASE64Intrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseBASE64Intrinsics" : "-XX:-UseBASE64Intrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableAdler32Intrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseAdler32Intrinsics" : "-XX:-UseAdler32Intrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableCRC32Intrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseCRC32Intrinsics" : "-XX:-UseCRC32Intrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableCRC32CIntrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseCRC32CIntrinsics" : "-XX:-UseCRC32CIntrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableSHA(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseSHA" : "-XX:-UseSHA");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableSHA1Intrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseSHA1Intrinsics" : "-XX:-UseSHA1Intrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableSHA256Intrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseSHA256Intrinsics" : "-XX:-UseSHA256Intrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableSHA512Intrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseSHA512Intrinsics" : "-XX:-UseSHA512Intrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableMathExactIntrinsics(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseMathExactIntrinsics" : "-XX:-UseMathExactIntrinsics");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableMultiplyToLenIntrinsic(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseMultiplyToLenIntrinsic" : "-XX:-UseMultiplyToLenIntrinsic");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableSquareToLenIntrinsic(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseSquareToLenIntrinsic" : "-XX:-UseSquareToLenIntrinsic");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableMulAddIntrinsic(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseMulAddIntrinsic" : "-XX:-UseMulAddIntrinsic");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableMontgomeryMultiplyIntrinsic(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseMontgomeryMultiplyIntrinsic" : "-XX:-UseMontgomeryMultiplyIntrinsic");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableMontgomerySquareIntrinsic(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseMontgomerySquareIntrinsic" : "-XX:-UseMontgomerySquareIntrinsic");
+        return this;
+    }
+
+    // -XX:+UseCMoveUnconditionally
+    //Generates CMove (scalar and vector) instructions regardless of profitability analysis.
+    //-XX:+UseCodeCacheFlushing
+    //Enables flushing of the code cache before shutting down the compiler. This option is enabled by default. To disable flushing of the code cache before shutting down the compiler, specify -XX:-UseCodeCacheFlushing.
+    //-XX:+UseCondCardMark
+    //Enables checking if the card is already marked before updating the card table. This option is disabled by default. It should be used only on machines with multiple sockets, where it increases the performance of Java applications that rely on concurrent operations.
+    //-XX:+UseCountedLoopSafepoints
+    //Keeps safepoints in counted loops. Its default value depends on whether the selected garbage collector requires low latency safepoints.
+    //-XX:LoopStripMiningIter=number_of_iterations
+    //Controls the number of iterations in the inner strip mined loop. Strip mining transforms counted loops into two level nested loops. Safepoints are kept in the outer loop while the inner loop can execute at full speed. This option controls the maximum number of iterations in the inner loop. The default value is 1,000.
+    //-XX:LoopStripMiningIterShortLoop=number_of_iterations
+    //Controls loop strip mining optimization. Loops with the number of iterations less than specified will not have safepoints in them. Default value is 1/10th of -XX:LoopStripMiningIter.
+    //-XX:+UseFMA
+    //Enables hardware-based FMA intrinsics for hardware where FMA instructions are available (such as, Intel and ARM64). FMA intrinsics are generated for the java.lang.Math.fma(a, b, c) methods that calculate the value of ( a * b + c ) expressions.
+    //-XX:+UseSuperWord
+    //Enables the transformation of scalar operations into superword operations. Superword is a vectorization optimization. This option is enabled by default. To disable the transformation of scalar operations into superword operations, specify -XX:-UseSuperWord.
+
+    public JavaExecutableCLIBuilder enableCMoveUnconditionally(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseCMoveUnconditionally" : "-XX:-UseCMoveUnconditionally");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableCodeCacheFlushing(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseCodeCacheFlushing" : "-XX:-UseCodeCacheFlushing");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableCondCardMark(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseCondCardMark" : "-XX:-UseCondCardMark");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableCountedLoopSafepoints(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseCountedLoopSafepoints" : "-XX:-UseCountedLoopSafepoints");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder loopStripMiningIterations(int iterationCount) {
+        if (iterationCount <= 0)
+            throw new IllegalArgumentException("Iteration count must be positive.");
+
+        this.arguments.add("-XX:LoopStripMiningIter=" + iterationCount);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder loopStripMiningIterationsForShortLoops(int iterationCount) {
+        if (iterationCount <= 0)
+            throw new IllegalArgumentException("Iteration count must be positive.");
+
+        this.arguments.add("-XX:LoopStripMiningIterShortLoop=" + iterationCount);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableFMA(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseFMA" : "-XX:-UseFMA");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableSuperWord(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseSuperWord" : "-XX:-UseSuperWord");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableAttachMechanism() {
+        this.arguments.add("-XX:+DisableAttachMechanism");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableDTraceAllocProbes() {
+        if (!OperatingSystem.isLinux() && !OperatingSystem.isMac())
+            throw new UnsupportedOperationException("DTrace allocation probes are only supported on macOS and Linux systems.");
+
+        this.arguments.add("-XX:+DTraceAllocProbes");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableDTraceMethodProbes() {
+        if (!OperatingSystem.isLinux() && !OperatingSystem.isMac())
+            throw new UnsupportedOperationException("DTrace method probes are only supported on macOS and Linux systems.");
+
+        this.arguments.add("-XX:+DTraceMethodProbes");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableDTraceMonitorProbes() {
+        if (!OperatingSystem.isLinux() && !OperatingSystem.isMac())
+            throw new UnsupportedOperationException("DTrace monitor probes are only supported on macOS and Linux systems.");
+
+        this.arguments.add("-XX:+DTraceMonitorProbes");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableDumpingHeapOnOutOfMemoryError() {
+        this.arguments.add("-XX:+HeapDumpOnOutOfMemoryError");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder heapDumpPath(Path dumpPath) {
+        Objects.requireNonNull(dumpPath, "Heap dump path cannot be null");
+        this.arguments.add("-XX:HeapDumpPath=" + dumpPath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder logFile(Path logFilePath) {
+        Objects.requireNonNull(logFilePath, "Log file path cannot be null");
+        this.arguments.add("-XX:LogFile=" + logFilePath);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enablePrintingClassHistogram() {
+        this.arguments.add("-XX:+PrintClassHistogram");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder printConcurrentLocks() {
+        this.arguments.add("-XX:+PrintConcurrentLocks");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder printFlagRanges() {
+        this.arguments.add("-XX:+PrintFlagRanges");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder perfDataSaveToFile() {
+        this.arguments.add("-XX:+PerfDataSaveToFile");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableUsingPerfData(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UsePerfData" : "-XX:-UsePerfData");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableAggressiveHeap() {
+        this.arguments.add("-XX:+AggressiveHeap");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder alwaysPreTouch() {
+        this.arguments.add("-XX:+AlwaysPreTouch");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder concurrentGCThreads(int threadCount) {
+        if (threadCount <= 0)
+            throw new IllegalArgumentException("Thread count must be positive.");
+
+        this.arguments.add("-XX:ConcGCThreads=" + threadCount);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder disableExplicitGC() {
+        this.arguments.add("-XX:+DisableExplicitGC");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableConcurrentExplicitGCInvokes() {
+        this.arguments.add("-XX:+ExplicitGCInvokesConcurrent");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder G1AdaptiveIHOPNumInitialSamples(int sampleCount) {
+        if (sampleCount < 0)
+            throw new IllegalArgumentException("Sample count cannot be negative.");
+
+        this.arguments.add("-XX:G1AdaptiveIHOPNumInitialSamples=" + sampleCount);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder G1HeapRegionSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Heap region size unit cannot be null");
+
+        if (unit.toBytes(size) < ByteUnit.MEGABYTES.toBytes(1) || unit.toBytes(size) > ByteUnit.MEGABYTES.toBytes(32))
+            throw new IllegalArgumentException("G1 heap region size must be between 1 MB and 32 MB.");
+
+        this.arguments.add("-XX:G1HeapRegionSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder G1HeapWastePercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Heap waste percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:G1HeapWastePercent=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder G1MaxNewSizePercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Max new size percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:G1MaxNewSizePercent=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder G1MixedGCCountTarget(int targetCount) {
+        if (targetCount < 0)
+            throw new IllegalArgumentException("Target count cannot be negative.");
+
+        this.arguments.add("-XX:G1MixedGCCountTarget=" + targetCount);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder G1MixedGCLiveThresholdPercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Live threshold percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:G1MixedGCLiveThresholdPercent=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder G1NewSizePercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("New size percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:G1NewSizePercent=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder G1OldCSetRegionThresholdPercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Old CSet region threshold percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:G1OldCSetRegionThresholdPercent=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder G1ReservePercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Reserve percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:G1ReservePercent=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableG1AdaptiveIHOP() {
+        this.arguments.add("-XX:+G1UseAdaptiveIHOP");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder initialHeapSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Heap size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Initial heap size cannot be negative.");
+
+        if (unit.toBytes(size) < ByteUnit.MEGABYTES.toBytes(1) || (unit.toBytes(size) % 1024) != 0)
+            throw new IllegalArgumentException("Initial heap size must be at least 1 MB and a multiple of 1024 bytes.");
+
+        this.arguments.add("-XX:InitialHeapSize" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder initialSurvivorRatio(int ratio) {
+        if (ratio <= 0)
+            throw new IllegalArgumentException("Initial survivor ratio must be positive.");
+
+        this.arguments.add("-XX:InitialSurvivorRatio=" + ratio);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder initiatingHeapOccupancyPercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Initiating heap occupancy percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:InitiatingHeapOccupancyPercent=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxGCPause(long time, TimeUnit unit) {
+        Objects.requireNonNull(unit, "Time unit cannot be null");
+
+        if (time < 0)
+            throw new IllegalArgumentException("Max GC pause time cannot be negative.");
+
+        this.arguments.add("-XX:MaxGCPauseMillis=" + unit.toMillis(time));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxHeapSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Heap size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Max heap size cannot be negative.");
+
+        if (unit.toBytes(size) < ByteUnit.MEGABYTES.toBytes(2) || (unit.toBytes(size) % 1024) != 0)
+            throw new IllegalArgumentException("Max heap size must be at least 2 MB and a multiple of 1024 bytes.");
+
+        this.arguments.add("-XX:MaxHeapSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxHeapFreeRatioPercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Max heap free ratio percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:MaxHeapFreeRatio=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxMetaspaceSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Metaspace size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Max metaspace size cannot be negative.");
+
+        this.arguments.add("-XX:MaxMetaspaceSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxNewSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "New size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Max new size cannot be negative.");
+
+        this.arguments.add("-XX:MaxNewSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxRAM(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "RAM size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Max RAM size cannot be negative.");
+
+        if (unit.toBytes(size) > ByteUnit.GIGABYTES.toBytes(128))
+            throw new IllegalArgumentException("Max RAM size cannot exceed 128 GB.");
+
+        this.arguments.add("-XX:MaxRAM=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxRAMPercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Max RAM percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:MaxRAMPercent=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxTenuringThreshold(int threshold) {
+        if (threshold < 0)
+            throw new IllegalArgumentException("Max tenuring threshold cannot be negative.");
+
+        if (threshold > 15)
+            throw new IllegalArgumentException("Max tenuring threshold cannot exceed 15.");
+
+        this.arguments.add("-XX:MaxTenuringThreshold=" + threshold);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder metaspaceSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "Metaspace size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("Metaspace size cannot be negative.");
+
+        this.arguments.add("-XX:MetaspaceSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder minHeapFreeRatioPercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Min heap free ratio percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:MinHeapFreeRatio=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder newRatio(int ratio) {
+        if (ratio <= 0)
+            throw new IllegalArgumentException("New ratio must be positive.");
+
+        this.arguments.add("-XX:NewRatio=" + ratio);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder newSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "New size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("New size cannot be negative.");
+
+        this.arguments.add("-XX:NewSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder parallelGCThreads(int threadCount) {
+        if (threadCount <= 0)
+            throw new IllegalArgumentException("Thread count must be positive.");
+
+        this.arguments.add("-XX:ParallelGCThreads=" + threadCount);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableParallelRefProc(boolean enable) {
+        this.arguments.add(enable ? "-XX:+ParallelRefProcEnabled" : "-XX:-ParallelRefProcEnabled");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enablePrintingAdaptiveSizePolicy() {
+        this.arguments.add("-XX:+PrintAdaptiveSizePolicy");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder softRefLRUPolicyMSPerMB(long time, TimeUnit unit) {
+        Objects.requireNonNull(unit, "Time unit cannot be null");
+
+        if (time < 0)
+            throw new IllegalArgumentException("Time cannot be negative.");
+
+        this.arguments.add("-XX:SoftRefLRUPolicyMSPerMB=" + unit.toMillis(time));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder incrementallyReduceJavaHeapSize() {
+        this.arguments.add("-XX:-ShrinkHeapInSteps");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder stringDeduplicationAgeThreshold(int threshold) {
+        if (threshold < 0)
+            throw new IllegalArgumentException("String deduplication age threshold cannot be negative.");
+
+        this.arguments.add("-XX:StringDeduplicationAgeThreshold=" + threshold);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder survivorRatio(int ratio) {
+        if (ratio <= 0)
+            throw new IllegalArgumentException("Survivor ratio must be positive.");
+
+        this.arguments.add("-XX:SurvivorRatio=" + ratio);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder targetSurvivorRatioPercent(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Target survivor ratio percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:TargetSurvivorRatio=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder TLABSize(long size, ByteUnit unit) {
+        Objects.requireNonNull(unit, "TLAB size unit cannot be null");
+
+        if (size < 0)
+            throw new IllegalArgumentException("TLAB size cannot be negative.");
+
+        this.arguments.add("-XX:TLABSize=" + size + unit.getUnit());
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableAdaptiveSizePolicy(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseAdaptiveSizePolicy" : "-XX:-UseAdaptiveSizePolicy");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableG1GC() {
+        this.arguments.add("-XX:+UseG1GC");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableGCOverheadLimit() {
+        this.arguments.add("-XX:+UseGCOverheadLimit");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableNUMA() {
+        this.arguments.add("-XX:+UseNUMA");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableParallelGC() {
+        this.arguments.add("-XX:+UseParallelGC");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableSerialGC() {
+        this.arguments.add("-XX:+UseSerialGC");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableStringDeduplication(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseStringDeduplication" : "-XX:-UseStringDeduplication");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableTLAB(boolean enable) {
+        this.arguments.add(enable ? "-XX:+UseTLAB" : "-XX:-UseTLAB");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableZGC() {
+        this.arguments.add("-XX:+UseZGC");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder allocationSpikeToleranceForZGC(float tolerance) {
+        this.arguments.add("-XX:ZAllocationSpikeTolerance=" + tolerance);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxCollectionIntervalForZGC(long time, TimeUnit unit) {
+        Objects.requireNonNull(unit, "Time unit cannot be null");
+
+        if (time < 0)
+            throw new IllegalArgumentException("Max collection interval cannot be negative.");
+
+        this.arguments.add("-XX:ZCollectionInterval=" + unit.toSeconds(time));
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder maxFragmentationLimitPercentForZGC(int percent) {
+        if (percent < 0 || percent > 100)
+            throw new IllegalArgumentException("Max fragmentation limit percent must be between 0 and 100.");
+
+        this.arguments.add("-XX:ZFragmentationLimit=" + percent);
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableProactiveGCCyclesForZGC(boolean enable) {
+        this.arguments.add(enable ? "-XX:+ZProactiveGCCycles" : "-XX:-ZProactiveGCCycles");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder enableUncommitForZGC(boolean enable) {
+        this.arguments.add(enable ? "-XX:+ZUncommit" : "-XX:-ZUncommit");
+        return this;
+    }
+
+    public JavaExecutableCLIBuilder uncommitDelayForZGC(long time, TimeUnit unit) {
+        Objects.requireNonNull(unit, "Time unit cannot be null");
+
+        if (time < 0)
+            throw new IllegalArgumentException("Uncommit delay cannot be negative.");
+
+        this.arguments.add("-XX:ZUncommitDelay=" + unit.toSeconds(time));
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(resolveExecutableName(enableConsole)).toString());
+        String preArgument = launchType.getPreArgument();
+        if (!preArgument.isEmpty()) {
+            command.add(preArgument);
+        }
+        command.add(primaryArgument);
+        command.addAll(arguments);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, resolveExecutableName(enableConsole));
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start Java process", exception);
+        }
+    }
+
+    private static String resolveExecutableName(boolean enableConsole) {
+        if (OperatingSystem.isWindows() && !enableConsole)
+            return "javaw.exe";
+
+        return JDKManager.JAVA_EXECUTABLE_NAME;
+    }
+
+    @Getter
+    public enum LaunchType {
+        CLASS_FILE,
+        JAR_FILE("-jar"),
+        MODULE("-m"),
+        SOURCE_FILE;
+
+        private final String preArgument;
+
+        LaunchType(String preArgument) {
+            this.preArgument = preArgument;
+        }
+
+        LaunchType() {
+            this.preArgument = "";
+        }
+    }
+
+    @Getter
+    public enum AccessMode {
+        ALLOW("allow"),
+        WARN("warn"),
+        DENY("deny"),
+        DEBUG("debug");
+
+        private final String mode;
+
+        AccessMode(String mode) {
+            this.mode = mode;
+        }
+    }
+
+    @Getter
+    public enum EnabledDisabled {
+        ENABLED,
+        DISABLED;
+
+        private final String state;
+
+        EnabledDisabled() {
+            this.state = name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    @Getter
+    public enum RootModule {
+        ALL_DEFAULT,
+        ALL_SYSTEM,
+        ALL_MODULE_PATH;
+
+        private final String module;
+
+        RootModule() {
+            this.module = name().toLowerCase(Locale.ROOT).replace('_', '-');
+        }
+    }
+
+    @Getter
+    public enum VerboseComponent {
+        CLASS,
+        GC,
+        JNI,
+        MODULE;
+
+        private final String component;
+
+        VerboseComponent() {
+            this.component = name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    public static final class LoggingConfiguration {
+        private final List<LogSelection> selections = new ArrayList<>();
+        private LogOutput output;
+        private final EnumSet<LogDecorator> decorators = EnumSet.noneOf(LogDecorator.class);
+
+        public LoggingConfiguration select(LogSelection selection) {
+            Objects.requireNonNull(selection, "Log selection cannot be null");
+            this.selections.add(selection);
+            return this;
+        }
+
+        public LoggingConfiguration select(LogSelection... selectionArray) {
+            Objects.requireNonNull(selectionArray, "Log selections cannot be null");
+            for (LogSelection selection : selectionArray) {
+                select(selection);
+            }
+
+            return this;
+        }
+
+        public LoggingConfiguration output(LogOutput output) {
+            this.output = Objects.requireNonNull(output, "Log output cannot be null");
+            return this;
+        }
+
+        public LoggingConfiguration decorators(LogDecorator... decoratorArray) {
+            Objects.requireNonNull(decoratorArray, "Log decorators cannot be null");
+            for (LogDecorator decorator : decoratorArray) {
+                Objects.requireNonNull(decorator, "Decorator cannot be null");
+                this.decorators.add(decorator);
+            }
+
+            return this;
+        }
+
+        private String asArgument() {
+            StringBuilder builder = new StringBuilder();
+            if (!selections.isEmpty()) {
+                builder.append(selections.stream().map(LogSelection::asToken).collect(Collectors.joining(",")));
+            }
+
+            boolean hasOutput = output != null;
+            boolean hasDecorators = !decorators.isEmpty();
+            boolean hasOutputOptions = hasOutput && output.hasOptions();
+
+            if (hasOutput || hasDecorators || hasOutputOptions) {
+                if (builder.length() > 0)
+                    builder.append(":");
+
+                if (hasOutput) {
+                    builder.append(output.destination());
+                }
+            }
+
+            if (hasDecorators || hasOutputOptions) {
+                builder.append(":");
+                if (hasDecorators) {
+                    builder.append(decorators.stream().map(LogDecorator::token).collect(Collectors.joining(",")));
+                }
+            }
+
+            if (hasOutputOptions) {
+                builder.append(":").append(output.optionsToken());
+            }
+
+            return builder.toString();
+        }
+    }
+
+    public static final class LogSelection {
+        private final List<String> tags = new ArrayList<>();
+        private LogLevel level = LogLevel.INFO;
+        private String literalToken;
+
+        public static LogSelection create() {
+            return new LogSelection();
+        }
+
+        public static LogSelection literal(String token) {
+            LogSelection selection = new LogSelection();
+            selection.literalToken = Objects.requireNonNull(token, "Log selector literal cannot be null");
+            return selection;
+        }
+
+        public static LogSelection all(LogLevel level) {
+            return create().level(level);
+        }
+
+        public LogSelection tags(String... tags) {
+            Objects.requireNonNull(tags, "Log tags cannot be null");
+            for (String tag : tags) {
+                if (tag == null || tag.isBlank())
+                    throw new IllegalArgumentException("Log tag cannot be null or blank");
+                this.tags.add(tag);
+            }
+
+            return this;
+        }
+
+        public LogSelection level(LogLevel level) {
+            this.level = Objects.requireNonNull(level, "Log level cannot be null");
+            return this;
+        }
+
+        private String asToken() {
+            if (literalToken != null) {
+                return literalToken;
+            }
+
+            String selector = tags.isEmpty() ? "*" : String.join("+", tags);
+            return selector + "=" + level.token();
+        }
+    }
+
+    public enum LogLevel {
+        TRACE("trace"),
+        DEBUG("debug"),
+        INFO("info"),
+        WARNING("warning"),
+        ERROR("error"),
+        OFF("off");
+
+        private final String token;
+
+        LogLevel(String token) {
+            this.token = token;
+        }
+
+        public String token() {
+            return token;
+        }
+    }
+
+    public enum LogDecorator {
+        TIME("time"),
+        UPTIME("uptime"),
+        TIMEMILLIS("timemillis"),
+        UPTIMEMILLIS("uptimemillis"),
+        TIMEDELTA("timedelta"),
+        USTAMP("ustamp"),
+        PID("pid"),
+        TID("tid"),
+        LEVEL("level"),
+        TAGS("tags"),
+        HOSTNAME("hostname");
+
+        private final String token;
+
+        LogDecorator(String token) {
+            this.token = token;
+        }
+
+        public String token() {
+            return token;
+        }
+    }
+
+    public static final class LogOutput {
+        private final String destination;
+        private final List<String> options = new ArrayList<>();
+
+        private LogOutput(String destination) {
+            this.destination = Objects.requireNonNull(destination, "Log output destination cannot be null");
+        }
+
+        public static LogOutput stdout() {
+            return new LogOutput("stdout");
+        }
+
+        public static LogOutput stderr() {
+            return new LogOutput("stderr");
+        }
+
+        public static LogOutput file(Path path) {
+            Objects.requireNonNull(path, "Log file path cannot be null");
+            return new LogOutput("file=" + path);
+        }
+
+        public static LogOutput custom(String destination) {
+            return new LogOutput(destination);
+        }
+
+        public LogOutput option(String key, String value) {
+            Objects.requireNonNull(key, "Output option key cannot be null");
+            Objects.requireNonNull(value, "Output option value cannot be null");
+            this.options.add(key + "=" + value);
+            return this;
+        }
+
+        public LogOutput rotateFiles(int fileCount, long fileSize, ByteUnit unit) {
+            if (fileCount <= 0)
+                throw new IllegalArgumentException("File count must be positive");
+            if (fileSize <= 0)
+                throw new IllegalArgumentException("File size must be positive");
+            Objects.requireNonNull(unit, "Byte unit cannot be null");
+            this.options.add("filecount=" + fileCount);
+            this.options.add("filesize=" + fileSize + unit.getUnit());
+            return this;
+        }
+
+        private boolean hasOptions() {
+            return !options.isEmpty();
+        }
+
+        private String optionsToken() {
+            return String.join(",", options);
+        }
+
+        private String destination() {
+            return destination;
+        }
+    }
+
+    @Getter
+    public enum ByteUnit {
+        BYTES(""),
+        KILOBYTES("K"),
+        MEGABYTES("M"),
+        GIGABYTES("G");
+
+        private static final long MULTIPLIER = 1024L;
+
+        private final String unit;
+
+        ByteUnit(String unit) {
+            this.unit = unit;
+        }
+
+        public long toBytes(long size) {
+            return switch (this) {
+                case BYTES -> size;
+                case KILOBYTES -> BYTES.toBytes(size) * MULTIPLIER;
+                case MEGABYTES -> KILOBYTES.toBytes(size) * MULTIPLIER;
+                case GIGABYTES -> MEGABYTES.toBytes(size) * MULTIPLIER;
+            };
+        }
+    }
+
+    @Getter
+    public enum AutoOnOff {
+        AUTO,
+        ON,
+        OFF;
+
+        private final String mode;
+
+        AutoOnOff() {
+            this.mode = name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    @Getter
+    public enum SettingCategory {
+        ALL,
+        LOCALE,
+        PROPERTIES,
+        SECURITY_ALL,
+        SECURITY_PROPERTIES,
+        SECURITY_PROVIDERS,
+        SECURITY_TLS,
+        VM,
+        SYSTEM;
+
+        private final String categoryName;
+
+        SettingCategory() {
+            this.categoryName = name().toLowerCase(Locale.ROOT).replace('_', ':');
+        }
+    }
+
+    public record FlightRecorderOption(String name, String value) {
+        public static FlightRecorderOption globalBufferSize(long size, ByteUnit unit) {
+            Objects.requireNonNull(unit, "Byte unit cannot be null");
+
+            if (size < 0)
+                throw new IllegalArgumentException("Global buffer size cannot be negative.");
+
+            return new FlightRecorderOption("globalbuffersize", size + unit.getUnit());
+        }
+
+        public static FlightRecorderOption maxChunkSize(long size, ByteUnit unit) {
+            Objects.requireNonNull(unit, "Byte unit cannot be null");
+
+            if (size < 0)
+                throw new IllegalArgumentException("Max chunk size cannot be negative.");
+
+            return new FlightRecorderOption("maxchunksize", size + unit.getUnit());
+        }
+
+        public static FlightRecorderOption memorySize(long size, ByteUnit unit) {
+            Objects.requireNonNull(unit, "Byte unit cannot be null");
+
+            if (size < 0)
+                throw new IllegalArgumentException("Memory size cannot be negative.");
+
+            return new FlightRecorderOption("memorysize", size + unit.getUnit());
+        }
+
+        public static FlightRecorderOption numGlobalBuffers(int count) {
+            if (count < 0)
+                throw new IllegalArgumentException("Number of global buffers cannot be negative.");
+
+            return new FlightRecorderOption("numglobalbuffers", Integer.toString(count));
+        }
+
+        public static FlightRecorderOption oldObjectQueueSize(int size) {
+            if (size < 0)
+                throw new IllegalArgumentException("Old object queue size cannot be negative.");
+
+            return new FlightRecorderOption("oldobjectqueuesize", Integer.toString(size));
+        }
+
+        public static FlightRecorderOption preserveRepository(boolean preserve) {
+            return new FlightRecorderOption("preserverecording", Boolean.toString(preserve));
+        }
+
+        public static FlightRecorderOption repositoryPath(Path path) {
+            Objects.requireNonNull(path, "Path cannot be null");
+            return new FlightRecorderOption("repositorypath", path.toString());
+        }
+
+        public static FlightRecorderOption retransformEventClasses(boolean retransform) {
+            return new FlightRecorderOption("retransform", Boolean.toString(retransform));
+        }
+
+        public static FlightRecorderOption stackDepth(int depth) {
+            if (depth < 0)
+                throw new IllegalArgumentException("Stack depth cannot be negative.");
+
+            return new FlightRecorderOption("stackdepth", Integer.toString(depth));
+        }
+
+        public static FlightRecorderOption threadBufferSize(long size, ByteUnit unit) {
+            Objects.requireNonNull(unit, "Byte unit cannot be null");
+            return new FlightRecorderOption("threadbuffersize", size + unit.getUnit());
+        }
+    }
+
+    public record FlightRecorderParameters(String name, String value) {
+        public static FlightRecorderParameters delay(long duration, TimeUnit unit) {
+            Objects.requireNonNull(unit, "TimeUnit cannot be null");
+
+            if (duration < 0)
+                throw new IllegalArgumentException("Delay duration cannot be negative.");
+
+            return new FlightRecorderParameters("delay", Long.toString(unit.toMillis(duration)));
+        }
+
+        public static FlightRecorderParameters writeToDisk(boolean toDisk) {
+            return new FlightRecorderParameters("disk", Boolean.toString(toDisk));
+        }
+
+        public static FlightRecorderParameters dumpOnExit(boolean dump) {
+            return new FlightRecorderParameters("dumponexit", Boolean.toString(dump));
+        }
+
+        public static FlightRecorderParameters duration(long duration, TimeUnit unit) {
+            Objects.requireNonNull(unit, "TimeUnit cannot be null");
+
+            if (duration < 0)
+                throw new IllegalArgumentException("Duration cannot be negative.");
+
+            return new FlightRecorderParameters("duration", Long.toString(unit.toMillis(duration)));
+        }
+
+        public static FlightRecorderParameters filename(Path path) {
+            Objects.requireNonNull(path, "Path cannot be null");
+            return new FlightRecorderParameters("filename", path.toString());
+        }
+
+        public static FlightRecorderParameters name(String identifier) {
+            Objects.requireNonNull(identifier, "Identifier cannot be null");
+            return new FlightRecorderParameters("name", identifier);
+        }
+
+        public static FlightRecorderParameters maxAge(long age, TimeUnit unit) {
+            Objects.requireNonNull(unit, "TimeUnit cannot be null");
+
+            if (age < 0)
+                throw new IllegalArgumentException("Max age cannot be negative.");
+
+            if (unit != TimeUnit.SECONDS && unit != TimeUnit.MINUTES && unit != TimeUnit.HOURS && unit != TimeUnit.DAYS)
+                throw new IllegalArgumentException("Max age must be specified in seconds, minutes, hours, or days.");
+
+            return new FlightRecorderParameters("maxage", age + unit.toString().substring(0, 1).toLowerCase(Locale.ROOT));
+        }
+
+        public static FlightRecorderParameters maxSize(long size, ByteUnit unit) {
+            Objects.requireNonNull(unit, "Byte unit cannot be null.");
+
+            if (size < 0)
+                throw new IllegalArgumentException("Max size cannot be negative.");
+
+            if (unit == ByteUnit.BYTES || unit == ByteUnit.KILOBYTES)
+                throw new IllegalArgumentException("Max size must be specified in MB or GB.");
+
+            return new FlightRecorderParameters("maxsize", size + unit.getUnit());
+        }
+
+        public static FlightRecorderParameters collectPathToGCRoots(boolean collect) {
+            return new FlightRecorderParameters("path-to-gc-roots", Boolean.toString(collect));
+        }
+
+        public static FlightRecorderParameters nameToReportOnExit(String name) {
+            Objects.requireNonNull(name, "Name cannot be null");
+            return new FlightRecorderParameters("report-on-exit", name);
+        }
+
+        public static FlightRecorderParameters settingsFile(Path path) {
+            Objects.requireNonNull(path, "Path cannot be null");
+            return new FlightRecorderParameters("settings", path.toString());
+        }
+
+        public static FlightRecorderParameters option(String value) {
+            Objects.requireNonNull(value, "Option value cannot be null");
+            return new FlightRecorderParameters("option", value);
+        }
+
+        public static FlightRecorderParameters eventSetting(String value) {
+            Objects.requireNonNull(value, "Event setting value cannot be null");
+            return new FlightRecorderParameters("event-setting", value);
+        }
+
+        @Override
+        public @NotNull String toString() {
+            return name + "=" + value;
+        }
+    }
+
+    @Getter
+    public enum NativeMemoryTracking {
+        OFF,
+        SUMMARY,
+        DETAIL;
+
+        private final String state;
+
+        NativeMemoryTracking() {
+            this.state = name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    @Getter
+    public enum BranchProtectionMode {
+        NONE("none"),
+        STANDARD("standard"),
+        PAC_RET("pac-ret");
+
+        private final String mode;
+
+        BranchProtectionMode(String mode) {
+            this.mode = mode;
+        }
+    }
+
+    public enum PrefetchStyle {
+        DO_NOT(0),
+        AFTER_ALLOCATE(1),
+        TLAB_WATERMARK_POINTER(2),
+        PER_CACHE_LINE(3);
+
+        private final int styleInt;
+
+        PrefetchStyle(int styleInt) {
+            this.styleInt = styleInt;
+        }
+
+        public int asInt() {
+            return styleInt;
+        }
+    }
+
+    @Getter
+    public enum CompileCommand {
+        BREAK("break"),
+        COMPILE_ONLY("compileonly"),
+        DO_NOT_INLINE("dontinline"),
+        EXCLUDE("exclude"),
+        HELP("help"),
+        INLINE("inline"),
+        LOG("log"),
+        OPTION("option"),
+        PRINT("print"),
+        QUIET("quiet");
+
+        private final String command;
+
+        CompileCommand(String command) {
+            this.command = command;
+        }
+    }
+
+    @Getter
+    public enum DataModel {
+        DATA_32("d32"),
+        DATA_64("d64");
+
+        private final String model;
+
+        DataModel(String model) {
+            this.model = model;
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JavadocCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JavadocCLIBuilder.java
@@ -18,6 +18,16 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A fluent builder for constructing and executing {@code javadoc} commands.
+ * <p>
+ * This builder provides comprehensive options for generating API documentation,
+ * including source path configuration, module-related options, doclet customization,
+ * and various output formatting controls.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/javadoc.html">javadoc command documentation</a>
+ */
 public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "javadoc.exe" : "javadoc";
     private static final DateTimeFormatter ISO_OFFSET_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
@@ -37,6 +47,12 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@code JavadocCLIBuilder} instance.
+     *
+     * @param jdk The JDK to use for executing the {@code javadoc} command.
+     * @return A new builder instance.
+     */
     public static JavadocCLIBuilder create(JDK jdk) {
         return new JavadocCLIBuilder(jdk);
     }
@@ -72,24 +88,48 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Adds a package name to be documented.
+     *
+     * @param packageName The name of the package.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addPackageName(String packageName) {
         Objects.requireNonNull(packageName, "Package name cannot be null");
         this.packageNames.add(packageName);
         return this;
     }
 
+    /**
+     * Adds a source file path to be documented.
+     *
+     * @param sourceFilePath The path to the source file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addSourceFilePath(Path sourceFilePath) {
         Objects.requireNonNull(sourceFilePath, "Source file path cannot be null");
         this.sourceFilePaths.add(sourceFilePath);
         return this;
     }
 
+    /**
+     * Adds an argument file path.
+     *
+     * @param argumentFilePath The path to the argument file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addArgumentFilePath(Path argumentFilePath) {
         Objects.requireNonNull(argumentFilePath, "Argument file path cannot be null");
         this.argumentFilePaths.add(argumentFilePath);
         return this;
     }
 
+    /**
+     * Adds modules to be documented. Corresponds to the {@code --add-modules} option.
+     *
+     * @param modules The names of the modules to add.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addModules(String... modules) {
         Objects.requireNonNull(modules, "Modules cannot be null");
 
@@ -102,10 +142,22 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Adds all modules on the module path to be documented. Corresponds to the {@code --add-modules ALL-MODULE-PATH} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addAllModules() {
         return addModules("ALL-MODULE-PATH");
     }
 
+    /**
+     * Appends entries to the bootstrap class path. Corresponds to the {@code --boot-class-path} option.
+     *
+     * @param bootClassPathEntries The entries to append.
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if the JDK version is 9 or above.
+     */
     public JavadocCLIBuilder appendBootClassPath(String... bootClassPathEntries) {
         if (jdk.version().major() >= 9)
             throw new UnsupportedOperationException("The --boot-class-path option is not supported in JDK 9 and above.");
@@ -115,12 +167,24 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Specifies the classpath for finding user class files. Corresponds to the {@code -cp} or {@code -classpath} option.
+     *
+     * @param classpathEntries The entries for the classpath.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder classpath(String... classpathEntries) {
         Objects.requireNonNull(classpathEntries, "Classpath entries cannot be null");
         this.arguments.add("-cp " + String.join(File.pathSeparator, classpathEntries));
         return this;
     }
 
+    /**
+     * Enables preview language features. Corresponds to the {@code --enable-preview} option.
+     *
+     * @return This builder instance.
+     * @throws UnsupportedOperationException if the JDK version is less than 12.
+     */
     public JavadocCLIBuilder enablePreviewFeatures() {
         if (jdk.version().major() < 12)
             throw new UnsupportedOperationException("Preview features are only supported in JDK 12 and above.");
@@ -129,238 +193,483 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Specifies the source file encoding name. Corresponds to the {@code -encoding} option.
+     *
+     * @param encoding The encoding name.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder encoding(String encoding) {
         Objects.requireNonNull(encoding, "Encoding cannot be null");
         this.arguments.add("-encoding " + encoding);
         return this;
     }
 
+    /**
+     * Specifies the source file encoding name. Corresponds to the {@code -encoding} option.
+     *
+     * @param encoding The encoding charset.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder encoding(Charset encoding) {
         Objects.requireNonNull(encoding, "Encoding cannot be null");
         return encoding(encoding.name());
     }
 
+    /**
+     * Specifies the directories in which to search for installed extensions. Corresponds to the {@code -extdirs} option.
+     *
+     * @param dirs The extension directories.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder extDirs(String... dirs) {
         Objects.requireNonNull(dirs, "Ext dirs cannot be null");
         this.arguments.add("-extdirs " + String.join(File.pathSeparator, dirs));
         return this;
     }
 
+    /**
+     * Specifies the directories in which to search for installed extensions. Corresponds to the {@code -extdirs} option.
+     *
+     * @param dirs The extension directories.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder extDirs(Path... dirs) {
         Objects.requireNonNull(dirs, "Ext dirs cannot be null");
         String[] dirStrings = Arrays.stream(dirs).map(Path::toString).toArray(String[]::new);
         return extDirs(dirStrings);
     }
 
+    /**
+     * Disables the generation of line-number information in Javadoc comments. Corresponds to the {@code --disable-line-doc-comments} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder disableLineDocComments() {
         this.arguments.add("--disable-line-doc-comments");
         return this;
     }
 
+    /**
+     * Limits the universe of observable modules. Corresponds to the {@code --limit-modules} option.
+     *
+     * @param modules The modules to limit to.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder limitModules(String... modules) {
         Objects.requireNonNull(modules, "Modules cannot be null");
         this.arguments.add("--limit-modules " + String.join(",", modules));
         return this;
     }
 
+    /**
+     * Adds module names to be documented. Corresponds to the {@code -module} option.
+     *
+     * @param moduleName The names of the modules to add.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addModuleNames(String... moduleName) {
         Objects.requireNonNull(moduleName, "Module names cannot be null");
         this.arguments.add("-module " + String.join(",", moduleName));
         return this;
     }
 
+    /**
+     * Specifies the module path. Corresponds to the {@code --module-path} option.
+     *
+     * @param modulePaths The entries for the module path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder modulePath(String... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
         this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
         return this;
     }
 
+    /**
+     * Specifies the module path. Corresponds to the {@code --module-path} option.
+     *
+     * @param modulePaths The entries for the module path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder modulePath(Path... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
         String[] pathStrings = Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new);
         return modulePath(pathStrings);
     }
 
+    /**
+     * Specifies the module source path. Corresponds to the {@code --module-source-path} option.
+     *
+     * @param moduleSourcePaths The entries for the module source path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder moduleSourcePath(String... moduleSourcePaths) {
         Objects.requireNonNull(moduleSourcePaths, "Module source path entries cannot be null");
         this.arguments.add("--module-source-path " + String.join(File.pathSeparator, moduleSourcePaths));
         return this;
     }
 
+    /**
+     * Specifies the module source path. Corresponds to the {@code --module-source-path} option.
+     *
+     * @param moduleSourcePaths The entries for the module source path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder moduleSourcePath(Path... moduleSourcePaths) {
         Objects.requireNonNull(moduleSourcePaths, "Module source path entries cannot be null");
         String[] pathStrings = Arrays.stream(moduleSourcePaths).map(Path::toString).toArray(String[]::new);
         return moduleSourcePath(pathStrings);
     }
 
+    /**
+     * Specifies the release version to use. Corresponds to the {@code --release} option.
+     *
+     * @param version The release version.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder releaseVersion(String version) {
         Objects.requireNonNull(version, "Release version cannot be null");
         this.arguments.add("--release " + version);
         return this;
     }
 
+    /**
+     * Specifies the release version to use. Corresponds to the {@code --release} option.
+     *
+     * @param version The release version.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder releaseVersion(int version) {
         return releaseVersion(Integer.toString(version));
     }
 
+    /**
+     * Specifies the source code version. Corresponds to the {@code --source} option.
+     *
+     * @param version The source version.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder sourceVersion(String version) {
         Objects.requireNonNull(version, "Source version cannot be null");
         this.arguments.add("--source " + version);
         return this;
     }
 
+    /**
+     * Specifies the source code version. Corresponds to the {@code --source} option.
+     *
+     * @param version The source version.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder sourceVersion(int version) {
         return sourceVersion(Integer.toString(version));
     }
 
+    /**
+     * Specifies the source code path. Corresponds to the {@code -sourcepath} option.
+     *
+     * @param sourcePaths The entries for the source path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder sourcepath(String... sourcePaths) {
         Objects.requireNonNull(sourcePaths, "Source path entries cannot be null");
         this.arguments.add("-sourcepath " + String.join(File.pathSeparator, sourcePaths));
         return this;
     }
 
+    /**
+     * Specifies the source code path. Corresponds to the {@code -sourcepath} option.
+     *
+     * @param sourcePaths The entries for the source path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder sourcepath(Path... sourcePaths) {
         Objects.requireNonNull(sourcePaths, "Source path entries cannot be null");
         String[] pathStrings = Arrays.stream(sourcePaths).map(Path::toString).toArray(String[]::new);
         return sourcepath(pathStrings);
     }
 
+    /**
+     * Specifies the system JDK to use. Corresponds to the {@code --system} option.
+     *
+     * @param systemJdk The system JDK.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder systemJdk(JDK systemJdk) {
         Objects.requireNonNull(systemJdk, "System JDK cannot be null");
         this.arguments.add("--system " + systemJdk.path().toString());
         return this;
     }
 
+    /**
+     * Specifies the upgrade module path. Corresponds to the {@code --upgrade-module-path} option.
+     *
+     * @param upgradeModulePaths The entries for the upgrade module path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder upgradeModulePath(String... upgradeModulePaths) {
         Objects.requireNonNull(upgradeModulePaths, "Upgrade module path entries cannot be null");
         this.arguments.add("--upgrade-module-path " + String.join(File.pathSeparator, upgradeModulePaths));
         return this;
     }
 
+    /**
+     * Specifies the upgrade module path. Corresponds to the {@code --upgrade-module-path} option.
+     *
+     * @param upgradeModulePaths The entries for the upgrade module path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder upgradeModulePath(Path... upgradeModulePaths) {
         Objects.requireNonNull(upgradeModulePaths, "Upgrade module path entries cannot be null");
         String[] pathStrings = Arrays.stream(upgradeModulePaths).map(Path::toString).toArray(String[]::new);
         return upgradeModulePath(pathStrings);
     }
 
+    /**
+     * Enables the use of {@code BreakIterator} for determining sentence breaks. Corresponds to the {@code -breakiterator} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder enableBreakIterator() {
         this.arguments.add("-breakiterator");
         return this;
     }
 
+    /**
+     * Specifies the class name of the doclet to use. Corresponds to the {@code -doclet} option.
+     *
+     * @param docletClassName The class name of the doclet.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder doclet(String docletClassName) {
         Objects.requireNonNull(docletClassName, "Doclet class name cannot be null");
         this.arguments.add("-doclet " + docletClassName);
         return this;
     }
 
+    /**
+     * Specifies the path where the doclet and its supporting classes are located. Corresponds to the {@code -docletpath} option.
+     *
+     * @param docletPaths The entries for the doclet path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder docletPath(String... docletPaths) {
         Objects.requireNonNull(docletPaths, "Doclet path entries cannot be null");
         this.arguments.add("-docletpath " + String.join(File.pathSeparator, docletPaths));
         return this;
     }
 
+    /**
+     * Specifies the path where the doclet and its supporting classes are located. Corresponds to the {@code -docletpath} option.
+     *
+     * @param docletPaths The entries for the doclet path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder docletPath(Path... docletPaths) {
         Objects.requireNonNull(docletPaths, "Doclet path entries cannot be null");
         String[] pathStrings = Arrays.stream(docletPaths).map(Path::toString).toArray(String[]::new);
         return docletPath(pathStrings);
     }
 
+    /**
+     * Excludes packages from the documentation. Corresponds to the {@code -exclude} option.
+     *
+     * @param packageNames The names of the packages to exclude.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder excludePackages(String... packageNames) {
         Objects.requireNonNull(packageNames, "Package names cannot be null");
         this.arguments.add("-exclude " + String.join(":", packageNames));
         return this;
     }
 
+    /**
+     * Expands the set of modules to be documented. Corresponds to the {@code --expand-requires} option.
+     *
+     * @param expansionType The type of expansion (TRANSITIVE or ALL).
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder expandRequires(ExpansionType expansionType) {
         Objects.requireNonNull(expansionType, "Expansion type cannot be null");
         this.arguments.add("--expand-requires " + expansionType.name().toLowerCase(Locale.ROOT));
         return this;
     }
 
+    /**
+     * Displays the help message. Corresponds to the {@code -?} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder help() {
         this.arguments.add("-?");
         return this;
     }
 
+    /**
+     * Displays help on extra non-standard options. Corresponds to the {@code -X} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder extraHelp() {
         this.arguments.add("-X");
         return this;
     }
 
+    /**
+     * Passes an argument directly to the Java Virtual Machine. Corresponds to the {@code -J} option.
+     *
+     * @param jflag The argument to pass to the JVM.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder jflag(String jflag) {
         Objects.requireNonNull(jflag, "JFlag cannot be null");
         this.arguments.add("-J" + jflag);
         return this;
     }
 
+    /**
+     * Specifies the locale to be used when generating documentation. Corresponds to the {@code -locale} option.
+     *
+     * @param locale The locale string.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder locale(String locale) {
         Objects.requireNonNull(locale, "Locale cannot be null");
         this.arguments.add("-locale " + locale);
         return this;
     }
 
+    /**
+     * Specifies the locale to be used when generating documentation. Corresponds to the {@code -locale} option.
+     *
+     * @param locale The locale object.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder locale(Locale locale) {
         Objects.requireNonNull(locale, "Locale cannot be null");
         return locale(locale.toLanguageTag());
     }
 
+    /**
+     * Sets the minimum visibility level of members to be documented. Corresponds to options like {@code -public}, {@code -protected}, {@code -package}, {@code -private}.
+     *
+     * @param visibility The minimum visibility level.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder visibility(Visibility visibility) {
         Objects.requireNonNull(visibility, "Visibility cannot be null");
         this.arguments.add("-" + visibility.name().toLowerCase(Locale.ROOT));
         return this;
     }
 
+    /**
+     * Suppresses messages, leaving only warnings and errors. Corresponds to the {@code -quiet} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder quiet() {
         this.arguments.add("-quiet");
         return this;
     }
 
+    /**
+     * Shows members with a specified visibility. Corresponds to the {@code --show-members} option.
+     *
+     * @param visibility The visibility level.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder showMembers(Visibility visibility) {
         Objects.requireNonNull(visibility, "Visibility cannot be null");
         this.arguments.add("--show-members " + visibility.name().toLowerCase(Locale.ROOT));
         return this;
     }
 
+    /**
+     * Shows module contents with a specified granularity. Corresponds to the {@code --show-module-contents} option.
+     *
+     * @param granularity The granularity level (API or ALL).
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder showModuleContents(ModuleGranularity granularity) {
         Objects.requireNonNull(granularity, "Module granularity cannot be null");
         this.arguments.add("--show-module-contents " + granularity.name().toLowerCase(Locale.ROOT));
         return this;
     }
 
+    /**
+     * Shows packages with a specified granularity. Corresponds to the {@code --show-packages} option.
+     *
+     * @param granularity The granularity level (EXPORTED or ALL).
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder showPackages(PackageGranularity granularity) {
         Objects.requireNonNull(granularity, "Package granularity cannot be null");
         this.arguments.add("--show-packages " + granularity.name().toLowerCase(Locale.ROOT));
         return this;
     }
 
+    /**
+     * Shows types with a specified visibility. Corresponds to the {@code --show-types} option.
+     *
+     * @param visibility The visibility level.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder showTypes(Visibility visibility) {
         Objects.requireNonNull(visibility, "Visibility cannot be null");
         this.arguments.add("--show-types " + visibility.name().toLowerCase(Locale.ROOT));
         return this;
     }
 
+    /**
+     * Recursively retrieves source files from the specified subpackages. Corresponds to the {@code -subpackages} option.
+     *
+     * @param packageNames The names of the subpackages.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder subpackages(String... packageNames) {
         Objects.requireNonNull(packageNames, "Package names cannot be null");
         this.arguments.add("-subpackages " + String.join(":", packageNames));
         return this;
     }
 
+    /**
+     * Enables verbose output. Corresponds to the {@code -verbose} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder verbose() {
         this.arguments.add("-verbose");
         return this;
     }
 
+    /**
+     * Prints version information and exits. Corresponds to the {@code --version} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder version() {
         this.arguments.add("--version");
         return this;
     }
 
+    /**
+     * Reports warnings as errors. Corresponds to the {@code -Werror} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder reportErrorOnWarnings() {
         this.arguments.add("-Werror");
         return this;
     }
 
+    /**
+     * Adds a read edge from a source module to target modules. Corresponds to the {@code --add-reads} option.
+     *
+     * @param sourceModule  The source module.
+     * @param targetModules The target modules.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addReads(String sourceModule, String... targetModules) {
         Objects.requireNonNull(sourceModule, "Source module cannot be null");
         Objects.requireNonNull(targetModules, "Target modules cannot be null");
@@ -369,10 +678,24 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Adds a read edge from a source module to all unnamed modules.
+     *
+     * @param sourceModule The source module.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addReadsAllUnnamed(String sourceModule) {
         return addReads(sourceModule, "ALL-UNNAMED");
     }
 
+    /**
+     * Adds an export of a package from a source module to target modules. Corresponds to the {@code --add-exports} option.
+     *
+     * @param sourceModule  The source module.
+     * @param packageName   The package to export.
+     * @param targetModules The target modules.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addExports(String sourceModule, String packageName, String... targetModules) {
         Objects.requireNonNull(sourceModule, "Source module cannot be null");
         Objects.requireNonNull(packageName, "Package name cannot be null");
@@ -382,10 +705,24 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Adds an export of a package from a source module to all unnamed modules.
+     *
+     * @param sourceModule The source module.
+     * @param packageName  The package to export.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addExportsAllUnnamed(String sourceModule, String packageName) {
         return addExports(sourceModule, packageName, "ALL-UNNAMED");
     }
 
+    /**
+     * Patches a module with classes and resources from specified paths. Corresponds to the {@code --patch-module} option.
+     *
+     * @param moduleName The module to patch.
+     * @param patchPaths The paths to the patch content.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder patchModule(String moduleName, String... patchPaths) {
         Objects.requireNonNull(moduleName, "Module name cannot be null");
         Objects.requireNonNull(patchPaths, "Patch paths cannot be null");
@@ -393,6 +730,13 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Patches a module with classes and resources from specified paths. Corresponds to the {@code --patch-module} option.
+     *
+     * @param moduleName The module to patch.
+     * @param patchPaths The paths to the patch content.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder patchModule(String moduleName, Path... patchPaths) {
         Objects.requireNonNull(moduleName, "Module name cannot be null");
         Objects.requireNonNull(patchPaths, "Patch paths cannot be null");
@@ -400,6 +744,13 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return patchModule(moduleName, pathStrings);
     }
 
+    /**
+     * Sets the maximum number of errors to report. Corresponds to the {@code -Xmaxerrs} option.
+     *
+     * @param maxErrors The maximum number of errors.
+     * @return This builder instance.
+     * @throws IllegalArgumentException if maxErrors is negative.
+     */
     public JavadocCLIBuilder maxErrors(int maxErrors) {
         if (maxErrors < 0)
             throw new IllegalArgumentException("Max errors cannot be negative");
@@ -408,6 +759,13 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Sets the maximum number of warnings to report. Corresponds to the {@code -Xmaxwarns} option.
+     *
+     * @param maxWarnings The maximum number of warnings.
+     * @return This builder instance.
+     * @throws IllegalArgumentException if maxWarnings is negative.
+     */
     public JavadocCLIBuilder maxWarnings(int maxWarnings) {
         if (maxWarnings < 0)
             throw new IllegalArgumentException("Max warnings cannot be negative");
@@ -416,151 +774,309 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Adds a script to the generated documentation. Corresponds to the {@code --add-script} option.
+     *
+     * @param script The script to add.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addScript(String script) {
         Objects.requireNonNull(script, "Script cannot be null");
         this.arguments.add("--add-script " + script);
         return this;
     }
 
+    /**
+     * Adds a script to the generated documentation. Corresponds to the {@code --add-script} option.
+     *
+     * @param scriptFilePath The path to the script file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addScript(Path scriptFilePath) {
         Objects.requireNonNull(scriptFilePath, "Script file path cannot be null");
         return addScript(scriptFilePath.toString());
     }
 
+    /**
+     * Adds a stylesheet to the generated documentation. Corresponds to the {@code --add-stylesheet} option.
+     *
+     * @param styleSheet The stylesheet to add.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addStylesheet(String styleSheet) {
         Objects.requireNonNull(styleSheet, "Style sheet cannot be null");
         this.arguments.add("--add-stylesheet " + styleSheet);
         return this;
     }
 
+    /**
+     * Adds a stylesheet to the generated documentation. Corresponds to the {@code --add-stylesheet} option.
+     *
+     * @param styleSheetPath The path to the stylesheet file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder addStylesheet(Path styleSheetPath) {
         Objects.requireNonNull(styleSheetPath, "Style sheet path cannot be null");
         return addStylesheet(styleSheetPath.toString());
     }
 
+    /**
+     * Allows JavaScript in Javadoc comments. Corresponds to the {@code --allow-script-in-comments} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder allowScriptInComments() {
         this.arguments.add("--allow-script-in-comments");
         return this;
     }
 
+    /**
+     * Includes {@code @author} tags in the generated documentation. Corresponds to the {@code -author} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder includeAuthorTags() {
         this.arguments.add("-author");
         return this;
     }
 
+    /**
+     * Specifies the text to be placed at the bottom of each generated page. Corresponds to the {@code -bottom} option.
+     *
+     * @param text The text to place at the bottom.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder textAtBottom(String text) {
         Objects.requireNonNull(text, "Text cannot be null");
         this.arguments.add("-bottom " + text);
         return this;
     }
 
+    /**
+     * Specifies the charset for the generated HTML files. Corresponds to the {@code -charset} option.
+     *
+     * @param charset The charset name.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder charset(String charset) {
         Objects.requireNonNull(charset, "Charset cannot be null");
         this.arguments.add("-charset " + charset);
         return this;
     }
 
+    /**
+     * Specifies the charset for the generated HTML files. Corresponds to the {@code -charset} option.
+     *
+     * @param charset The charset object.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder charset(Charset charset) {
         Objects.requireNonNull(charset, "Charset cannot be null");
         return charset(charset.name());
     }
 
+    /**
+     * Specifies the destination directory for the generated HTML files. Corresponds to the {@code -d} option.
+     *
+     * @param outputDirectory The output directory.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder destinationDirectory(Path outputDirectory) {
         Objects.requireNonNull(outputDirectory, "Output directory cannot be null");
         this.arguments.add("-d " + outputDirectory);
         return this;
     }
 
+    /**
+     * Specifies the encoding for the generated HTML files. Corresponds to the {@code -docencoding} option.
+     *
+     * @param encoding The encoding name.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder generatedEncoding(String encoding) {
         Objects.requireNonNull(encoding, "Encoding cannot be null");
         this.arguments.add("-docencoding " + encoding);
         return this;
     }
 
+    /**
+     * Specifies the encoding for the generated HTML files. Corresponds to the {@code -docencoding} option.
+     *
+     * @param encoding The encoding charset.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder generatedEncoding(Charset encoding) {
         Objects.requireNonNull(encoding, "Encoding cannot be null");
         return generatedEncoding(encoding.name());
     }
 
+    /**
+     * Recursively copies doc-files subdirectories. Corresponds to the {@code -docfilessubdirs} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder deepCopySubdirectories() {
         this.arguments.add("-docfilessubdirs");
         return this;
     }
 
+    /**
+     * Specifies the title to be placed in the HTML {@code <title>} tag. Corresponds to the {@code -doctitle} option.
+     *
+     * @param title The document title.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder documentTitle(String title) {
         Objects.requireNonNull(title, "Title cannot be null");
         this.arguments.add("-doctitle " + title);
         return this;
     }
 
+    /**
+     * Excludes subdirectories from the {@code doc-files} directory. Corresponds to the {@code -excludedocfilessubdir} option.
+     *
+     * @param dirNames The names of the directories to exclude.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder excludeSubdirectories(String... dirNames) {
         Objects.requireNonNull(dirNames, "Directory names cannot be null");
         this.arguments.add("-excludedocfilessubdir " + String.join(",", dirNames));
         return this;
     }
 
+    /**
+     * Specifies the footer text for each generated page. Corresponds to the {@code -footer} option.
+     *
+     * @param text The footer text.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder footerText(String text) {
         Objects.requireNonNull(text, "Text cannot be null");
         this.arguments.add("-footer " + text);
         return this;
     }
 
+    /**
+     * Specifies the header text for each generated page. Corresponds to the {@code -header} option.
+     *
+     * @param text The header text.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder headerText(String text) {
         Objects.requireNonNull(text, "Text cannot be null");
         this.arguments.add("-header " + text);
         return this;
     }
 
+    /**
+     * Separates packages into groups on the overview page. Corresponds to the {@code -group} option.
+     *
+     * @param groupDefinitions The group definitions.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder groups(String... groupDefinitions) {
         Objects.requireNonNull(groupDefinitions, "Group definitions cannot be null");
         this.arguments.add("-group " + String.join(",", groupDefinitions));
         return this;
     }
 
+    /**
+     * Specifies the path to an alternative help file. Corresponds to the {@code -helpfile} option.
+     *
+     * @param filename The name of the help file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder helpFilename(String filename) {
         Objects.requireNonNull(filename, "Filename cannot be null");
         this.arguments.add("-helpfile " + filename);
         return this;
     }
 
+    /**
+     * Specifies the path to an alternative help file. Corresponds to the {@code -helpfile} option.
+     *
+     * @param filePath The path to the help file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder helpFilename(Path filePath) {
         Objects.requireNonNull(filePath, "File path cannot be null");
         return helpFilename(filePath.toString());
     }
 
+    /**
+     * Generates HTML5 output. Corresponds to the {@code -html5} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder enableHtml5() {
         this.arguments.add("-html5");
         return this;
     }
 
+    /**
+     * Enables JavaFX-specific features. Corresponds to the {@code -javafx} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder enableJavaFX() {
         this.arguments.add("-javafx");
         return this;
     }
 
+    /**
+     * Adds HTML keywords to the generated documentation. Corresponds to the {@code -keywords} option.
+     *
+     * @param keywords The keywords to add.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder keywords(String... keywords) {
         Objects.requireNonNull(keywords, "Keywords cannot be null");
         this.arguments.add("-keywords " + String.join(",", keywords));
         return this;
     }
 
+    /**
+     * Creates links to existing Javadoc documentation. Corresponds to the {@code -link} option.
+     *
+     * @param url The URL of the external Javadoc documentation.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder link(String url) {
         Objects.requireNonNull(url, "URL cannot be null");
         this.arguments.add("-link " + url);
         return this;
     }
 
+    /**
+     * Creates links to existing Javadoc documentation. Corresponds to the {@code -link} option.
+     *
+     * @param urlPath The path to the external Javadoc documentation.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder link(Path urlPath) {
         Objects.requireNonNull(urlPath, "URL path cannot be null");
         return link("file://" + urlPath);
     }
 
+    /**
+     * Specifies how to handle modularity mismatches when linking. Corresponds to the {@code --link-modularity-mismatch} option.
+     *
+     * @param mismatchBehavior The behavior for modularity mismatches (WARN or INFO).
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder linkModularityMismatch(LinkModularityMismatch mismatchBehavior) {
         Objects.requireNonNull(mismatchBehavior, "Mismatch behavior cannot be null");
         this.arguments.add("--link-modularity-mismatch " + mismatchBehavior.name().toLowerCase(Locale.ROOT));
         return this;
     }
 
+    /**
+     * Creates links to existing Javadoc documentation for offline access. Corresponds to the {@code -linkoffline} option.
+     *
+     * @param url             The URL of the external Javadoc documentation.
+     * @param packageListPath The path to the {@code package-list} file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder linkOffline(String url, Path packageListPath) {
         Objects.requireNonNull(url, "URL cannot be null");
         Objects.requireNonNull(packageListPath, "Package list path cannot be null");
@@ -568,6 +1084,13 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Creates links to existing Javadoc documentation for offline access. Corresponds to the {@code -linkoffline} option.
+     *
+     * @param url             The URL of the external Javadoc documentation.
+     * @param packageListPath The path to the {@code package-list} file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder linkOffline(String url, String packageListPath) {
         Objects.requireNonNull(url, "URL cannot be null");
         Objects.requireNonNull(packageListPath, "Package list path cannot be null");
@@ -575,146 +1098,296 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Links to platform properties. Corresponds to the {@code -linkplatformproperties} option.
+     *
+     * @param url The URL of the platform properties.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder linkPlatformProperties(String url) {
         Objects.requireNonNull(url, "URL cannot be null");
         this.arguments.add("-linkplatformproperties " + url);
         return this;
     }
 
+    /**
+     * Links to platform properties. Corresponds to the {@code -linkplatformproperties} option.
+     *
+     * @param urlPath The path to the platform properties.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder linkPlatformProperties(Path urlPath) {
         Objects.requireNonNull(urlPath, "URL path cannot be null");
         return linkPlatformProperties("file://" + urlPath);
     }
 
+    /**
+     * Includes HTML versions of the source files. Corresponds to the {@code -linksource} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder shouldLinkSource() {
         this.arguments.add("-linksource");
         return this;
     }
 
+    /**
+     * Specifies the path to an alternative stylesheet file. Corresponds to the {@code -stylesheetfile} option.
+     *
+     * @param filePath The path to the stylesheet file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder stylesheetFile(String filePath) {
         Objects.requireNonNull(filePath, "File path cannot be null");
         this.arguments.add("-stylesheetfile " + filePath);
         return this;
     }
 
+    /**
+     * Specifies the path to an alternative stylesheet file. Corresponds to the {@code -stylesheetfile} option.
+     *
+     * @param filePath The path to the stylesheet file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder stylesheetFile(Path filePath) {
         Objects.requireNonNull(filePath, "File path cannot be null");
         return stylesheetFile(filePath.toString());
     }
 
+    /**
+     * Suppresses the entire comment body, including the main description and all tags, from the generated documentation. Corresponds to the {@code -nocomment} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noComments() {
         this.arguments.add("-nocomment");
         return this;
     }
 
+    /**
+     * Excludes deprecated APIs from the generated documentation. Corresponds to the {@code -nodeprecated} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noDeprecated() {
         this.arguments.add("-nodeprecated");
         return this;
     }
 
+    /**
+     * Prevents the generation of the deprecated list. Corresponds to the {@code -nodeprecatedlist} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noDeprecatedList() {
         this.arguments.add("-nodeprecatedlist");
         return this;
     }
 
+    /**
+     * Suppresses the generation of font-related HTML tags. Corresponds to the {@code --nofonts} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noFonts() {
         this.arguments.add("--nofonts");
         return this;
     }
 
+    /**
+     * Suppresses the generation of the HELP link in the navigation bar. Corresponds to the {@code -nohelp} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noHelp() {
         this.arguments.add("-nohelp");
         return this;
     }
 
+    /**
+     * Suppresses the generation of the index. Corresponds to the {@code -noindex} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noIndex() {
         this.arguments.add("-noindex");
         return this;
     }
 
+    /**
+     * Suppresses the generation of the navigation bar. Corresponds to the {@code -nonavbar} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noNavBar() {
         this.arguments.add("-nonavbar");
         return this;
     }
 
+    /**
+     * Suppresses the generation of links to platform documentation. Corresponds to the {@code --no-platform-links} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noPlatformLinks() {
         this.arguments.add("--no-platform-links");
         return this;
     }
 
+    /**
+     * Excludes package name qualifiers from the generated output. Corresponds to the {@code -noqualifier} option.
+     *
+     * @param qualifiers The qualifiers to exclude.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noQualifier(String... qualifiers) {
         Objects.requireNonNull(qualifiers, "Qualifiers cannot be null");
         this.arguments.add("-noqualifier " + String.join(",", qualifiers));
         return this;
     }
 
+    /**
+     * Suppresses the generation of {@code @since} tags. Corresponds to the {@code -nosince} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noSinceTag() {
         this.arguments.add("-nosince");
         return this;
     }
 
+    /**
+     * Suppresses the generation of a timestamp in the generated HTML. Corresponds to the {@code -notimestamp} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noTimestamp() {
         this.arguments.add("-notimestamp");
         return this;
     }
 
+    /**
+     * Suppresses the generation of the class hierarchy tree. Corresponds to the {@code -notree} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noTree() {
         this.arguments.add("-notree");
         return this;
     }
 
+    /**
+     * Specifies how to handle method override documentation. Corresponds to the {@code --override-methods} option.
+     *
+     * @param handling The handling strategy (DETAIL or SUMMARY).
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder methodOverrideHandling(MethodOverrideHandling handling) {
         Objects.requireNonNull(handling, "Method override handling cannot be null");
         this.arguments.add("--override-methods " + handling.name().toLowerCase(Locale.ROOT));
         return this;
     }
 
+    /**
+     * Specifies the path to an HTML file that contains overview documentation. Corresponds to the {@code -overview} option.
+     *
+     * @param filePath The path to the overview file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder overviewFile(String filePath) {
         Objects.requireNonNull(filePath, "File path cannot be null");
         this.arguments.add("-overview " + filePath);
         return this;
     }
 
+    /**
+     * Specifies the path to an HTML file that contains overview documentation. Corresponds to the {@code -overview} option.
+     *
+     * @param filePath The path to the overview file.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder overviewFile(Path filePath) {
         Objects.requireNonNull(filePath, "File path cannot be null");
         return overviewFile(filePath.toString());
     }
 
+    /**
+     * Reports warnings about {@code @serial} tags. Corresponds to the {@code -serialwarn} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder reportSerialWarnings() {
         this.arguments.add("-serialwarn");
         return this;
     }
 
+    /**
+     * Includes documentation for APIs introduced in a specific release version. Corresponds to the {@code -since} option.
+     *
+     * @param releaseVersions The release versions.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder since(String... releaseVersions) {
         Objects.requireNonNull(releaseVersions, "Release versions cannot be null");
         this.arguments.add("-since " + String.join(",", releaseVersions));
         return this;
     }
 
+    /**
+     * Includes documentation for APIs introduced in a specific release version. Corresponds to the {@code -since} option.
+     *
+     * @param releaseVersions The release versions.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder since(int... releaseVersions) {
         Objects.requireNonNull(releaseVersions, "Release versions cannot be null");
         String[] versionStrings = Arrays.stream(releaseVersions).mapToObj(Integer::toString).toArray(String[]::new);
         return since(versionStrings);
     }
 
+    /**
+     * Specifies the label to be used for the "Since" heading. Corresponds to the {@code -sincelabel} option.
+     *
+     * @param label The label.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder sinceLabel(String label) {
         Objects.requireNonNull(label, "Label cannot be null");
         this.arguments.add("-sincelabel " + label);
         return this;
     }
 
+    /**
+     * Specifies the paths where snippet files are located. Corresponds to the {@code --snippet-path} option.
+     *
+     * @param paths The paths to the snippet files.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder snippetPaths(String... paths) {
         Objects.requireNonNull(paths, "Paths cannot be null");
         this.arguments.add("--snippet-path " + String.join(File.pathSeparator, paths));
         return this;
     }
 
+    /**
+     * Specifies the paths where snippet files are located. Corresponds to the {@code --snippet-path} option.
+     *
+     * @param paths The paths to the snippet files.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder snippetPaths(Path... paths) {
         Objects.requireNonNull(paths, "Paths cannot be null");
         String[] pathStrings = Arrays.stream(paths).map(Path::toString).toArray(String[]::new);
         return snippetPaths(pathStrings);
     }
 
+    /**
+     * Specifies the number of spaces each tab in the source file occupies. Corresponds to the {@code -sourcetab} option.
+     *
+     * @param spaces The number of spaces per tab.
+     * @return This builder instance.
+     * @throws IllegalArgumentException if spaces is not positive.
+     */
     public JavadocCLIBuilder spacesPerTab(int spaces) {
         if (spaces <= 0)
             throw new IllegalArgumentException("Spaces per tab must be positive");
@@ -723,22 +1396,46 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Specifies the base URL for the generated specification. Corresponds to the {@code --spec-base-url} option.
+     *
+     * @param url The base URL.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder specBaseUrl(String url) {
         Objects.requireNonNull(url, "URL cannot be null");
         this.arguments.add("--spec-base-url " + url);
         return this;
     }
 
+    /**
+     * Splits the index into multiple files, one for each letter. Corresponds to the {@code -splitindex} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder shouldSplitIndex() {
         this.arguments.add("-splitindex");
         return this;
     }
 
+    /**
+     * Enables syntax highlighting in the generated documentation. Corresponds to the {@code --syntaxhighlight} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder enableSyntaxHighlighting() {
         this.arguments.add("--syntaxhighlight");
         return this;
     }
 
+    /**
+     * Enables the Javadoc tool to interpret a simple custom block tag. Corresponds to the {@code -tag} option.
+     *
+     * @param name      The name of the tag.
+     * @param locations The locations where the tag is valid.
+     * @param header    The header text for the tag.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder tag(String name, String locations, String header) {
         Objects.requireNonNull(name, "Tag name cannot be null");
         Objects.requireNonNull(locations, "Locations cannot be null");
@@ -747,46 +1444,93 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Specifies the class name of the taglet to use. Corresponds to the {@code -taglet} option.
+     *
+     * @param tagletClassName The class name of the taglet.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder taglet(String tagletClassName) {
         Objects.requireNonNull(tagletClassName, "Taglet class name cannot be null");
         this.arguments.add("-taglet " + tagletClassName);
         return this;
     }
 
+    /**
+     * Specifies the path where the taglet and its supporting classes are located. Corresponds to the {@code -tagletpath} option.
+     *
+     * @param tagletPaths The entries for the taglet path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder tagletPath(String... tagletPaths) {
         Objects.requireNonNull(tagletPaths, "Taglet path entries cannot be null");
         this.arguments.add("-tagletpath " + String.join(File.pathSeparator, tagletPaths));
         return this;
     }
 
+    /**
+     * Specifies the path where the taglet and its supporting classes are located. Corresponds to the {@code -tagletpath} option.
+     *
+     * @param tagletPaths The entries for the taglet path.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder tagletPath(Path... tagletPaths) {
         Objects.requireNonNull(tagletPaths, "Taglet path entries cannot be null");
         String[] pathStrings = Arrays.stream(tagletPaths).map(Path::toString).toArray(String[]::new);
         return tagletPath(pathStrings);
     }
 
+    /**
+     * Specifies the text to be placed at the top of each generated page. Corresponds to the {@code -top} option.
+     *
+     * @param text The text to place at the top.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder topText(String text) {
         Objects.requireNonNull(text, "Text cannot be null");
         this.arguments.add("-top " + text);
         return this;
     }
 
+    /**
+     * Creates a "Use" page for each class and package. Corresponds to the {@code -use} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder createUsagePages() {
         this.arguments.add("-use");
         return this;
     }
 
+    /**
+     * Includes {@code @version} tags in the generated documentation. Corresponds to the {@code -version} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder includeVersionTags() {
         this.arguments.add("-version");
         return this;
     }
 
+    /**
+     * Specifies the title to be placed in the HTML window title. Corresponds to the {@code -windowtitle} option.
+     *
+     * @param title The window title.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder windowTitle(String title) {
         Objects.requireNonNull(title, "Title cannot be null");
         this.arguments.add("-windowtitle " + title);
         return this;
     }
 
+    /**
+     * Specifies the date and time to be used for the generated documentation. Corresponds to the {@code -date} option.
+     *
+     * @param iso8601Date The date and time in ISO 8601 format (e.g., "2023-10-05T14:48:00Z").
+     * @return This builder instance.
+     * @throws IllegalArgumentException if the date is not in ISO 8601 format or is outside a reasonable range.
+     */
     public JavadocCLIBuilder date(String iso8601Date) {
         Objects.requireNonNull(iso8601Date, "Date cannot be null");
         try {
@@ -797,20 +1541,45 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         }
     }
 
+    /**
+     * Specifies the date and time to be used for the generated documentation. Corresponds to the {@code -date} option.
+     *
+     * @param date The date object.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder date(Date date) {
         Objects.requireNonNull(date, "Date cannot be null");
         return date(OffsetDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()));
     }
 
+    /**
+     * Specifies the date and time to be used for the generated documentation. Corresponds to the {@code -date} option.
+     *
+     * @param epochMillis The date and time as epoch milliseconds.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder date(long epochMillis) {
         return date(OffsetDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault()));
     }
 
+    /**
+     * Specifies the date and time to be used for the generated documentation. Corresponds to the {@code -date} option.
+     *
+     * @param dateTime The {@link LocalDateTime} object.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder date(LocalDateTime dateTime) {
         Objects.requireNonNull(dateTime, "DateTime cannot be null");
         return date(dateTime.atZone(ZoneId.systemDefault()).toOffsetDateTime());
     }
 
+    /**
+     * Specifies the date and time to be used for the generated documentation. Corresponds to the {@code -date} option.
+     *
+     * @param dateTime The {@link OffsetDateTime} object.
+     * @return This builder instance.
+     * @throws IllegalArgumentException if the date is outside a reasonable range (10 years before or after current date).
+     */
     private JavadocCLIBuilder date(OffsetDateTime dateTime) {
         Objects.requireNonNull(dateTime, "DateTime cannot be null");
         Instant candidate = dateTime.toInstant();
@@ -824,72 +1593,153 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         return this;
     }
 
+    /**
+     * Specifies the date and time to be used for the generated documentation. Corresponds to the {@code -date} option.
+     *
+     * @param year   The year.
+     * @param month  The month.
+     * @param day    The day.
+     * @param hour   The hour.
+     * @param minute The minute.
+     * @param second The second.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder date(int year, int month, int day, int hour, int minute, int second) {
         var dateTime = LocalDateTime.of(year, month, day, hour, minute, second);
         return date(dateTime);
     }
 
+    /**
+     * Specifies the date and time to be used for the generated documentation. Corresponds to the {@code -date} option.
+     *
+     * @param year  The year.
+     * @param month The month.
+     * @param day   The day.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder date(int year, int month, int day) {
         var dateTime = LocalDateTime.of(year, month, day, 0, 0, 0);
         return date(dateTime);
     }
 
+    /**
+     * Includes the default legal notices. Corresponds to the {@code --legal-notices default} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder defaultLegalNotices() {
         this.arguments.add("--legal-notices default");
         return this;
     }
 
+    /**
+     * Excludes legal notices. Corresponds to the {@code --legal-notices none} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder noLegalNotices() {
         this.arguments.add("--legal-notices none");
         return this;
     }
 
+    /**
+     * Includes custom legal notices from a specified file. Corresponds to the {@code --legal-notices} option.
+     *
+     * @param filePath The path to the file containing custom legal notices.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder customLegalNotices(Path filePath) {
         Objects.requireNonNull(filePath, "File path cannot be null");
         this.arguments.add("--legal-notices " + filePath);
         return this;
     }
 
+    /**
+     * Suppresses the generation of frames. Corresponds to the {@code -noframes} option.
+     *
+     * @return This builder instance.
+     * @deprecated This option is deprecated and may be removed in future versions.
+     */
     @Deprecated
     public JavadocCLIBuilder noFrames() {
         this.arguments.add("-noframes");
         return this;
     }
 
+    /**
+     * Enables recommended doclint checks. Corresponds to the {@code -Xdoclint} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder enableRecommendedChecks() {
         this.arguments.add("-Xdoclint");
         return this;
     }
 
+    /**
+     * Disables all doclint checks. Corresponds to the {@code -Xdoclint:none} option.
+     *
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder disableAllChecks() {
         this.arguments.add("-Xdoclint:none");
         return this;
     }
 
+    /**
+     * Enables specific doclint checks. Corresponds to the {@code -Xdoclint:checks} option.
+     *
+     * @param checks A comma-separated list of checks to enable.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder enableChecks(String checks) {
         Objects.requireNonNull(checks, "Checks cannot be null");
         this.arguments.add("-Xdoclint:" + checks);
         return this;
     }
 
+    /**
+     * Disables specific doclint checks. Corresponds to the {@code -Xdoclint:-checks} option.
+     *
+     * @param checks A comma-separated list of checks to disable.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder disableChecks(String checks) {
         Objects.requireNonNull(checks, "Checks cannot be null");
         this.arguments.add("-Xdoclint:-" + checks);
         return this;
     }
 
+    /**
+     * Enables doclint checks for specific packages. Corresponds to the {@code -Xdoclint/package:packages} option.
+     *
+     * @param packages A comma-separated list of packages to enable checks for.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder enableChecks(String... packages) {
         Objects.requireNonNull(packages, "Packages cannot be null");
         this.arguments.add("-Xdoclint/package:" + String.join(",", packages));
         return this;
     }
 
+    /**
+     * Disables doclint checks for specific packages. Corresponds to the {@code -Xdoclint/package:-packages} option.
+     *
+     * @param packages A comma-separated list of packages to disable checks for.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder disableChecks(String... packages) {
         Objects.requireNonNull(packages, "Packages cannot be null");
         this.arguments.add("-Xdoclint/package:-" + String.join(",", packages));
         return this;
     }
 
+    /**
+     * Specifies the URL of the parent directory for the generated documentation. Corresponds to the {@code -Xdocrootparent} option.
+     *
+     * @param url The URL of the parent directory.
+     * @return This builder instance.
+     */
     public JavadocCLIBuilder docRootParentUrl(String url) {
         Objects.requireNonNull(url, "URL cannot be null");
         this.arguments.add("-Xdocrootparent " + url);
@@ -928,11 +1778,17 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         }
     }
 
+    /**
+     * Represents the type of module expansion.
+     */
     public enum ExpansionType {
         TRANSITIVE,
         ALL
     }
 
+    /**
+     * Represents the visibility levels for members.
+     */
     public enum Visibility {
         PUBLIC,
         PROTECTED,
@@ -940,21 +1796,33 @@ public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder>
         PRIVATE
     }
 
+    /**
+     * Represents the granularity levels for module contents.
+     */
     public enum ModuleGranularity {
         API,
         ALL
     }
 
+    /**
+     * Represents the granularity levels for packages.
+     */
     public enum PackageGranularity {
         EXPORTED,
         ALL
     }
 
+    /**
+     * Represents how to handle modularity mismatches when linking.
+     */
     public enum LinkModularityMismatch {
         WARN,
         INFO
     }
 
+    /**
+     * Represents how to handle method override documentation.
+     */
     public enum MethodOverrideHandling {
         DETAIL,
         SUMMARY

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JavadocCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JavadocCLIBuilder.java
@@ -1,0 +1,962 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JavadocCLIBuilder implements CLIBuilder<Process, JavadocCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "javadoc.exe" : "javadoc";
+    private static final DateTimeFormatter ISO_OFFSET_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<String> packageNames = new ArrayList<>();
+    private final List<Path> sourceFilePaths = new ArrayList<>();
+    private final List<Path> argumentFilePaths = new ArrayList<>();
+    private Path workingDirectory;
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private JavadocCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JavadocCLIBuilder create(JDK jdk) {
+        return new JavadocCLIBuilder(jdk);
+    }
+
+    @Override
+    public JavadocCLIBuilder addArgument(String arg) {
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JavadocCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JavadocCLIBuilder setEnvironmentVariable(String key, String value) {
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JavadocCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JavadocCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JavadocCLIBuilder addPackageName(String packageName) {
+        Objects.requireNonNull(packageName, "Package name cannot be null");
+        this.packageNames.add(packageName);
+        return this;
+    }
+
+    public JavadocCLIBuilder addSourceFilePath(Path sourceFilePath) {
+        Objects.requireNonNull(sourceFilePath, "Source file path cannot be null");
+        this.sourceFilePaths.add(sourceFilePath);
+        return this;
+    }
+
+    public JavadocCLIBuilder addArgumentFilePath(Path argumentFilePath) {
+        Objects.requireNonNull(argumentFilePath, "Argument file path cannot be null");
+        this.argumentFilePaths.add(argumentFilePath);
+        return this;
+    }
+
+    public JavadocCLIBuilder addModules(String... modules) {
+        Objects.requireNonNull(modules, "Modules cannot be null");
+
+        var modulesBuilder = new StringBuilder("--add-modules ");
+        for (String module : modules) {
+            modulesBuilder.append(",").append(module);
+        }
+
+        this.arguments.add(modulesBuilder.toString());
+        return this;
+    }
+
+    public JavadocCLIBuilder addAllModules() {
+        return addModules("ALL-MODULE-PATH");
+    }
+
+    public JavadocCLIBuilder appendBootClassPath(String... bootClassPathEntries) {
+        if (jdk.version().major() >= 9)
+            throw new UnsupportedOperationException("The --boot-class-path option is not supported in JDK 9 and above.");
+
+        Objects.requireNonNull(bootClassPathEntries, "Boot class path entries cannot be null");
+        this.arguments.add("--boot-class-path " + String.join(File.pathSeparator, bootClassPathEntries));
+        return this;
+    }
+
+    public JavadocCLIBuilder classpath(String... classpathEntries) {
+        Objects.requireNonNull(classpathEntries, "Classpath entries cannot be null");
+        this.arguments.add("-cp " + String.join(File.pathSeparator, classpathEntries));
+        return this;
+    }
+
+    public JavadocCLIBuilder enablePreviewFeatures() {
+        if (jdk.version().major() < 12)
+            throw new UnsupportedOperationException("Preview features are only supported in JDK 12 and above.");
+
+        this.arguments.add("--enable-preview");
+        return this;
+    }
+
+    public JavadocCLIBuilder encoding(String encoding) {
+        Objects.requireNonNull(encoding, "Encoding cannot be null");
+        this.arguments.add("-encoding " + encoding);
+        return this;
+    }
+
+    public JavadocCLIBuilder encoding(Charset encoding) {
+        Objects.requireNonNull(encoding, "Encoding cannot be null");
+        return encoding(encoding.name());
+    }
+
+    public JavadocCLIBuilder extDirs(String... dirs) {
+        Objects.requireNonNull(dirs, "Ext dirs cannot be null");
+        this.arguments.add("-extdirs " + String.join(File.pathSeparator, dirs));
+        return this;
+    }
+
+    public JavadocCLIBuilder extDirs(Path... dirs) {
+        Objects.requireNonNull(dirs, "Ext dirs cannot be null");
+        String[] dirStrings = Arrays.stream(dirs).map(Path::toString).toArray(String[]::new);
+        return extDirs(dirStrings);
+    }
+
+    public JavadocCLIBuilder disableLineDocComments() {
+        this.arguments.add("--disable-line-doc-comments");
+        return this;
+    }
+
+    public JavadocCLIBuilder limitModules(String... modules) {
+        Objects.requireNonNull(modules, "Modules cannot be null");
+        this.arguments.add("--limit-modules " + String.join(",", modules));
+        return this;
+    }
+
+    public JavadocCLIBuilder addModuleNames(String... moduleName) {
+        Objects.requireNonNull(moduleName, "Module names cannot be null");
+        this.arguments.add("-module " + String.join(",", moduleName));
+        return this;
+    }
+
+    public JavadocCLIBuilder modulePath(String... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
+        this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
+        return this;
+    }
+
+    public JavadocCLIBuilder modulePath(Path... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
+        String[] pathStrings = Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new);
+        return modulePath(pathStrings);
+    }
+
+    public JavadocCLIBuilder moduleSourcePath(String... moduleSourcePaths) {
+        Objects.requireNonNull(moduleSourcePaths, "Module source path entries cannot be null");
+        this.arguments.add("--module-source-path " + String.join(File.pathSeparator, moduleSourcePaths));
+        return this;
+    }
+
+    public JavadocCLIBuilder moduleSourcePath(Path... moduleSourcePaths) {
+        Objects.requireNonNull(moduleSourcePaths, "Module source path entries cannot be null");
+        String[] pathStrings = Arrays.stream(moduleSourcePaths).map(Path::toString).toArray(String[]::new);
+        return moduleSourcePath(pathStrings);
+    }
+
+    public JavadocCLIBuilder releaseVersion(String version) {
+        Objects.requireNonNull(version, "Release version cannot be null");
+        this.arguments.add("--release " + version);
+        return this;
+    }
+
+    public JavadocCLIBuilder releaseVersion(int version) {
+        return releaseVersion(Integer.toString(version));
+    }
+
+    public JavadocCLIBuilder sourceVersion(String version) {
+        Objects.requireNonNull(version, "Source version cannot be null");
+        this.arguments.add("--source " + version);
+        return this;
+    }
+
+    public JavadocCLIBuilder sourceVersion(int version) {
+        return sourceVersion(Integer.toString(version));
+    }
+
+    public JavadocCLIBuilder sourcepath(String... sourcePaths) {
+        Objects.requireNonNull(sourcePaths, "Source path entries cannot be null");
+        this.arguments.add("-sourcepath " + String.join(File.pathSeparator, sourcePaths));
+        return this;
+    }
+
+    public JavadocCLIBuilder sourcepath(Path... sourcePaths) {
+        Objects.requireNonNull(sourcePaths, "Source path entries cannot be null");
+        String[] pathStrings = Arrays.stream(sourcePaths).map(Path::toString).toArray(String[]::new);
+        return sourcepath(pathStrings);
+    }
+
+    public JavadocCLIBuilder systemJdk(JDK systemJdk) {
+        Objects.requireNonNull(systemJdk, "System JDK cannot be null");
+        this.arguments.add("--system " + systemJdk.path().toString());
+        return this;
+    }
+
+    public JavadocCLIBuilder upgradeModulePath(String... upgradeModulePaths) {
+        Objects.requireNonNull(upgradeModulePaths, "Upgrade module path entries cannot be null");
+        this.arguments.add("--upgrade-module-path " + String.join(File.pathSeparator, upgradeModulePaths));
+        return this;
+    }
+
+    public JavadocCLIBuilder upgradeModulePath(Path... upgradeModulePaths) {
+        Objects.requireNonNull(upgradeModulePaths, "Upgrade module path entries cannot be null");
+        String[] pathStrings = Arrays.stream(upgradeModulePaths).map(Path::toString).toArray(String[]::new);
+        return upgradeModulePath(pathStrings);
+    }
+
+    public JavadocCLIBuilder enableBreakIterator() {
+        this.arguments.add("-breakiterator");
+        return this;
+    }
+
+    public JavadocCLIBuilder doclet(String docletClassName) {
+        Objects.requireNonNull(docletClassName, "Doclet class name cannot be null");
+        this.arguments.add("-doclet " + docletClassName);
+        return this;
+    }
+
+    public JavadocCLIBuilder docletPath(String... docletPaths) {
+        Objects.requireNonNull(docletPaths, "Doclet path entries cannot be null");
+        this.arguments.add("-docletpath " + String.join(File.pathSeparator, docletPaths));
+        return this;
+    }
+
+    public JavadocCLIBuilder docletPath(Path... docletPaths) {
+        Objects.requireNonNull(docletPaths, "Doclet path entries cannot be null");
+        String[] pathStrings = Arrays.stream(docletPaths).map(Path::toString).toArray(String[]::new);
+        return docletPath(pathStrings);
+    }
+
+    public JavadocCLIBuilder excludePackages(String... packageNames) {
+        Objects.requireNonNull(packageNames, "Package names cannot be null");
+        this.arguments.add("-exclude " + String.join(":", packageNames));
+        return this;
+    }
+
+    public JavadocCLIBuilder expandRequires(ExpansionType expansionType) {
+        Objects.requireNonNull(expansionType, "Expansion type cannot be null");
+        this.arguments.add("--expand-requires " + expansionType.name().toLowerCase(Locale.ROOT));
+        return this;
+    }
+
+    public JavadocCLIBuilder help() {
+        this.arguments.add("-?");
+        return this;
+    }
+
+    public JavadocCLIBuilder extraHelp() {
+        this.arguments.add("-X");
+        return this;
+    }
+
+    public JavadocCLIBuilder jflag(String jflag) {
+        Objects.requireNonNull(jflag, "JFlag cannot be null");
+        this.arguments.add("-J" + jflag);
+        return this;
+    }
+
+    public JavadocCLIBuilder locale(String locale) {
+        Objects.requireNonNull(locale, "Locale cannot be null");
+        this.arguments.add("-locale " + locale);
+        return this;
+    }
+
+    public JavadocCLIBuilder locale(Locale locale) {
+        Objects.requireNonNull(locale, "Locale cannot be null");
+        return locale(locale.toLanguageTag());
+    }
+
+    public JavadocCLIBuilder visibility(Visibility visibility) {
+        Objects.requireNonNull(visibility, "Visibility cannot be null");
+        this.arguments.add("-" + visibility.name().toLowerCase(Locale.ROOT));
+        return this;
+    }
+
+    public JavadocCLIBuilder quiet() {
+        this.arguments.add("-quiet");
+        return this;
+    }
+
+    public JavadocCLIBuilder showMembers(Visibility visibility) {
+        Objects.requireNonNull(visibility, "Visibility cannot be null");
+        this.arguments.add("--show-members " + visibility.name().toLowerCase(Locale.ROOT));
+        return this;
+    }
+
+    public JavadocCLIBuilder showModuleContents(ModuleGranularity granularity) {
+        Objects.requireNonNull(granularity, "Module granularity cannot be null");
+        this.arguments.add("--show-module-contents " + granularity.name().toLowerCase(Locale.ROOT));
+        return this;
+    }
+
+    public JavadocCLIBuilder showPackages(PackageGranularity granularity) {
+        Objects.requireNonNull(granularity, "Package granularity cannot be null");
+        this.arguments.add("--show-packages " + granularity.name().toLowerCase(Locale.ROOT));
+        return this;
+    }
+
+    public JavadocCLIBuilder showTypes(Visibility visibility) {
+        Objects.requireNonNull(visibility, "Visibility cannot be null");
+        this.arguments.add("--show-types " + visibility.name().toLowerCase(Locale.ROOT));
+        return this;
+    }
+
+    public JavadocCLIBuilder subpackages(String... packageNames) {
+        Objects.requireNonNull(packageNames, "Package names cannot be null");
+        this.arguments.add("-subpackages " + String.join(":", packageNames));
+        return this;
+    }
+
+    public JavadocCLIBuilder verbose() {
+        this.arguments.add("-verbose");
+        return this;
+    }
+
+    public JavadocCLIBuilder version() {
+        this.arguments.add("--version");
+        return this;
+    }
+
+    public JavadocCLIBuilder reportErrorOnWarnings() {
+        this.arguments.add("-Werror");
+        return this;
+    }
+
+    public JavadocCLIBuilder addReads(String sourceModule, String... targetModules) {
+        Objects.requireNonNull(sourceModule, "Source module cannot be null");
+        Objects.requireNonNull(targetModules, "Target modules cannot be null");
+
+        this.arguments.add("--add-reads " + sourceModule + "=" + String.join(",", targetModules));
+        return this;
+    }
+
+    public JavadocCLIBuilder addReadsAllUnnamed(String sourceModule) {
+        return addReads(sourceModule, "ALL-UNNAMED");
+    }
+
+    public JavadocCLIBuilder addExports(String sourceModule, String packageName, String... targetModules) {
+        Objects.requireNonNull(sourceModule, "Source module cannot be null");
+        Objects.requireNonNull(packageName, "Package name cannot be null");
+        Objects.requireNonNull(targetModules, "Target modules cannot be null");
+
+        this.arguments.add("--add-exports " + sourceModule + "/" + packageName + "=" + String.join(",", targetModules));
+        return this;
+    }
+
+    public JavadocCLIBuilder addExportsAllUnnamed(String sourceModule, String packageName) {
+        return addExports(sourceModule, packageName, "ALL-UNNAMED");
+    }
+
+    public JavadocCLIBuilder patchModule(String moduleName, String... patchPaths) {
+        Objects.requireNonNull(moduleName, "Module name cannot be null");
+        Objects.requireNonNull(patchPaths, "Patch paths cannot be null");
+        this.arguments.add("--patch-module " + moduleName + "=" + String.join(File.pathSeparator, patchPaths));
+        return this;
+    }
+
+    public JavadocCLIBuilder patchModule(String moduleName, Path... patchPaths) {
+        Objects.requireNonNull(moduleName, "Module name cannot be null");
+        Objects.requireNonNull(patchPaths, "Patch paths cannot be null");
+        String[] pathStrings = Arrays.stream(patchPaths).map(Path::toString).toArray(String[]::new);
+        return patchModule(moduleName, pathStrings);
+    }
+
+    public JavadocCLIBuilder maxErrors(int maxErrors) {
+        if (maxErrors < 0)
+            throw new IllegalArgumentException("Max errors cannot be negative");
+
+        this.arguments.add("-Xmaxerrs " + maxErrors);
+        return this;
+    }
+
+    public JavadocCLIBuilder maxWarnings(int maxWarnings) {
+        if (maxWarnings < 0)
+            throw new IllegalArgumentException("Max warnings cannot be negative");
+
+        this.arguments.add("-Xmaxwarns " + maxWarnings);
+        return this;
+    }
+
+    public JavadocCLIBuilder addScript(String script) {
+        Objects.requireNonNull(script, "Script cannot be null");
+        this.arguments.add("--add-script " + script);
+        return this;
+    }
+
+    public JavadocCLIBuilder addScript(Path scriptFilePath) {
+        Objects.requireNonNull(scriptFilePath, "Script file path cannot be null");
+        return addScript(scriptFilePath.toString());
+    }
+
+    public JavadocCLIBuilder addStylesheet(String styleSheet) {
+        Objects.requireNonNull(styleSheet, "Style sheet cannot be null");
+        this.arguments.add("--add-stylesheet " + styleSheet);
+        return this;
+    }
+
+    public JavadocCLIBuilder addStylesheet(Path styleSheetPath) {
+        Objects.requireNonNull(styleSheetPath, "Style sheet path cannot be null");
+        return addStylesheet(styleSheetPath.toString());
+    }
+
+    public JavadocCLIBuilder allowScriptInComments() {
+        this.arguments.add("--allow-script-in-comments");
+        return this;
+    }
+
+    public JavadocCLIBuilder includeAuthorTags() {
+        this.arguments.add("-author");
+        return this;
+    }
+
+    public JavadocCLIBuilder textAtBottom(String text) {
+        Objects.requireNonNull(text, "Text cannot be null");
+        this.arguments.add("-bottom " + text);
+        return this;
+    }
+
+    public JavadocCLIBuilder charset(String charset) {
+        Objects.requireNonNull(charset, "Charset cannot be null");
+        this.arguments.add("-charset " + charset);
+        return this;
+    }
+
+    public JavadocCLIBuilder charset(Charset charset) {
+        Objects.requireNonNull(charset, "Charset cannot be null");
+        return charset(charset.name());
+    }
+
+    public JavadocCLIBuilder destinationDirectory(Path outputDirectory) {
+        Objects.requireNonNull(outputDirectory, "Output directory cannot be null");
+        this.arguments.add("-d " + outputDirectory);
+        return this;
+    }
+
+    public JavadocCLIBuilder generatedEncoding(String encoding) {
+        Objects.requireNonNull(encoding, "Encoding cannot be null");
+        this.arguments.add("-docencoding " + encoding);
+        return this;
+    }
+
+    public JavadocCLIBuilder generatedEncoding(Charset encoding) {
+        Objects.requireNonNull(encoding, "Encoding cannot be null");
+        return generatedEncoding(encoding.name());
+    }
+
+    public JavadocCLIBuilder deepCopySubdirectories() {
+        this.arguments.add("-docfilessubdirs");
+        return this;
+    }
+
+    public JavadocCLIBuilder documentTitle(String title) {
+        Objects.requireNonNull(title, "Title cannot be null");
+        this.arguments.add("-doctitle " + title);
+        return this;
+    }
+
+    public JavadocCLIBuilder excludeSubdirectories(String... dirNames) {
+        Objects.requireNonNull(dirNames, "Directory names cannot be null");
+        this.arguments.add("-excludedocfilessubdir " + String.join(",", dirNames));
+        return this;
+    }
+
+    public JavadocCLIBuilder footerText(String text) {
+        Objects.requireNonNull(text, "Text cannot be null");
+        this.arguments.add("-footer " + text);
+        return this;
+    }
+
+    public JavadocCLIBuilder headerText(String text) {
+        Objects.requireNonNull(text, "Text cannot be null");
+        this.arguments.add("-header " + text);
+        return this;
+    }
+
+    public JavadocCLIBuilder groups(String... groupDefinitions) {
+        Objects.requireNonNull(groupDefinitions, "Group definitions cannot be null");
+        this.arguments.add("-group " + String.join(",", groupDefinitions));
+        return this;
+    }
+
+    public JavadocCLIBuilder helpFilename(String filename) {
+        Objects.requireNonNull(filename, "Filename cannot be null");
+        this.arguments.add("-helpfile " + filename);
+        return this;
+    }
+
+    public JavadocCLIBuilder helpFilename(Path filePath) {
+        Objects.requireNonNull(filePath, "File path cannot be null");
+        return helpFilename(filePath.toString());
+    }
+
+    public JavadocCLIBuilder enableHtml5() {
+        this.arguments.add("-html5");
+        return this;
+    }
+
+    public JavadocCLIBuilder enableJavaFX() {
+        this.arguments.add("-javafx");
+        return this;
+    }
+
+    public JavadocCLIBuilder keywords(String... keywords) {
+        Objects.requireNonNull(keywords, "Keywords cannot be null");
+        this.arguments.add("-keywords " + String.join(",", keywords));
+        return this;
+    }
+
+    public JavadocCLIBuilder link(String url) {
+        Objects.requireNonNull(url, "URL cannot be null");
+        this.arguments.add("-link " + url);
+        return this;
+    }
+
+    public JavadocCLIBuilder link(Path urlPath) {
+        Objects.requireNonNull(urlPath, "URL path cannot be null");
+        return link("file://" + urlPath);
+    }
+
+    public JavadocCLIBuilder linkModularityMismatch(LinkModularityMismatch mismatchBehavior) {
+        Objects.requireNonNull(mismatchBehavior, "Mismatch behavior cannot be null");
+        this.arguments.add("--link-modularity-mismatch " + mismatchBehavior.name().toLowerCase(Locale.ROOT));
+        return this;
+    }
+
+    public JavadocCLIBuilder linkOffline(String url, Path packageListPath) {
+        Objects.requireNonNull(url, "URL cannot be null");
+        Objects.requireNonNull(packageListPath, "Package list path cannot be null");
+        this.arguments.add("-linkoffline " + url + " " + packageListPath);
+        return this;
+    }
+
+    public JavadocCLIBuilder linkOffline(String url, String packageListPath) {
+        Objects.requireNonNull(url, "URL cannot be null");
+        Objects.requireNonNull(packageListPath, "Package list path cannot be null");
+        this.arguments.add("-linkoffline " + url + " " + packageListPath);
+        return this;
+    }
+
+    public JavadocCLIBuilder linkPlatformProperties(String url) {
+        Objects.requireNonNull(url, "URL cannot be null");
+        this.arguments.add("-linkplatformproperties " + url);
+        return this;
+    }
+
+    public JavadocCLIBuilder linkPlatformProperties(Path urlPath) {
+        Objects.requireNonNull(urlPath, "URL path cannot be null");
+        return linkPlatformProperties("file://" + urlPath);
+    }
+
+    public JavadocCLIBuilder shouldLinkSource() {
+        this.arguments.add("-linksource");
+        return this;
+    }
+
+    public JavadocCLIBuilder stylesheetFile(String filePath) {
+        Objects.requireNonNull(filePath, "File path cannot be null");
+        this.arguments.add("-stylesheetfile " + filePath);
+        return this;
+    }
+
+    public JavadocCLIBuilder stylesheetFile(Path filePath) {
+        Objects.requireNonNull(filePath, "File path cannot be null");
+        return stylesheetFile(filePath.toString());
+    }
+
+    public JavadocCLIBuilder noComments() {
+        this.arguments.add("-nocomment");
+        return this;
+    }
+
+    public JavadocCLIBuilder noDeprecated() {
+        this.arguments.add("-nodeprecated");
+        return this;
+    }
+
+    public JavadocCLIBuilder noDeprecatedList() {
+        this.arguments.add("-nodeprecatedlist");
+        return this;
+    }
+
+    public JavadocCLIBuilder noFonts() {
+        this.arguments.add("--nofonts");
+        return this;
+    }
+
+    public JavadocCLIBuilder noHelp() {
+        this.arguments.add("-nohelp");
+        return this;
+    }
+
+    public JavadocCLIBuilder noIndex() {
+        this.arguments.add("-noindex");
+        return this;
+    }
+
+    public JavadocCLIBuilder noNavBar() {
+        this.arguments.add("-nonavbar");
+        return this;
+    }
+
+    public JavadocCLIBuilder noPlatformLinks() {
+        this.arguments.add("--no-platform-links");
+        return this;
+    }
+
+    public JavadocCLIBuilder noQualifier(String... qualifiers) {
+        Objects.requireNonNull(qualifiers, "Qualifiers cannot be null");
+        this.arguments.add("-noqualifier " + String.join(",", qualifiers));
+        return this;
+    }
+
+    public JavadocCLIBuilder noSinceTag() {
+        this.arguments.add("-nosince");
+        return this;
+    }
+
+    public JavadocCLIBuilder noTimestamp() {
+        this.arguments.add("-notimestamp");
+        return this;
+    }
+
+    public JavadocCLIBuilder noTree() {
+        this.arguments.add("-notree");
+        return this;
+    }
+
+    public JavadocCLIBuilder methodOverrideHandling(MethodOverrideHandling handling) {
+        Objects.requireNonNull(handling, "Method override handling cannot be null");
+        this.arguments.add("--override-methods " + handling.name().toLowerCase(Locale.ROOT));
+        return this;
+    }
+
+    public JavadocCLIBuilder overviewFile(String filePath) {
+        Objects.requireNonNull(filePath, "File path cannot be null");
+        this.arguments.add("-overview " + filePath);
+        return this;
+    }
+
+    public JavadocCLIBuilder overviewFile(Path filePath) {
+        Objects.requireNonNull(filePath, "File path cannot be null");
+        return overviewFile(filePath.toString());
+    }
+
+    public JavadocCLIBuilder reportSerialWarnings() {
+        this.arguments.add("-serialwarn");
+        return this;
+    }
+
+    public JavadocCLIBuilder since(String... releaseVersions) {
+        Objects.requireNonNull(releaseVersions, "Release versions cannot be null");
+        this.arguments.add("-since " + String.join(",", releaseVersions));
+        return this;
+    }
+
+    public JavadocCLIBuilder since(int... releaseVersions) {
+        Objects.requireNonNull(releaseVersions, "Release versions cannot be null");
+        String[] versionStrings = Arrays.stream(releaseVersions).mapToObj(Integer::toString).toArray(String[]::new);
+        return since(versionStrings);
+    }
+
+    public JavadocCLIBuilder sinceLabel(String label) {
+        Objects.requireNonNull(label, "Label cannot be null");
+        this.arguments.add("-sincelabel " + label);
+        return this;
+    }
+
+    public JavadocCLIBuilder snippetPaths(String... paths) {
+        Objects.requireNonNull(paths, "Paths cannot be null");
+        this.arguments.add("--snippet-path " + String.join(File.pathSeparator, paths));
+        return this;
+    }
+
+    public JavadocCLIBuilder snippetPaths(Path... paths) {
+        Objects.requireNonNull(paths, "Paths cannot be null");
+        String[] pathStrings = Arrays.stream(paths).map(Path::toString).toArray(String[]::new);
+        return snippetPaths(pathStrings);
+    }
+
+    public JavadocCLIBuilder spacesPerTab(int spaces) {
+        if (spaces <= 0)
+            throw new IllegalArgumentException("Spaces per tab must be positive");
+
+        this.arguments.add("-sourcetab " + spaces);
+        return this;
+    }
+
+    public JavadocCLIBuilder specBaseUrl(String url) {
+        Objects.requireNonNull(url, "URL cannot be null");
+        this.arguments.add("--spec-base-url " + url);
+        return this;
+    }
+
+    public JavadocCLIBuilder shouldSplitIndex() {
+        this.arguments.add("-splitindex");
+        return this;
+    }
+
+    public JavadocCLIBuilder enableSyntaxHighlighting() {
+        this.arguments.add("--syntaxhighlight");
+        return this;
+    }
+
+    public JavadocCLIBuilder tag(String name, String locations, String header) {
+        Objects.requireNonNull(name, "Tag name cannot be null");
+        Objects.requireNonNull(locations, "Locations cannot be null");
+        Objects.requireNonNull(header, "Header cannot be null");
+        this.arguments.add("-tag " + name + ":" + locations + ":" + header);
+        return this;
+    }
+
+    public JavadocCLIBuilder taglet(String tagletClassName) {
+        Objects.requireNonNull(tagletClassName, "Taglet class name cannot be null");
+        this.arguments.add("-taglet " + tagletClassName);
+        return this;
+    }
+
+    public JavadocCLIBuilder tagletPath(String... tagletPaths) {
+        Objects.requireNonNull(tagletPaths, "Taglet path entries cannot be null");
+        this.arguments.add("-tagletpath " + String.join(File.pathSeparator, tagletPaths));
+        return this;
+    }
+
+    public JavadocCLIBuilder tagletPath(Path... tagletPaths) {
+        Objects.requireNonNull(tagletPaths, "Taglet path entries cannot be null");
+        String[] pathStrings = Arrays.stream(tagletPaths).map(Path::toString).toArray(String[]::new);
+        return tagletPath(pathStrings);
+    }
+
+    public JavadocCLIBuilder topText(String text) {
+        Objects.requireNonNull(text, "Text cannot be null");
+        this.arguments.add("-top " + text);
+        return this;
+    }
+
+    public JavadocCLIBuilder createUsagePages() {
+        this.arguments.add("-use");
+        return this;
+    }
+
+    public JavadocCLIBuilder includeVersionTags() {
+        this.arguments.add("-version");
+        return this;
+    }
+
+    public JavadocCLIBuilder windowTitle(String title) {
+        Objects.requireNonNull(title, "Title cannot be null");
+        this.arguments.add("-windowtitle " + title);
+        return this;
+    }
+
+    public JavadocCLIBuilder date(String iso8601Date) {
+        Objects.requireNonNull(iso8601Date, "Date cannot be null");
+        try {
+            OffsetDateTime dateTime = OffsetDateTime.parse(iso8601Date, ISO_OFFSET_FORMATTER);
+            return date(dateTime);
+        } catch (DateTimeParseException exception) {
+            throw new IllegalArgumentException("Date must be in ISO 8601 format (e.g., 2023-10-05T14:48:00Z)", exception);
+        }
+    }
+
+    public JavadocCLIBuilder date(Date date) {
+        Objects.requireNonNull(date, "Date cannot be null");
+        return date(OffsetDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()));
+    }
+
+    public JavadocCLIBuilder date(long epochMillis) {
+        return date(OffsetDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault()));
+    }
+
+    public JavadocCLIBuilder date(LocalDateTime dateTime) {
+        Objects.requireNonNull(dateTime, "DateTime cannot be null");
+        return date(dateTime.atZone(ZoneId.systemDefault()).toOffsetDateTime());
+    }
+
+    private JavadocCLIBuilder date(OffsetDateTime dateTime) {
+        Objects.requireNonNull(dateTime, "DateTime cannot be null");
+        Instant candidate = dateTime.toInstant();
+        Instant now = Instant.now();
+        Instant tenYearsAgo = now.minus(10, ChronoUnit.YEARS);
+        Instant tenYearsAhead = now.plus(10, ChronoUnit.YEARS);
+        if (candidate.isBefore(tenYearsAgo) || candidate.isAfter(tenYearsAhead))
+            throw new IllegalArgumentException("Date must be within 10 years of the current date");
+
+        this.arguments.add("-date " + ISO_OFFSET_FORMATTER.format(dateTime));
+        return this;
+    }
+
+    public JavadocCLIBuilder date(int year, int month, int day, int hour, int minute, int second) {
+        var dateTime = LocalDateTime.of(year, month, day, hour, minute, second);
+        return date(dateTime);
+    }
+
+    public JavadocCLIBuilder date(int year, int month, int day) {
+        var dateTime = LocalDateTime.of(year, month, day, 0, 0, 0);
+        return date(dateTime);
+    }
+
+    public JavadocCLIBuilder defaultLegalNotices() {
+        this.arguments.add("--legal-notices default");
+        return this;
+    }
+
+    public JavadocCLIBuilder noLegalNotices() {
+        this.arguments.add("--legal-notices none");
+        return this;
+    }
+
+    public JavadocCLIBuilder customLegalNotices(Path filePath) {
+        Objects.requireNonNull(filePath, "File path cannot be null");
+        this.arguments.add("--legal-notices " + filePath);
+        return this;
+    }
+
+    @Deprecated
+    public JavadocCLIBuilder noFrames() {
+        this.arguments.add("-noframes");
+        return this;
+    }
+
+    public JavadocCLIBuilder enableRecommendedChecks() {
+        this.arguments.add("-Xdoclint");
+        return this;
+    }
+
+    public JavadocCLIBuilder disableAllChecks() {
+        this.arguments.add("-Xdoclint:none");
+        return this;
+    }
+
+    public JavadocCLIBuilder enableChecks(String checks) {
+        Objects.requireNonNull(checks, "Checks cannot be null");
+        this.arguments.add("-Xdoclint:" + checks);
+        return this;
+    }
+
+    public JavadocCLIBuilder disableChecks(String checks) {
+        Objects.requireNonNull(checks, "Checks cannot be null");
+        this.arguments.add("-Xdoclint:-" + checks);
+        return this;
+    }
+
+    public JavadocCLIBuilder enableChecks(String... packages) {
+        Objects.requireNonNull(packages, "Packages cannot be null");
+        this.arguments.add("-Xdoclint/package:" + String.join(",", packages));
+        return this;
+    }
+
+    public JavadocCLIBuilder disableChecks(String... packages) {
+        Objects.requireNonNull(packages, "Packages cannot be null");
+        this.arguments.add("-Xdoclint/package:-" + String.join(",", packages));
+        return this;
+    }
+
+    public JavadocCLIBuilder docRootParentUrl(String url) {
+        Objects.requireNonNull(url, "URL cannot be null");
+        this.arguments.add("-Xdocrootparent " + url);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        command.addAll(packageNames);
+        command.addAll(sourceFilePaths.stream().map(Path::toString).toList());
+        command.addAll(argumentFilePaths.stream().map(Path::toString).toList());
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "javadoc");
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start Javadoc process", exception);
+        }
+    }
+
+    public enum ExpansionType {
+        TRANSITIVE,
+        ALL
+    }
+
+    public enum Visibility {
+        PUBLIC,
+        PROTECTED,
+        PACKAGE,
+        PRIVATE
+    }
+
+    public enum ModuleGranularity {
+        API,
+        ALL
+    }
+
+    public enum PackageGranularity {
+        EXPORTED,
+        ALL
+    }
+
+    public enum LinkModularityMismatch {
+        WARN,
+        INFO
+    }
+
+    public enum MethodOverrideHandling {
+        DETAIL,
+        SUMMARY
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JavapCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JavapCLIBuilder.java
@@ -11,6 +11,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A fluent builder for constructing and executing {@code javap} commands.
+ * <p>
+ * This builder provides methods to configure various options for disassembling class files,
+ * including verbosity, visibility filters, and classpath settings.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/javap.html">javap command documentation</a>
+ */
 public class JavapCLIBuilder implements CLIBuilder<Process, JavapCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "javap.exe" : "javap";
 
@@ -27,6 +36,12 @@ public class JavapCLIBuilder implements CLIBuilder<Process, JavapCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@code JavapCLIBuilder} instance.
+     *
+     * @param jdk The JDK to use for executing the {@code javap} command.
+     * @return A new builder instance.
+     */
     public static JavapCLIBuilder create(JDK jdk) {
         return new JavapCLIBuilder(jdk);
     }
@@ -69,115 +84,232 @@ public class JavapCLIBuilder implements CLIBuilder<Process, JavapCLIBuilder> {
         return this;
     }
 
+    /**
+     * Displays the help message. Corresponds to the {@code --help} option.
+     *
+     * @return This builder instance.
+     */
     public JavapCLIBuilder help() {
         this.arguments.add("--help");
         return this;
     }
 
+    /**
+     * Displays version information. Corresponds to the {@code -version} option.
+     *
+     * @return This builder instance.
+     */
     public JavapCLIBuilder version() {
         this.arguments.add("-version");
         return this;
     }
 
+    /**
+     * Enables verbose output, including stack size, number of locals, and args for methods. Corresponds to the {@code -verbose} option.
+     *
+     * @return This builder instance.
+     */
     public JavapCLIBuilder verbose() {
         this.arguments.add("-verbose");
         return this;
     }
 
+    /**
+     * Prints line number and local variable tables. Corresponds to the {@code -l} option.
+     *
+     * @return This builder instance.
+     */
     public JavapCLIBuilder lineAndLocalVariableTables() {
         this.arguments.add("-l");
         return this;
     }
 
+    /**
+     * Specifies the minimum visibility level of members to print. Corresponds to options like {@code -public}, {@code -protected}, {@code -package}, {@code -private}.
+     *
+     * @param visibility The minimum visibility level.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder visibility(Visibility visibility) {
         Objects.requireNonNull(visibility, "Visibility cannot be null");
         this.arguments.add(visibility.getFlag());
         return this;
     }
 
+    /**
+     * Disassembles the code. Corresponds to the {@code -c} option.
+     *
+     * @return This builder instance.
+     */
     public JavapCLIBuilder disassembleCode() {
         this.arguments.add("-c");
         return this;
     }
 
+    /**
+     * Prints internal type signatures. Corresponds to the {@code -s} option.
+     *
+     * @return This builder instance.
+     */
     public JavapCLIBuilder printSignatures() {
         this.arguments.add("-s");
         return this;
     }
 
+    /**
+     * Shows system information. Corresponds to the {@code -sysinfo} option.
+     *
+     * @return This builder instance.
+     */
     public JavapCLIBuilder showSystemInfo() {
         this.arguments.add("-sysinfo");
         return this;
     }
 
+    /**
+     * Verifies the reachability of classes. Corresponds to the {@code -verify} option.
+     *
+     * @return This builder instance.
+     */
     public JavapCLIBuilder verifyClasses() {
         this.arguments.add("-verify");
         return this;
     }
 
+    /**
+     * Shows final static constants. Corresponds to the {@code -constants} option.
+     *
+     * @return This builder instance.
+     */
     public JavapCLIBuilder showConstants() {
         this.arguments.add("-constants");
         return this;
     }
 
+    /**
+     * Specifies the module to inspect. Corresponds to the {@code --module} option.
+     *
+     * @param moduleName The name of the module.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder module(String moduleName) {
         Objects.requireNonNull(moduleName, "Module name cannot be null");
         this.arguments.add("--module " + moduleName);
         return this;
     }
 
+    /**
+     * Specifies the module path. Corresponds to the {@code --module-path} option.
+     *
+     * @param modulePaths The entries for the module path.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder modulePath(String... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module paths cannot be null");
         this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
         return this;
     }
 
+    /**
+     * Specifies the module path. Corresponds to the {@code --module-path} option.
+     *
+     * @param modulePaths The entries for the module path.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder modulePath(Path... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module paths cannot be null");
         String[] pathStrings = Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new);
         return modulePath(pathStrings);
     }
 
+    /**
+     * Specifies the path to the system modules. Corresponds to the {@code --system} option.
+     *
+     * @param systemPath The path to the system modules.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder systemModules(String systemPath) {
         Objects.requireNonNull(systemPath, "System module path cannot be null");
         this.arguments.add("--system " + systemPath);
         return this;
     }
 
+    /**
+     * Specifies the classpath for finding class files. Corresponds to the {@code -cp} or {@code -classpath} option.
+     *
+     * @param classpathEntries The entries for the classpath.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder classpath(String... classpathEntries) {
         Objects.requireNonNull(classpathEntries, "Classpath entries cannot be null");
         this.arguments.add("-cp " + String.join(File.pathSeparator, classpathEntries));
         return this;
     }
 
+    /**
+     * Specifies the classpath for finding class files. Corresponds to the {@code -cp} or {@code -classpath} option.
+     *
+     * @param classpathEntries The entries for the classpath.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder classpath(Path... classpathEntries) {
         Objects.requireNonNull(classpathEntries, "Classpath entries cannot be null");
         String[] entryStrings = Arrays.stream(classpathEntries).map(Path::toString).toArray(String[]::new);
         return classpath(entryStrings);
     }
 
+    /**
+     * Specifies the boot classpath. Corresponds to the {@code -bootclasspath} option.
+     *
+     * @param bootClassPathEntries The entries for the boot classpath.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder bootClassPath(String... bootClassPathEntries) {
         Objects.requireNonNull(bootClassPathEntries, "Boot class path entries cannot be null");
         this.arguments.add("-bootclasspath " + String.join(File.pathSeparator, bootClassPathEntries));
         return this;
     }
 
+    /**
+     * Specifies the boot classpath. Corresponds to the {@code -bootclasspath} option.
+     *
+     * @param bootClassPathEntries The entries for the boot classpath.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder bootClassPath(Path... bootClassPathEntries) {
         Objects.requireNonNull(bootClassPathEntries, "Boot class path entries cannot be null");
         String[] entryStrings = Arrays.stream(bootClassPathEntries).map(Path::toString).toArray(String[]::new);
         return bootClassPath(entryStrings);
     }
 
+    /**
+     * Specifies the multi-release JAR file version. Corresponds to the {@code --multi-release} option.
+     *
+     * @param version The multi-release version.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder multiRelease(String version) {
         Objects.requireNonNull(version, "Multi-release version cannot be null");
         this.arguments.add("--multi-release " + version);
         return this;
     }
 
+    /**
+     * Specifies the multi-release JAR file version. Corresponds to the {@code --multi-release} option.
+     *
+     * @param version The multi-release version.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder multiRelease(int version) {
         return multiRelease(Integer.toString(version));
     }
 
+    /**
+     * Passes options to the Java Virtual Machine. Corresponds to the {@code -J} option.
+     *
+     * @param options The JVM options.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder jvmOptions(String... options) {
         Objects.requireNonNull(options, "JVM options cannot be null");
         for (String option : options) {
@@ -188,12 +320,24 @@ public class JavapCLIBuilder implements CLIBuilder<Process, JavapCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a class name to be disassembled.
+     *
+     * @param className The name of the class.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder addClassName(String className) {
         Objects.requireNonNull(className, "Class name cannot be null");
         this.classTargets.add(className);
         return this;
     }
 
+    /**
+     * Adds multiple class names to be disassembled.
+     *
+     * @param classNames The names of the classes.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder addClassNames(String... classNames) {
         Objects.requireNonNull(classNames, "Class names cannot be null");
         for (String className : classNames) {
@@ -203,12 +347,24 @@ public class JavapCLIBuilder implements CLIBuilder<Process, JavapCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a class file to be disassembled.
+     *
+     * @param classFilePath The path to the class file.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder addClassFile(Path classFilePath) {
         Objects.requireNonNull(classFilePath, "Class file path cannot be null");
         this.classTargets.add(classFilePath.toString());
         return this;
     }
 
+    /**
+     * Adds multiple class files to be disassembled.
+     *
+     * @param classFilePaths The paths to the class files.
+     * @return This builder instance.
+     */
     public JavapCLIBuilder addClassFiles(Path... classFilePaths) {
         Objects.requireNonNull(classFilePaths, "Class file paths cannot be null");
         for (Path classFilePath : classFilePaths) {
@@ -248,6 +404,9 @@ public class JavapCLIBuilder implements CLIBuilder<Process, JavapCLIBuilder> {
         }
     }
 
+    /**
+     * Represents the visibility levels for members to be printed.
+     */
     @Getter
     public enum Visibility {
         PUBLIC("-public"),

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JavapCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JavapCLIBuilder.java
@@ -1,0 +1,264 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+import lombok.Getter;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JavapCLIBuilder implements CLIBuilder<Process, JavapCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "javap.exe" : "javap";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<String> classTargets = new ArrayList<>();
+    private Path workingDirectory;
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private JavapCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JavapCLIBuilder create(JDK jdk) {
+        return new JavapCLIBuilder(jdk);
+    }
+
+    @Override
+    public JavapCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JavapCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JavapCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JavapCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JavapCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JavapCLIBuilder help() {
+        this.arguments.add("--help");
+        return this;
+    }
+
+    public JavapCLIBuilder version() {
+        this.arguments.add("-version");
+        return this;
+    }
+
+    public JavapCLIBuilder verbose() {
+        this.arguments.add("-verbose");
+        return this;
+    }
+
+    public JavapCLIBuilder lineAndLocalVariableTables() {
+        this.arguments.add("-l");
+        return this;
+    }
+
+    public JavapCLIBuilder visibility(Visibility visibility) {
+        Objects.requireNonNull(visibility, "Visibility cannot be null");
+        this.arguments.add(visibility.getFlag());
+        return this;
+    }
+
+    public JavapCLIBuilder disassembleCode() {
+        this.arguments.add("-c");
+        return this;
+    }
+
+    public JavapCLIBuilder printSignatures() {
+        this.arguments.add("-s");
+        return this;
+    }
+
+    public JavapCLIBuilder showSystemInfo() {
+        this.arguments.add("-sysinfo");
+        return this;
+    }
+
+    public JavapCLIBuilder verifyClasses() {
+        this.arguments.add("-verify");
+        return this;
+    }
+
+    public JavapCLIBuilder showConstants() {
+        this.arguments.add("-constants");
+        return this;
+    }
+
+    public JavapCLIBuilder module(String moduleName) {
+        Objects.requireNonNull(moduleName, "Module name cannot be null");
+        this.arguments.add("--module " + moduleName);
+        return this;
+    }
+
+    public JavapCLIBuilder modulePath(String... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module paths cannot be null");
+        this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
+        return this;
+    }
+
+    public JavapCLIBuilder modulePath(Path... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module paths cannot be null");
+        String[] pathStrings = Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new);
+        return modulePath(pathStrings);
+    }
+
+    public JavapCLIBuilder systemModules(String systemPath) {
+        Objects.requireNonNull(systemPath, "System module path cannot be null");
+        this.arguments.add("--system " + systemPath);
+        return this;
+    }
+
+    public JavapCLIBuilder classpath(String... classpathEntries) {
+        Objects.requireNonNull(classpathEntries, "Classpath entries cannot be null");
+        this.arguments.add("-cp " + String.join(File.pathSeparator, classpathEntries));
+        return this;
+    }
+
+    public JavapCLIBuilder classpath(Path... classpathEntries) {
+        Objects.requireNonNull(classpathEntries, "Classpath entries cannot be null");
+        String[] entryStrings = Arrays.stream(classpathEntries).map(Path::toString).toArray(String[]::new);
+        return classpath(entryStrings);
+    }
+
+    public JavapCLIBuilder bootClassPath(String... bootClassPathEntries) {
+        Objects.requireNonNull(bootClassPathEntries, "Boot class path entries cannot be null");
+        this.arguments.add("-bootclasspath " + String.join(File.pathSeparator, bootClassPathEntries));
+        return this;
+    }
+
+    public JavapCLIBuilder bootClassPath(Path... bootClassPathEntries) {
+        Objects.requireNonNull(bootClassPathEntries, "Boot class path entries cannot be null");
+        String[] entryStrings = Arrays.stream(bootClassPathEntries).map(Path::toString).toArray(String[]::new);
+        return bootClassPath(entryStrings);
+    }
+
+    public JavapCLIBuilder multiRelease(String version) {
+        Objects.requireNonNull(version, "Multi-release version cannot be null");
+        this.arguments.add("--multi-release " + version);
+        return this;
+    }
+
+    public JavapCLIBuilder multiRelease(int version) {
+        return multiRelease(Integer.toString(version));
+    }
+
+    public JavapCLIBuilder jvmOptions(String... options) {
+        Objects.requireNonNull(options, "JVM options cannot be null");
+        for (String option : options) {
+            Objects.requireNonNull(option, "JVM option cannot be null");
+            this.arguments.add("-J" + option);
+        }
+
+        return this;
+    }
+
+    public JavapCLIBuilder addClassName(String className) {
+        Objects.requireNonNull(className, "Class name cannot be null");
+        this.classTargets.add(className);
+        return this;
+    }
+
+    public JavapCLIBuilder addClassNames(String... classNames) {
+        Objects.requireNonNull(classNames, "Class names cannot be null");
+        for (String className : classNames) {
+            addClassName(className);
+        }
+
+        return this;
+    }
+
+    public JavapCLIBuilder addClassFile(Path classFilePath) {
+        Objects.requireNonNull(classFilePath, "Class file path cannot be null");
+        this.classTargets.add(classFilePath.toString());
+        return this;
+    }
+
+    public JavapCLIBuilder addClassFiles(Path... classFilePaths) {
+        Objects.requireNonNull(classFilePaths, "Class file paths cannot be null");
+        for (Path classFilePath : classFilePaths) {
+            addClassFile(classFilePath);
+        }
+
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        command.addAll(classTargets);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "javap");
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start javap process", exception);
+        }
+    }
+
+    @Getter
+    public enum Visibility {
+        PUBLIC("-public"),
+        PROTECTED("-protected"),
+        PACKAGE("-package"),
+        PRIVATE("-private");
+
+        private final String flag;
+
+        Visibility(String flag) {
+            this.flag = flag;
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JcmdCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JcmdCLIBuilder.java
@@ -9,6 +9,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A fluent builder for constructing and executing {@code jcmd} commands.
+ * <p>
+ * This builder provides methods to interact with a running JVM, allowing for
+ * diagnostic command execution, listing JVM processes, and retrieving help information.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jcmd.html">jcmd command documentation</a>
+ */
 public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jcmd.exe" : "jcmd";
 
@@ -28,6 +37,12 @@ public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@code JcmdCLIBuilder} instance.
+     *
+     * @param jdk The JDK to use for executing the {@code jcmd} command.
+     * @return A new builder instance.
+     */
     public static JcmdCLIBuilder create(JDK jdk) {
         return new JcmdCLIBuilder(jdk);
     }
@@ -70,6 +85,11 @@ public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Configures the builder to list all running Java processes. Corresponds to the {@code -l} option.
+     *
+     * @return This builder instance.
+     */
     public JcmdCLIBuilder listJavaProcesses() {
         this.mode = Mode.LIST;
         this.commandFile = null;
@@ -77,6 +97,11 @@ public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Configures the builder to display help information. Corresponds to the {@code -h} option.
+     *
+     * @return This builder instance.
+     */
     public JcmdCLIBuilder showHelp() {
         this.mode = Mode.HELP;
         this.commandFile = null;
@@ -84,6 +109,13 @@ public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the target JVM by its process ID (PID).
+     *
+     * @param pid The process ID of the target JVM.
+     * @return This builder instance.
+     * @throws IllegalArgumentException if the PID is negative.
+     */
     public JcmdCLIBuilder targetPid(long pid) {
         if (pid < 0)
             throw new IllegalArgumentException("PID cannot be negative");
@@ -93,6 +125,12 @@ public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the target JVM by its main class name.
+     *
+     * @param mainClass The main class name of the target JVM.
+     * @return This builder instance.
+     */
     public JcmdCLIBuilder targetMainClass(String mainClass) {
         Objects.requireNonNull(mainClass, "Main class cannot be null");
         this.target = Target.mainClass(mainClass);
@@ -100,12 +138,23 @@ public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the target to all running Java processes. Corresponds to using "0" as the PID.
+     *
+     * @return This builder instance.
+     */
     public JcmdCLIBuilder targetAllJavaProcesses() {
         this.target = Target.pid("0");
         this.mode = Mode.COMMAND;
         return this;
     }
 
+    /**
+     * Executes diagnostic commands from a specified file. Corresponds to the {@code -f} option.
+     *
+     * @param file The path to the command file.
+     * @return This builder instance.
+     */
     public JcmdCLIBuilder executeCommandsFromFile(Path file) {
         Objects.requireNonNull(file, "Command file cannot be null");
         this.commandFile = file;
@@ -113,6 +162,13 @@ public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a diagnostic command to be executed.
+     *
+     * @param command The name of the diagnostic command (e.g., "GC.heap_info").
+     * @param args    Optional arguments for the command.
+     * @return This builder instance.
+     */
     public JcmdCLIBuilder addDiagnosticCommand(String command, String... args) {
         Objects.requireNonNull(command, "Command name cannot be null");
         var commandTokens = new ArrayList<String>();
@@ -126,6 +182,11 @@ public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Executes the "PerfCounter.print" diagnostic command.
+     *
+     * @return This builder instance.
+     */
     public JcmdCLIBuilder perfCounterPrint() {
         return addDiagnosticCommand("PerfCounter.print");
     }
@@ -182,12 +243,18 @@ public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
         }
     }
 
+    /**
+     * Represents the operation mode for the {@code jcmd} command.
+     */
     private enum Mode {
         COMMAND,
         LIST,
         HELP
     }
 
+    /**
+     * Represents the target JVM for the {@code jcmd} command.
+     */
     private record Target(TargetType type, String value) {
         static Target none() {
             return new Target(TargetType.NONE, null);
@@ -202,6 +269,9 @@ public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
         }
     }
 
+    /**
+     * Represents the type of target for the {@code jcmd} command.
+     */
     private enum TargetType {
         NONE,
         PID,

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JcmdCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JcmdCLIBuilder.java
@@ -1,0 +1,210 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JcmdCLIBuilder implements CLIBuilder<Process, JcmdCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jcmd.exe" : "jcmd";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<List<String>> diagnosticCommands = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private Mode mode = Mode.COMMAND;
+    private Target target = Target.none();
+    private Path commandFile;
+
+    private JcmdCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JcmdCLIBuilder create(JDK jdk) {
+        return new JcmdCLIBuilder(jdk);
+    }
+
+    @Override
+    public JcmdCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JcmdCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JcmdCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JcmdCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JcmdCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JcmdCLIBuilder listJavaProcesses() {
+        this.mode = Mode.LIST;
+        this.commandFile = null;
+        this.diagnosticCommands.clear();
+        return this;
+    }
+
+    public JcmdCLIBuilder showHelp() {
+        this.mode = Mode.HELP;
+        this.commandFile = null;
+        this.diagnosticCommands.clear();
+        return this;
+    }
+
+    public JcmdCLIBuilder targetPid(long pid) {
+        if (pid < 0)
+            throw new IllegalArgumentException("PID cannot be negative");
+
+        this.target = Target.pid(Long.toString(pid));
+        this.mode = Mode.COMMAND;
+        return this;
+    }
+
+    public JcmdCLIBuilder targetMainClass(String mainClass) {
+        Objects.requireNonNull(mainClass, "Main class cannot be null");
+        this.target = Target.mainClass(mainClass);
+        this.mode = Mode.COMMAND;
+        return this;
+    }
+
+    public JcmdCLIBuilder targetAllJavaProcesses() {
+        this.target = Target.pid("0");
+        this.mode = Mode.COMMAND;
+        return this;
+    }
+
+    public JcmdCLIBuilder executeCommandsFromFile(Path file) {
+        Objects.requireNonNull(file, "Command file cannot be null");
+        this.commandFile = file;
+        this.mode = Mode.COMMAND;
+        return this;
+    }
+
+    public JcmdCLIBuilder addDiagnosticCommand(String command, String... args) {
+        Objects.requireNonNull(command, "Command name cannot be null");
+        var commandTokens = new ArrayList<String>();
+        commandTokens.add(command);
+        if (args != null) {
+            commandTokens.addAll(Arrays.asList(args));
+        }
+
+        this.diagnosticCommands.add(commandTokens);
+        this.mode = Mode.COMMAND;
+        return this;
+    }
+
+    public JcmdCLIBuilder perfCounterPrint() {
+        return addDiagnosticCommand("PerfCounter.print");
+    }
+
+    @Override
+    public Process run() {
+        if (mode == Mode.COMMAND && commandFile == null && diagnosticCommands.isEmpty())
+            throw new IllegalStateException("At least one diagnostic command or command file must be specified.");
+
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+
+        switch (mode) {
+            case HELP -> command.add("-h");
+            case LIST -> command.add("-l");
+            case COMMAND -> {
+                if (target.value() != null)
+                    command.add(target.value());
+                if (commandFile != null) {
+                    command.add("-f");
+                    command.add(commandFile.toString());
+                }
+            }
+        }
+
+        command.addAll(arguments);
+        if (mode == Mode.COMMAND && commandFile == null) {
+            for (List<String> diagnosticCommand : diagnosticCommands) {
+                command.addAll(diagnosticCommand);
+            }
+        }
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jcmd");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jcmd process", exception);
+        }
+    }
+
+    private enum Mode {
+        COMMAND,
+        LIST,
+        HELP
+    }
+
+    private record Target(TargetType type, String value) {
+        static Target none() {
+            return new Target(TargetType.NONE, null);
+        }
+
+        static Target pid(String pid) {
+            return new Target(TargetType.PID, pid);
+        }
+
+        static Target mainClass(String mainClass) {
+            return new Target(TargetType.MAIN_CLASS, mainClass);
+        }
+    }
+
+    private enum TargetType {
+        NONE,
+        PID,
+        MAIN_CLASS
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JdbCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JdbCLIBuilder.java
@@ -1,0 +1,226 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JdbCLIBuilder implements CLIBuilder<Process, JdbCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jdb.exe" : "jdb";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<String> targetArguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private String mainClass;
+
+    private JdbCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JdbCLIBuilder create(JDK jdk) {
+        return new JdbCLIBuilder(jdk);
+    }
+
+    @Override
+    public JdbCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JdbCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JdbCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JdbCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JdbCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JdbCLIBuilder help() {
+        this.arguments.add("-help");
+        return this;
+    }
+
+    public JdbCLIBuilder sourcePath(String... directories) {
+        Objects.requireNonNull(directories, "Source directories cannot be null");
+        this.arguments.add("-sourcepath " + String.join(File.pathSeparator, directories));
+        return this;
+    }
+
+    public JdbCLIBuilder attach(String address) {
+        Objects.requireNonNull(address, "Attach address cannot be null");
+        this.arguments.add("-attach " + address);
+        return this;
+    }
+
+    public JdbCLIBuilder listen(String address) {
+        Objects.requireNonNull(address, "Listen address cannot be null");
+        this.arguments.add("-listen " + address);
+        return this;
+    }
+
+    public JdbCLIBuilder listenAny() {
+        this.arguments.add("-listenany");
+        return this;
+    }
+
+    public JdbCLIBuilder launchOnStart() {
+        this.arguments.add("-launch");
+        return this;
+    }
+
+    public JdbCLIBuilder listConnectors() {
+        this.arguments.add("-listconnectors");
+        return this;
+    }
+
+    public JdbCLIBuilder connect(String connectorName, Map<String, String> arguments) {
+        Objects.requireNonNull(connectorName, "Connector name cannot be null");
+        Objects.requireNonNull(arguments, "Connector arguments cannot be null");
+        var builder = new StringBuilder("-connect ").append(connectorName);
+        arguments.forEach((key, value) -> builder.append(":").append(key).append("=").append(value));
+        this.arguments.add(builder.toString());
+        return this;
+    }
+
+    public JdbCLIBuilder debugTrace(String flags) {
+        Objects.requireNonNull(flags, "Debug trace flags cannot be null");
+        this.arguments.add("-dbgtrace " + flags);
+        return this;
+    }
+
+    public JdbCLIBuilder tClient() {
+        this.arguments.add("-tclient");
+        return this;
+    }
+
+    public JdbCLIBuilder trackAllThreads() {
+        this.arguments.add("-trackallthreads");
+        return this;
+    }
+
+    public JdbCLIBuilder tServer() {
+        this.arguments.add("-tserver");
+        return this;
+    }
+
+    public JdbCLIBuilder javaOption(String option) {
+        Objects.requireNonNull(option, "Java option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    public JdbCLIBuilder debuggeeOption(String option) {
+        Objects.requireNonNull(option, "Debuggee option cannot be null");
+        this.arguments.add("-R" + option);
+        return this;
+    }
+
+    public JdbCLIBuilder verbose() {
+        this.arguments.add("-verbose");
+        return this;
+    }
+
+    public JdbCLIBuilder verbose(String mode) {
+        Objects.requireNonNull(mode, "Verbose mode cannot be null");
+        this.arguments.add("-verbose:" + mode);
+        return this;
+    }
+
+    public JdbCLIBuilder systemProperty(String key, String value) {
+        Objects.requireNonNull(key, "Property key cannot be null");
+        Objects.requireNonNull(value, "Property value cannot be null");
+        this.arguments.add("-D" + key + "=" + value);
+        return this;
+    }
+
+    public JdbCLIBuilder classpath(String... entries) {
+        Objects.requireNonNull(entries, "Classpath entries cannot be null");
+        this.arguments.add("-classpath " + String.join(File.pathSeparator, entries));
+        return this;
+    }
+
+    public JdbCLIBuilder xOption(String option) {
+        Objects.requireNonNull(option, "Nonstandard option cannot be null");
+        this.arguments.add("-X" + option);
+        return this;
+    }
+
+    public JdbCLIBuilder mainClass(String mainClass) {
+        Objects.requireNonNull(mainClass, "Main class cannot be null");
+        this.mainClass = mainClass;
+        return this;
+    }
+
+    public JdbCLIBuilder mainClassArguments(String... args) {
+        Objects.requireNonNull(args, "Main class arguments cannot be null");
+        Collections.addAll(this.targetArguments, args);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        if (mainClass != null) {
+            command.add(mainClass);
+        }
+        command.addAll(targetArguments);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jdb");
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jdb process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JdbCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JdbCLIBuilder.java
@@ -10,6 +10,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A fluent builder for constructing and executing {@code jdb} commands.
+ * <p>
+ * This builder provides methods to configure various options for debugging Java applications,
+ * including source paths, connection details, and JVM options.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jdb.html">jdb command documentation</a>
+ */
 public class JdbCLIBuilder implements CLIBuilder<Process, JdbCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jdb.exe" : "jdb";
 
@@ -27,6 +36,12 @@ public class JdbCLIBuilder implements CLIBuilder<Process, JdbCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@code JdbCLIBuilder} instance.
+     *
+     * @param jdk The JDK to use for executing the {@code jdb} command.
+     * @return A new builder instance.
+     */
     public static JdbCLIBuilder create(JDK jdk) {
         return new JdbCLIBuilder(jdk);
     }
@@ -69,44 +84,89 @@ public class JdbCLIBuilder implements CLIBuilder<Process, JdbCLIBuilder> {
         return this;
     }
 
+    /**
+     * Displays the help message. Corresponds to the {@code -help} option.
+     *
+     * @return This builder instance.
+     */
     public JdbCLIBuilder help() {
         this.arguments.add("-help");
         return this;
     }
 
+    /**
+     * Specifies the source code path. Corresponds to the {@code -sourcepath} option.
+     *
+     * @param directories The directories for the source path.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder sourcePath(String... directories) {
         Objects.requireNonNull(directories, "Source directories cannot be null");
         this.arguments.add("-sourcepath " + String.join(File.pathSeparator, directories));
         return this;
     }
 
+    /**
+     * Attaches the debugger to a running JVM. Corresponds to the {@code -attach} option.
+     *
+     * @param address The address of the target JVM.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder attach(String address) {
         Objects.requireNonNull(address, "Attach address cannot be null");
         this.arguments.add("-attach " + address);
         return this;
     }
 
+    /**
+     * Listens for a debugger connection at the specified address. Corresponds to the {@code -listen} option.
+     *
+     * @param address The address to listen on.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder listen(String address) {
         Objects.requireNonNull(address, "Listen address cannot be null");
         this.arguments.add("-listen " + address);
         return this;
     }
 
+    /**
+     * Listens for a debugger connection on any available address. Corresponds to the {@code -listenany} option.
+     *
+     * @return This builder instance.
+     */
     public JdbCLIBuilder listenAny() {
         this.arguments.add("-listenany");
         return this;
     }
 
+    /**
+     * Launches the debuggee VM on startup. Corresponds to the {@code -launch} option.
+     *
+     * @return This builder instance.
+     */
     public JdbCLIBuilder launchOnStart() {
         this.arguments.add("-launch");
         return this;
     }
 
+    /**
+     * Lists available connectors. Corresponds to the {@code -listconnectors} option.
+     *
+     * @return This builder instance.
+     */
     public JdbCLIBuilder listConnectors() {
         this.arguments.add("-listconnectors");
         return this;
     }
 
+    /**
+     * Connects to a running JVM using the specified connector. Corresponds to the {@code -connect} option.
+     *
+     * @param connectorName The name of the connector.
+     * @param arguments     A map of arguments for the connector.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder connect(String connectorName, Map<String, String> arguments) {
         Objects.requireNonNull(connectorName, "Connector name cannot be null");
         Objects.requireNonNull(arguments, "Connector arguments cannot be null");
@@ -116,50 +176,101 @@ public class JdbCLIBuilder implements CLIBuilder<Process, JdbCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the debug trace flags. Corresponds to the {@code -dbgtrace} option.
+     *
+     * @param flags The debug trace flags.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder debugTrace(String flags) {
         Objects.requireNonNull(flags, "Debug trace flags cannot be null");
         this.arguments.add("-dbgtrace " + flags);
         return this;
     }
 
+    /**
+     * Uses the client VM. Corresponds to the {@code -tclient} option.
+     *
+     * @return This builder instance.
+     */
     public JdbCLIBuilder tClient() {
         this.arguments.add("-tclient");
         return this;
     }
 
+    /**
+     * Tracks all threads. Corresponds to the {@code -trackallthreads} option.
+     *
+     * @return This builder instance.
+     */
     public JdbCLIBuilder trackAllThreads() {
         this.arguments.add("-trackallthreads");
         return this;
     }
 
+    /**
+     * Uses the server VM. Corresponds to the {@code -tserver} option.
+     *
+     * @return This builder instance.
+     */
     public JdbCLIBuilder tServer() {
         this.arguments.add("-tserver");
         return this;
     }
 
+    /**
+     * Passes an option to the Java Virtual Machine. Corresponds to the {@code -J} option.
+     *
+     * @param option The option to pass to the JVM.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder javaOption(String option) {
         Objects.requireNonNull(option, "Java option cannot be null");
         this.arguments.add("-J" + option);
         return this;
     }
 
+    /**
+     * Passes an option to the debuggee JVM. Corresponds to the {@code -R} option.
+     *
+     * @param option The option to pass to the debuggee JVM.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder debuggeeOption(String option) {
         Objects.requireNonNull(option, "Debuggee option cannot be null");
         this.arguments.add("-R" + option);
         return this;
     }
 
+    /**
+     * Enables verbose output. Corresponds to the {@code -verbose} option.
+     *
+     * @return This builder instance.
+     */
     public JdbCLIBuilder verbose() {
         this.arguments.add("-verbose");
         return this;
     }
 
+    /**
+     * Enables verbose output for a specific mode. Corresponds to the {@code -verbose:mode} option.
+     *
+     * @param mode The verbose mode.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder verbose(String mode) {
         Objects.requireNonNull(mode, "Verbose mode cannot be null");
         this.arguments.add("-verbose:" + mode);
         return this;
     }
 
+    /**
+     * Sets a system property for the debuggee JVM. Corresponds to the {@code -Dkey=value} option.
+     *
+     * @param key   The property key.
+     * @param value The property value.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder systemProperty(String key, String value) {
         Objects.requireNonNull(key, "Property key cannot be null");
         Objects.requireNonNull(value, "Property value cannot be null");
@@ -167,24 +278,48 @@ public class JdbCLIBuilder implements CLIBuilder<Process, JdbCLIBuilder> {
         return this;
     }
 
+    /**
+     * Specifies the classpath for the debuggee JVM. Corresponds to the {@code -classpath} option.
+     *
+     * @param entries The classpath entries.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder classpath(String... entries) {
         Objects.requireNonNull(entries, "Classpath entries cannot be null");
         this.arguments.add("-classpath " + String.join(File.pathSeparator, entries));
         return this;
     }
 
+    /**
+     * Passes a non-standard option to the debuggee JVM. Corresponds to the {@code -X} option.
+     *
+     * @param option The non-standard option.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder xOption(String option) {
         Objects.requireNonNull(option, "Nonstandard option cannot be null");
         this.arguments.add("-X" + option);
         return this;
     }
 
+    /**
+     * Sets the main class to be debugged.
+     *
+     * @param mainClass The main class name.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder mainClass(String mainClass) {
         Objects.requireNonNull(mainClass, "Main class cannot be null");
         this.mainClass = mainClass;
         return this;
     }
 
+    /**
+     * Adds arguments to be passed to the main class.
+     *
+     * @param args The arguments for the main class.
+     * @return This builder instance.
+     */
     public JdbCLIBuilder mainClassArguments(String... args) {
         Objects.requireNonNull(args, "Main class arguments cannot be null");
         Collections.addAll(this.targetArguments, args);

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JdeprscanCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JdeprscanCLIBuilder.java
@@ -10,6 +10,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A fluent builder for constructing and executing {@code jdeprscan} commands.
+ * <p>
+ * This builder provides methods to configure various options for scanning JAR files
+ * for usages of deprecated APIs, including specifying class paths, releases, and verbosity.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jdeprscan.html">jdeprscan command documentation</a>
+ */
 public class JdeprscanCLIBuilder implements CLIBuilder<Process, JdeprscanCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jdeprscan.exe" : "jdeprscan";
 
@@ -26,6 +35,12 @@ public class JdeprscanCLIBuilder implements CLIBuilder<Process, JdeprscanCLIBuil
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@code JdeprscanCLIBuilder} instance.
+     *
+     * @param jdk The JDK to use for executing the {@code jdeprscan} command.
+     * @return A new builder instance.
+     */
     public static JdeprscanCLIBuilder create(JDK jdk) {
         return new JdeprscanCLIBuilder(jdk);
     }
@@ -68,70 +83,142 @@ public class JdeprscanCLIBuilder implements CLIBuilder<Process, JdeprscanCLIBuil
         return this;
     }
 
+    /**
+     * Specifies the class path for scanning. Corresponds to the {@code --class-path} option.
+     *
+     * @param paths The class path entries.
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder classPath(String... paths) {
         Objects.requireNonNull(paths, "Class path entries cannot be null");
         this.arguments.add("--class-path " + String.join(File.pathSeparator, paths));
         return this;
     }
 
+    /**
+     * Specifies the class path for scanning. Corresponds to the {@code --class-path} option.
+     *
+     * @param paths The class path entries.
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder classPath(Path... paths) {
         Objects.requireNonNull(paths, "Class path entries cannot be null");
         return classPath(Arrays.stream(paths).map(Path::toString).toArray(String[]::new));
     }
 
+    /**
+     * Scans for APIs that are deprecated for removal. Corresponds to the {@code --for-removal} option.
+     *
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder forRemovalOnly() {
         this.arguments.add("--for-removal");
         return this;
     }
 
+    /**
+     * Displays full version information. Corresponds to the {@code --full-version} option.
+     *
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder fullVersion() {
         this.arguments.add("--full-version");
         return this;
     }
 
+    /**
+     * Displays the help message. Corresponds to the {@code --help} option.
+     *
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder help() {
         this.arguments.add("--help");
         return this;
     }
 
+    /**
+     * Lists all deprecated APIs. Corresponds to the {@code --list} option.
+     *
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder listDeprecatedApis() {
         this.arguments.add("--list");
         return this;
     }
 
+    /**
+     * Specifies the Java SE release version to scan against. Corresponds to the {@code --release} option.
+     *
+     * @param release The release version.
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder release(int release) {
         this.arguments.add("--release " + release);
         return this;
     }
 
+    /**
+     * Specifies the Java SE release version to scan against. Corresponds to the {@code --release} option.
+     *
+     * @param release The release version.
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder release(String release) {
         Objects.requireNonNull(release, "Release cannot be null");
         this.arguments.add("--release " + release);
         return this;
     }
 
+    /**
+     * Enables verbose output. Corresponds to the {@code --verbose} option.
+     *
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder verbose() {
         this.arguments.add("--verbose");
         return this;
     }
 
+    /**
+     * Displays version information. Corresponds to the {@code --version} option.
+     *
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder version() {
         this.arguments.add("--version");
         return this;
     }
 
+    /**
+     * Adds a target (JAR file, class file, or directory) to scan.
+     *
+     * @param path The path to the target.
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder addTarget(Path path) {
         Objects.requireNonNull(path, "Target path cannot be null");
         this.targets.add(path.toString());
         return this;
     }
 
+    /**
+     * Adds a target (JAR file, class file, or directory) to scan.
+     *
+     * @param classOrDir The class name or directory path.
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder addTarget(String classOrDir) {
         Objects.requireNonNull(classOrDir, "Target cannot be null");
         this.targets.add(classOrDir);
         return this;
     }
 
+    /**
+     * Adds multiple targets (JAR files, class files, or directories) to scan.
+     *
+     * @param targets The targets to add.
+     * @return This builder instance.
+     */
     public JdeprscanCLIBuilder addTargets(String... targets) {
         Objects.requireNonNull(targets, "Targets cannot be null");
         Collections.addAll(this.targets, targets);

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JdeprscanCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JdeprscanCLIBuilder.java
@@ -1,0 +1,171 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JdeprscanCLIBuilder implements CLIBuilder<Process, JdeprscanCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jdeprscan.exe" : "jdeprscan";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<String> targets = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private JdeprscanCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JdeprscanCLIBuilder create(JDK jdk) {
+        return new JdeprscanCLIBuilder(jdk);
+    }
+
+    @Override
+    public JdeprscanCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JdeprscanCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JdeprscanCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JdeprscanCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JdeprscanCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JdeprscanCLIBuilder classPath(String... paths) {
+        Objects.requireNonNull(paths, "Class path entries cannot be null");
+        this.arguments.add("--class-path " + String.join(File.pathSeparator, paths));
+        return this;
+    }
+
+    public JdeprscanCLIBuilder classPath(Path... paths) {
+        Objects.requireNonNull(paths, "Class path entries cannot be null");
+        return classPath(Arrays.stream(paths).map(Path::toString).toArray(String[]::new));
+    }
+
+    public JdeprscanCLIBuilder forRemovalOnly() {
+        this.arguments.add("--for-removal");
+        return this;
+    }
+
+    public JdeprscanCLIBuilder fullVersion() {
+        this.arguments.add("--full-version");
+        return this;
+    }
+
+    public JdeprscanCLIBuilder help() {
+        this.arguments.add("--help");
+        return this;
+    }
+
+    public JdeprscanCLIBuilder listDeprecatedApis() {
+        this.arguments.add("--list");
+        return this;
+    }
+
+    public JdeprscanCLIBuilder release(int release) {
+        this.arguments.add("--release " + release);
+        return this;
+    }
+
+    public JdeprscanCLIBuilder release(String release) {
+        Objects.requireNonNull(release, "Release cannot be null");
+        this.arguments.add("--release " + release);
+        return this;
+    }
+
+    public JdeprscanCLIBuilder verbose() {
+        this.arguments.add("--verbose");
+        return this;
+    }
+
+    public JdeprscanCLIBuilder version() {
+        this.arguments.add("--version");
+        return this;
+    }
+
+    public JdeprscanCLIBuilder addTarget(Path path) {
+        Objects.requireNonNull(path, "Target path cannot be null");
+        this.targets.add(path.toString());
+        return this;
+    }
+
+    public JdeprscanCLIBuilder addTarget(String classOrDir) {
+        Objects.requireNonNull(classOrDir, "Target cannot be null");
+        this.targets.add(classOrDir);
+        return this;
+    }
+
+    public JdeprscanCLIBuilder addTargets(String... targets) {
+        Objects.requireNonNull(targets, "Targets cannot be null");
+        Collections.addAll(this.targets, targets);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        command.addAll(targets);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jdeprscan");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jdeprscan process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JdepsCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JdepsCLIBuilder.java
@@ -1,0 +1,338 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JdepsCLIBuilder implements CLIBuilder<Process, JdepsCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jdeps.exe" : "jdeps";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<String> targets = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private JdepsCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JdepsCLIBuilder create(JDK jdk) {
+        return new JdepsCLIBuilder(jdk);
+    }
+
+    @Override
+    public JdepsCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JdepsCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JdepsCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JdepsCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JdepsCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JdepsCLIBuilder help() {
+        this.arguments.add("--help");
+        return this;
+    }
+
+    public JdepsCLIBuilder dotOutput(Path directory) {
+        Objects.requireNonNull(directory, "DOT output directory cannot be null");
+        this.arguments.add("--dot-output " + directory);
+        return this;
+    }
+
+    public JdepsCLIBuilder summary() {
+        this.arguments.add("--summary");
+        return this;
+    }
+
+    public JdepsCLIBuilder verbose() {
+        this.arguments.add("--verbose");
+        return this;
+    }
+
+    public JdepsCLIBuilder verbosePackages() {
+        this.arguments.add("-verbose:package");
+        return this;
+    }
+
+    public JdepsCLIBuilder verboseClasses() {
+        this.arguments.add("-verbose:class");
+        return this;
+    }
+
+    public JdepsCLIBuilder apiOnly() {
+        this.arguments.add("--api-only");
+        return this;
+    }
+
+    public JdepsCLIBuilder jdkInternals() {
+        this.arguments.add("--jdk-internals");
+        return this;
+    }
+
+    public JdepsCLIBuilder classPath(String... pathEntries) {
+        Objects.requireNonNull(pathEntries, "Classpath entries cannot be null");
+        this.arguments.add("--class-path " + String.join(File.pathSeparator, pathEntries));
+        return this;
+    }
+
+    public JdepsCLIBuilder classPath(Path... pathEntries) {
+        Objects.requireNonNull(pathEntries, "Classpath entries cannot be null");
+        return classPath(Arrays.stream(pathEntries).map(Path::toString).toArray(String[]::new));
+    }
+
+    public JdepsCLIBuilder modulePath(String... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
+        this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
+        return this;
+    }
+
+    public JdepsCLIBuilder modulePath(Path... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
+        return modulePath(Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new));
+    }
+
+    public JdepsCLIBuilder upgradeModulePath(String... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Upgrade module path entries cannot be null");
+        this.arguments.add("--upgrade-module-path " + String.join(File.pathSeparator, modulePaths));
+        return this;
+    }
+
+    public JdepsCLIBuilder systemModulePath(String javaHome) {
+        Objects.requireNonNull(javaHome, "Java home cannot be null");
+        this.arguments.add("--system " + javaHome);
+        return this;
+    }
+
+    public JdepsCLIBuilder addModules(String... modules) {
+        Objects.requireNonNull(modules, "Module names cannot be null");
+        this.arguments.add("--add-modules " + String.join(",", modules));
+        return this;
+    }
+
+    public JdepsCLIBuilder multiRelease(String version) {
+        Objects.requireNonNull(version, "Multi-release version cannot be null");
+        this.arguments.add("--multi-release " + version);
+        return this;
+    }
+
+    public JdepsCLIBuilder multiRelease(int version) {
+        return multiRelease(Integer.toString(version));
+    }
+
+    public JdepsCLIBuilder quiet() {
+        this.arguments.add("--quiet");
+        return this;
+    }
+
+    public JdepsCLIBuilder version() {
+        this.arguments.add("--version");
+        return this;
+    }
+
+    public JdepsCLIBuilder module(String moduleName) {
+        Objects.requireNonNull(moduleName, "Module name cannot be null");
+        this.arguments.add("--module " + moduleName);
+        return this;
+    }
+
+    public JdepsCLIBuilder generateModuleInfo(Path directory) {
+        Objects.requireNonNull(directory, "Directory cannot be null");
+        this.arguments.add("--generate-module-info " + directory);
+        return this;
+    }
+
+    public JdepsCLIBuilder generateOpenModule(Path directory) {
+        Objects.requireNonNull(directory, "Directory cannot be null");
+        this.arguments.add("--generate-open-module " + directory);
+        return this;
+    }
+
+    public JdepsCLIBuilder checkModules(String... modules) {
+        Objects.requireNonNull(modules, "Modules cannot be null");
+        this.arguments.add("--check " + String.join(",", modules));
+        return this;
+    }
+
+    public JdepsCLIBuilder listDependences() {
+        this.arguments.add("--list-deps");
+        return this;
+    }
+
+    public JdepsCLIBuilder listReducedDependences() {
+        this.arguments.add("--list-reduced-deps");
+        return this;
+    }
+
+    public JdepsCLIBuilder printModuleDependences() {
+        this.arguments.add("--print-module-deps");
+        return this;
+    }
+
+    public JdepsCLIBuilder ignoreMissingDependences() {
+        this.arguments.add("--ignore-missing-deps");
+        return this;
+    }
+
+    public JdepsCLIBuilder packageFilter(String packageName) {
+        Objects.requireNonNull(packageName, "Package name cannot be null");
+        this.arguments.add("--package " + packageName);
+        return this;
+    }
+
+    public JdepsCLIBuilder regexFilter(String regex) {
+        Objects.requireNonNull(regex, "Regex cannot be null");
+        this.arguments.add("--regex " + regex);
+        return this;
+    }
+
+    public JdepsCLIBuilder requireFilter(String moduleName) {
+        Objects.requireNonNull(moduleName, "Module name cannot be null");
+        this.arguments.add("--require " + moduleName);
+        return this;
+    }
+
+    public JdepsCLIBuilder filter(String pattern) {
+        Objects.requireNonNull(pattern, "Filter pattern cannot be null");
+        this.arguments.add("--filter " + pattern);
+        return this;
+    }
+
+    public JdepsCLIBuilder filterPackage() {
+        this.arguments.add("-filter:package");
+        return this;
+    }
+
+    public JdepsCLIBuilder filterArchive() {
+        this.arguments.add("-filter:archive");
+        return this;
+    }
+
+    public JdepsCLIBuilder filterModule() {
+        this.arguments.add("-filter:module");
+        return this;
+    }
+
+    public JdepsCLIBuilder filterNone() {
+        this.arguments.add("-filter:none");
+        return this;
+    }
+
+    public JdepsCLIBuilder missingDependences() {
+        this.arguments.add("--missing-deps");
+        return this;
+    }
+
+    public JdepsCLIBuilder includePattern(String regex) {
+        Objects.requireNonNull(regex, "Include pattern cannot be null");
+        this.arguments.add("-include " + regex);
+        return this;
+    }
+
+    public JdepsCLIBuilder recursive() {
+        this.arguments.add("--recursive");
+        return this;
+    }
+
+    public JdepsCLIBuilder nonRecursive() {
+        this.arguments.add("--no-recursive");
+        return this;
+    }
+
+    public JdepsCLIBuilder inverse() {
+        this.arguments.add("--inverse");
+        return this;
+    }
+
+    public JdepsCLIBuilder compileTimeView() {
+        this.arguments.add("--compile-time");
+        return this;
+    }
+
+    public JdepsCLIBuilder addTarget(Path target) {
+        Objects.requireNonNull(target, "Target cannot be null");
+        this.targets.add(target.toString());
+        return this;
+    }
+
+    public JdepsCLIBuilder addTarget(String target) {
+        Objects.requireNonNull(target, "Target cannot be null");
+        this.targets.add(target);
+        return this;
+    }
+
+    public JdepsCLIBuilder addTargets(String... targetEntries) {
+        Objects.requireNonNull(targetEntries, "Targets cannot be null");
+        Collections.addAll(this.targets, targetEntries);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        command.addAll(targets);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jdeps");
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jdeps process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JdepsCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JdepsCLIBuilder.java
@@ -10,6 +10,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A fluent builder for constructing and executing {@code jdeps} commands.
+ * <p>
+ * This builder provides methods to analyze class dependencies, including options for
+ * output format, classpath and module path settings, and various filtering capabilities.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jdeps.html">jdeps command documentation</a>
+ */
 public class JdepsCLIBuilder implements CLIBuilder<Process, JdepsCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jdeps.exe" : "jdeps";
 
@@ -26,6 +35,12 @@ public class JdepsCLIBuilder implements CLIBuilder<Process, JdepsCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@code JdepsCLIBuilder} instance.
+     *
+     * @param jdk The JDK to use for executing the {@code jdeps} command.
+     * @return A new builder instance.
+     */
     public static JdepsCLIBuilder create(JDK jdk) {
         return new JdepsCLIBuilder(jdk);
     }
@@ -68,238 +83,480 @@ public class JdepsCLIBuilder implements CLIBuilder<Process, JdepsCLIBuilder> {
         return this;
     }
 
+    /**
+     * Displays the help message. Corresponds to the {@code --help} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder help() {
         this.arguments.add("--help");
         return this;
     }
 
+    /**
+     * Specifies the directory for DOT file output. Corresponds to the {@code --dot-output} option.
+     *
+     * @param directory The output directory.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder dotOutput(Path directory) {
         Objects.requireNonNull(directory, "DOT output directory cannot be null");
         this.arguments.add("--dot-output " + directory);
         return this;
     }
 
+    /**
+     * Prints a summary of the dependencies. Corresponds to the {@code --summary} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder summary() {
         this.arguments.add("--summary");
         return this;
     }
 
+    /**
+     * Enables verbose output. Corresponds to the {@code --verbose} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder verbose() {
         this.arguments.add("--verbose");
         return this;
     }
 
+    /**
+     * Enables verbose output for package-level dependencies. Corresponds to the {@code -verbose:package} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder verbosePackages() {
         this.arguments.add("-verbose:package");
         return this;
     }
 
+    /**
+     * Enables verbose output for class-level dependencies. Corresponds to the {@code -verbose:class} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder verboseClasses() {
         this.arguments.add("-verbose:class");
         return this;
     }
 
+    /**
+     * Shows only API dependencies. Corresponds to the {@code --api-only} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder apiOnly() {
         this.arguments.add("--api-only");
         return this;
     }
 
+    /**
+     * Shows dependencies on internal JDK APIs. Corresponds to the {@code --jdk-internals} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder jdkInternals() {
         this.arguments.add("--jdk-internals");
         return this;
     }
 
+    /**
+     * Specifies the class path for analyzing dependencies. Corresponds to the {@code --class-path} option.
+     *
+     * @param pathEntries The class path entries.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder classPath(String... pathEntries) {
         Objects.requireNonNull(pathEntries, "Classpath entries cannot be null");
         this.arguments.add("--class-path " + String.join(File.pathSeparator, pathEntries));
         return this;
     }
 
+    /**
+     * Specifies the class path for analyzing dependencies. Corresponds to the {@code --class-path} option.
+     *
+     * @param pathEntries The class path entries.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder classPath(Path... pathEntries) {
         Objects.requireNonNull(pathEntries, "Classpath entries cannot be null");
         return classPath(Arrays.stream(pathEntries).map(Path::toString).toArray(String[]::new));
     }
 
+    /**
+     * Specifies the module path for analyzing dependencies. Corresponds to the {@code --module-path} option.
+     *
+     * @param modulePaths The module path entries.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder modulePath(String... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
         this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
         return this;
     }
 
+    /**
+     * Specifies the module path for analyzing dependencies. Corresponds to the {@code --module-path} option.
+     *
+     * @param modulePaths The module path entries.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder modulePath(Path... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
         return modulePath(Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new));
     }
 
+    /**
+     * Specifies the upgrade module path. Corresponds to the {@code --upgrade-module-path} option.
+     *
+     * @param modulePaths The upgrade module path entries.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder upgradeModulePath(String... modulePaths) {
         Objects.requireNonNull(modulePaths, "Upgrade module path entries cannot be null");
         this.arguments.add("--upgrade-module-path " + String.join(File.pathSeparator, modulePaths));
         return this;
     }
 
+    /**
+     * Specifies the system module path. Corresponds to the {@code --system} option.
+     *
+     * @param javaHome The path to the Java home directory.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder systemModulePath(String javaHome) {
         Objects.requireNonNull(javaHome, "Java home cannot be null");
         this.arguments.add("--system " + javaHome);
         return this;
     }
 
+    /**
+     * Adds modules to the module graph. Corresponds to the {@code --add-modules} option.
+     *
+     * @param modules The names of the modules to add.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder addModules(String... modules) {
         Objects.requireNonNull(modules, "Module names cannot be null");
         this.arguments.add("--add-modules " + String.join(",", modules));
         return this;
     }
 
+    /**
+     * Specifies the multi-release JAR file version. Corresponds to the {@code --multi-release} option.
+     *
+     * @param version The multi-release version.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder multiRelease(String version) {
         Objects.requireNonNull(version, "Multi-release version cannot be null");
         this.arguments.add("--multi-release " + version);
         return this;
     }
 
+    /**
+     * Specifies the multi-release JAR file version. Corresponds to the {@code --multi-release} option.
+     *
+     * @param version The multi-release version.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder multiRelease(int version) {
         return multiRelease(Integer.toString(version));
     }
 
+    /**
+     * Suppresses output. Corresponds to the {@code --quiet} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder quiet() {
         this.arguments.add("--quiet");
         return this;
     }
 
+    /**
+     * Prints version information and exits. Corresponds to the {@code --version} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder version() {
         this.arguments.add("--version");
         return this;
     }
 
+    /**
+     * Specifies the module to analyze. Corresponds to the {@code --module} option.
+     *
+     * @param moduleName The name of the module.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder module(String moduleName) {
         Objects.requireNonNull(moduleName, "Module name cannot be null");
         this.arguments.add("--module " + moduleName);
         return this;
     }
 
+    /**
+     * Generates a {@code module-info.java} file in the specified directory. Corresponds to the {@code --generate-module-info} option.
+     *
+     * @param directory The output directory.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder generateModuleInfo(Path directory) {
         Objects.requireNonNull(directory, "Directory cannot be null");
         this.arguments.add("--generate-module-info " + directory);
         return this;
     }
 
+    /**
+     * Generates an {@code open module} declaration in the specified directory. Corresponds to the {@code --generate-open-module} option.
+     *
+     * @param directory The output directory.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder generateOpenModule(Path directory) {
         Objects.requireNonNull(directory, "Directory cannot be null");
         this.arguments.add("--generate-open-module " + directory);
         return this;
     }
 
+    /**
+     * Checks the specified modules for dependencies. Corresponds to the {@code --check} option.
+     *
+     * @param modules The modules to check.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder checkModules(String... modules) {
         Objects.requireNonNull(modules, "Modules cannot be null");
         this.arguments.add("--check " + String.join(",", modules));
         return this;
     }
 
+    /**
+     * Lists all dependencies. Corresponds to the {@code --list-deps} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder listDependences() {
         this.arguments.add("--list-deps");
         return this;
     }
 
+    /**
+     * Lists reduced dependencies. Corresponds to the {@code --list-reduced-deps} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder listReducedDependences() {
         this.arguments.add("--list-reduced-deps");
         return this;
     }
 
+    /**
+     * Prints module dependencies. Corresponds to the {@code --print-module-deps} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder printModuleDependences() {
         this.arguments.add("--print-module-deps");
         return this;
     }
 
+    /**
+     * Ignores missing dependencies. Corresponds to the {@code --ignore-missing-deps} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder ignoreMissingDependences() {
         this.arguments.add("--ignore-missing-deps");
         return this;
     }
 
+    /**
+     * Filters by package name. Corresponds to the {@code --package} option.
+     *
+     * @param packageName The package name to filter by.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder packageFilter(String packageName) {
         Objects.requireNonNull(packageName, "Package name cannot be null");
         this.arguments.add("--package " + packageName);
         return this;
     }
 
+    /**
+     * Filters by a regular expression. Corresponds to the {@code --regex} option.
+     *
+     * @param regex The regular expression to filter by.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder regexFilter(String regex) {
         Objects.requireNonNull(regex, "Regex cannot be null");
         this.arguments.add("--regex " + regex);
         return this;
     }
 
+    /**
+     * Filters by required module. Corresponds to the {@code --require} option.
+     *
+     * @param moduleName The module name to filter by.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder requireFilter(String moduleName) {
         Objects.requireNonNull(moduleName, "Module name cannot be null");
         this.arguments.add("--require " + moduleName);
         return this;
     }
 
+    /**
+     * Filters the output by a specified pattern. Corresponds to the {@code --filter} option.
+     *
+     * @param pattern The filter pattern.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder filter(String pattern) {
         Objects.requireNonNull(pattern, "Filter pattern cannot be null");
         this.arguments.add("--filter " + pattern);
         return this;
     }
 
+    /**
+     * Filters output to show only package-level dependencies. Corresponds to the {@code -filter:package} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder filterPackage() {
         this.arguments.add("-filter:package");
         return this;
     }
 
+    /**
+     * Filters output to show only archive-level dependencies. Corresponds to the {@code -filter:archive} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder filterArchive() {
         this.arguments.add("-filter:archive");
         return this;
     }
 
+    /**
+     * Filters output to show only module-level dependencies. Corresponds to the {@code -filter:module} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder filterModule() {
         this.arguments.add("-filter:module");
         return this;
     }
 
+    /**
+     * Disables all filtering. Corresponds to the {@code -filter:none} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder filterNone() {
         this.arguments.add("-filter:none");
         return this;
     }
 
+    /**
+     * Shows missing dependencies. Corresponds to the {@code --missing-deps} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder missingDependences() {
         this.arguments.add("--missing-deps");
         return this;
     }
 
+    /**
+     * Includes dependencies matching the specified regular expression. Corresponds to the {@code -include} option.
+     *
+     * @param regex The regular expression to include.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder includePattern(String regex) {
         Objects.requireNonNull(regex, "Include pattern cannot be null");
         this.arguments.add("-include " + regex);
         return this;
     }
 
+    /**
+     * Recursively traverses dependencies. Corresponds to the {@code --recursive} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder recursive() {
         this.arguments.add("--recursive");
         return this;
     }
 
+    /**
+     * Disables recursive traversal of dependencies. Corresponds to the {@code --no-recursive} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder nonRecursive() {
         this.arguments.add("--no-recursive");
         return this;
     }
 
+    /**
+     * Shows the inverse of the dependencies. Corresponds to the {@code --inverse} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder inverse() {
         this.arguments.add("--inverse");
         return this;
     }
 
+    /**
+     * Shows the compile-time view of dependencies. Corresponds to the {@code --compile-time} option.
+     *
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder compileTimeView() {
         this.arguments.add("--compile-time");
         return this;
     }
 
+    /**
+     * Adds a target (JAR file, class file, or directory) to analyze.
+     *
+     * @param target The path to the target.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder addTarget(Path target) {
         Objects.requireNonNull(target, "Target cannot be null");
         this.targets.add(target.toString());
         return this;
     }
 
+    /**
+     * Adds a target (JAR file, class file, or directory) to analyze.
+     *
+     * @param target The target to add.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder addTarget(String target) {
         Objects.requireNonNull(target, "Target cannot be null");
         this.targets.add(target);
         return this;
     }
 
+    /**
+     * Adds multiple targets (JAR files, class files, or directories) to analyze.
+     *
+     * @param targetEntries The targets to add.
+     * @return This builder instance.
+     */
     public JdepsCLIBuilder addTargets(String... targetEntries) {
         Objects.requireNonNull(targetEntries, "Targets cannot be null");
         Collections.addAll(this.targets, targetEntries);

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JfrCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JfrCLIBuilder.java
@@ -1,0 +1,374 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jfr.exe" : "jfr";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private Subcommand subcommand;
+
+    private JfrCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JfrCLIBuilder create(JDK jdk) {
+        return new JfrCLIBuilder(jdk);
+    }
+
+    @Override
+    public JfrCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JfrCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JfrCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JfrCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JfrCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JfrCLIBuilder print(Path file) {
+        Objects.requireNonNull(file, "Recording file cannot be null");
+        this.subcommand = Subcommand.PRINT;
+        this.arguments.add(file.toString());
+        return this;
+    }
+
+    public JfrCLIBuilder view(String viewName, Path file) {
+        Objects.requireNonNull(viewName, "View name cannot be null");
+        Objects.requireNonNull(file, "Recording file cannot be null");
+        this.subcommand = Subcommand.VIEW;
+        this.arguments.add(viewName);
+        this.arguments.add(file.toString());
+        return this;
+    }
+
+    public JfrCLIBuilder configure() {
+        this.subcommand = Subcommand.CONFIGURE;
+        return this;
+    }
+
+    public JfrCLIBuilder metadata(Path file) {
+        Objects.requireNonNull(file, "Recording file cannot be null");
+        this.subcommand = Subcommand.METADATA;
+        this.arguments.add(file.toString());
+        return this;
+    }
+
+    public JfrCLIBuilder metadata() {
+        this.subcommand = Subcommand.METADATA;
+        return this;
+    }
+
+    public JfrCLIBuilder summary(Path file) {
+        Objects.requireNonNull(file, "Recording file cannot be null");
+        this.subcommand = Subcommand.SUMMARY;
+        this.arguments.add(file.toString());
+        return this;
+    }
+
+    public JfrCLIBuilder scrub(Path inputFile, Path outputFile) {
+        Objects.requireNonNull(inputFile, "Input file cannot be null");
+        Objects.requireNonNull(outputFile, "Output file cannot be null");
+        this.subcommand = Subcommand.SCRUB;
+        this.arguments.add(inputFile.toString());
+        this.arguments.add(outputFile.toString());
+        return this;
+    }
+
+    public JfrCLIBuilder scrub(Path inputFile) {
+        Objects.requireNonNull(inputFile, "Input file cannot be null");
+        this.subcommand = Subcommand.SCRUB;
+        this.arguments.add(inputFile.toString());
+        return this;
+    }
+
+    public JfrCLIBuilder assemble(Path repository, Path file) {
+        Objects.requireNonNull(repository, "Repository cannot be null");
+        Objects.requireNonNull(file, "Output file cannot be null");
+        this.subcommand = Subcommand.ASSEMBLE;
+        this.arguments.add(repository.toString());
+        this.arguments.add(file.toString());
+        return this;
+    }
+
+    public JfrCLIBuilder disassemble(Path file) {
+        Objects.requireNonNull(file, "Recording file cannot be null");
+        this.subcommand = Subcommand.DISASSEMBLE;
+        this.arguments.add(file.toString());
+        return this;
+    }
+
+    public JfrCLIBuilder printXml() {
+        this.arguments.add("--xml");
+        return this;
+    }
+
+    public JfrCLIBuilder printJson() {
+        this.arguments.add("--json");
+        return this;
+    }
+
+    public JfrCLIBuilder printExact() {
+        this.arguments.add("--exact");
+        return this;
+    }
+
+    public JfrCLIBuilder categoriesFilter(String filter) {
+        Objects.requireNonNull(filter, "Category filter cannot be null");
+        this.arguments.add("--categories " + filter);
+        return this;
+    }
+
+    public JfrCLIBuilder eventFilter(String filter) {
+        Objects.requireNonNull(filter, "Event filter cannot be null");
+        this.arguments.add("--events " + filter);
+        return this;
+    }
+
+    public JfrCLIBuilder stackDepth(int depth) {
+        if (depth < 0)
+            throw new IllegalArgumentException("Stack depth cannot be negative");
+
+        this.arguments.add("--stack-depth " + depth);
+        return this;
+    }
+
+    public JfrCLIBuilder viewVerbose() {
+        this.arguments.add("--verbose");
+        return this;
+    }
+
+    public JfrCLIBuilder viewWidth(int width) {
+        this.arguments.add("--width " + width);
+        return this;
+    }
+
+    public JfrCLIBuilder viewTruncateMode(String mode) {
+        Objects.requireNonNull(mode, "Truncate mode cannot be null");
+        this.arguments.add("--truncate " + mode);
+        return this;
+    }
+
+    public JfrCLIBuilder viewCellHeight(int height) {
+        this.arguments.add("--cell-height " + height);
+        return this;
+    }
+
+    public JfrCLIBuilder configureInteractive() {
+        this.arguments.add("--interactive");
+        return this;
+    }
+
+    public JfrCLIBuilder configureVerbose() {
+        this.arguments.add("--verbose");
+        return this;
+    }
+
+    public JfrCLIBuilder configureInput(String files) {
+        Objects.requireNonNull(files, "Input files cannot be null");
+        this.arguments.add("--input " + files);
+        return this;
+    }
+
+    public JfrCLIBuilder configureOutput(Path file) {
+        Objects.requireNonNull(file, "Output file cannot be null");
+        this.arguments.add("--output " + file);
+        return this;
+    }
+
+    public JfrCLIBuilder configureOption(String option, String value) {
+        Objects.requireNonNull(option, "Option cannot be null");
+        Objects.requireNonNull(value, "Value cannot be null");
+        this.arguments.add(option + "=" + value);
+        return this;
+    }
+
+    public JfrCLIBuilder configureEventSetting(String setting, String value) {
+        Objects.requireNonNull(setting, "Setting cannot be null");
+        Objects.requireNonNull(value, "Value cannot be null");
+        this.arguments.add(setting + "=" + value);
+        return this;
+    }
+
+    public JfrCLIBuilder metadataCategoryFilter(String filter) {
+        Objects.requireNonNull(filter, "Category filter cannot be null");
+        this.arguments.add("--categories " + filter);
+        return this;
+    }
+
+    public JfrCLIBuilder metadataEventFilter(String filter) {
+        Objects.requireNonNull(filter, "Event filter cannot be null");
+        this.arguments.add("--events " + filter);
+        return this;
+    }
+
+    public JfrCLIBuilder scrubIncludeEvents(String filter) {
+        Objects.requireNonNull(filter, "Include events filter cannot be null");
+        this.arguments.add("--include-events " + filter);
+        return this;
+    }
+
+    public JfrCLIBuilder scrubExcludeEvents(String filter) {
+        Objects.requireNonNull(filter, "Exclude events filter cannot be null");
+        this.arguments.add("--exclude-events " + filter);
+        return this;
+    }
+
+    public JfrCLIBuilder scrubIncludeCategories(String filter) {
+        Objects.requireNonNull(filter, "Include categories filter cannot be null");
+        this.arguments.add("--include-categories " + filter);
+        return this;
+    }
+
+    public JfrCLIBuilder scrubExcludeCategories(String filter) {
+        Objects.requireNonNull(filter, "Exclude categories filter cannot be null");
+        this.arguments.add("--exclude-categories " + filter);
+        return this;
+    }
+
+    public JfrCLIBuilder scrubIncludeThreads(String filter) {
+        Objects.requireNonNull(filter, "Include threads filter cannot be null");
+        this.arguments.add("--include-threads " + filter);
+        return this;
+    }
+
+    public JfrCLIBuilder scrubExcludeThreads(String filter) {
+        Objects.requireNonNull(filter, "Exclude threads filter cannot be null");
+        this.arguments.add("--exclude-threads " + filter);
+        return this;
+    }
+
+    public JfrCLIBuilder disassembleOutput(Path directory) {
+        Objects.requireNonNull(directory, "Output directory cannot be null");
+        this.arguments.add("--output " + directory);
+        return this;
+    }
+
+    public JfrCLIBuilder disassembleMaxChunks(int chunks) {
+        if (chunks <= 0)
+            throw new IllegalArgumentException("Max chunks must be positive");
+
+        this.arguments.add("--max-chunks " + chunks);
+        return this;
+    }
+
+    public JfrCLIBuilder disassembleMaxSize(String size) {
+        Objects.requireNonNull(size, "Max size cannot be null");
+        this.arguments.add("--max-size " + size);
+        return this;
+    }
+
+    public JfrCLIBuilder version() {
+        this.subcommand = Subcommand.VERSION;
+        return this;
+    }
+
+    public JfrCLIBuilder help() {
+        this.subcommand = Subcommand.HELP;
+        return this;
+    }
+
+    public JfrCLIBuilder help(String subcommand) {
+        Objects.requireNonNull(subcommand, "Subcommand cannot be null");
+        this.subcommand = Subcommand.HELP;
+        this.arguments.add(subcommand);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        if (subcommand == null)
+            throw new IllegalStateException("A jfr subcommand must be selected.");
+
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.add(subcommand.command());
+        command.addAll(arguments);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jfr");
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jfr process", exception);
+        }
+    }
+
+    private enum Subcommand {
+        PRINT("print"),
+        VIEW("view"),
+        CONFIGURE("configure"),
+        METADATA("metadata"),
+        SUMMARY("summary"),
+        SCRUB("scrub"),
+        ASSEMBLE("assemble"),
+        DISASSEMBLE("disassemble"),
+        VERSION("version"),
+        HELP("--help");
+
+        private final String command;
+
+        Subcommand(String command) {
+            this.command = command;
+        }
+
+        public String command() {
+            return command;
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JfrCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JfrCLIBuilder.java
@@ -9,6 +9,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A fluent builder for constructing and executing {@code jfr} commands.
+ * <p>
+ * This builder provides methods to interact with Java Flight Recorder (JFR) recordings,
+ * allowing for printing, viewing, configuring, and analyzing JFR data.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jfr.html">jfr command documentation</a>
+ */
 public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jfr.exe" : "jfr";
 
@@ -25,6 +34,12 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@code JfrCLIBuilder} instance.
+     *
+     * @param jdk The JDK to use for executing the {@code jfr} command.
+     * @return A new builder instance.
+     */
     public static JfrCLIBuilder create(JDK jdk) {
         return new JfrCLIBuilder(jdk);
     }
@@ -67,6 +82,13 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a "print" subcommand to the JFR CLI with the specified recording file.
+     *
+     * @param file the recording file to print; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the file is null
+     */
     public JfrCLIBuilder print(Path file) {
         Objects.requireNonNull(file, "Recording file cannot be null");
         this.subcommand = Subcommand.PRINT;
@@ -74,6 +96,14 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a "view" subcommand to the JFR CLI with the specified view name and recording file.
+     *
+     * @param viewName the name of the view; must not be null
+     * @param file     the recording file to view; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the view name or file is null
+     */
     public JfrCLIBuilder view(String viewName, Path file) {
         Objects.requireNonNull(viewName, "View name cannot be null");
         Objects.requireNonNull(file, "Recording file cannot be null");
@@ -83,11 +113,23 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a "configure" subcommand to the JFR CLI.
+     *
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder configure() {
         this.subcommand = Subcommand.CONFIGURE;
         return this;
     }
 
+    /**
+     * Adds a "metadata" subcommand to the JFR CLI with the specified recording file.
+     *
+     * @param file the recording file for metadata; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the file is null
+     */
     public JfrCLIBuilder metadata(Path file) {
         Objects.requireNonNull(file, "Recording file cannot be null");
         this.subcommand = Subcommand.METADATA;
@@ -95,11 +137,23 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a "metadata" subcommand to the JFR CLI without specifying a file.
+     *
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder metadata() {
         this.subcommand = Subcommand.METADATA;
         return this;
     }
 
+    /**
+     * Adds a "summary" subcommand to the JFR CLI with the specified recording file.
+     *
+     * @param file the recording file for the summary; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the file is null
+     */
     public JfrCLIBuilder summary(Path file) {
         Objects.requireNonNull(file, "Recording file cannot be null");
         this.subcommand = Subcommand.SUMMARY;
@@ -107,6 +161,14 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a "scrub" subcommand to the JFR CLI with the specified input and output files.
+     *
+     * @param inputFile  the input file to scrub; must not be null
+     * @param outputFile the output file to save the scrubbed data; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the input or output file is null
+     */
     public JfrCLIBuilder scrub(Path inputFile, Path outputFile) {
         Objects.requireNonNull(inputFile, "Input file cannot be null");
         Objects.requireNonNull(outputFile, "Output file cannot be null");
@@ -116,6 +178,13 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a "scrub" subcommand to the JFR CLI with the specified input file.
+     *
+     * @param inputFile the input file to scrub; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the input file is null
+     */
     public JfrCLIBuilder scrub(Path inputFile) {
         Objects.requireNonNull(inputFile, "Input file cannot be null");
         this.subcommand = Subcommand.SCRUB;
@@ -123,6 +192,14 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds an "assemble" subcommand to the JFR CLI with the specified repository and output file.
+     *
+     * @param repository the repository path; must not be null
+     * @param file       the output file to save the assembled data; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the repository or output file is null
+     */
     public JfrCLIBuilder assemble(Path repository, Path file) {
         Objects.requireNonNull(repository, "Repository cannot be null");
         Objects.requireNonNull(file, "Output file cannot be null");
@@ -132,6 +209,13 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a "disassemble" subcommand to the JFR CLI with the specified recording file.
+     *
+     * @param file the recording file to disassemble; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the file is null
+     */
     public JfrCLIBuilder disassemble(Path file) {
         Objects.requireNonNull(file, "Recording file cannot be null");
         this.subcommand = Subcommand.DISASSEMBLE;
@@ -139,33 +223,69 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds the "--xml" option to the current subcommand.
+     *
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder printXml() {
         this.arguments.add("--xml");
         return this;
     }
 
+    /**
+     * Adds the "--json" option to the current subcommand.
+     *
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder printJson() {
         this.arguments.add("--json");
         return this;
     }
 
+    /**
+     * Adds the "--exact" option to the current subcommand.
+     *
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder printExact() {
         this.arguments.add("--exact");
         return this;
     }
 
+    /**
+     * Adds a category filter to the current subcommand.
+     *
+     * @param filter the category filter; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the filter is null
+     */
     public JfrCLIBuilder categoriesFilter(String filter) {
         Objects.requireNonNull(filter, "Category filter cannot be null");
         this.arguments.add("--categories " + filter);
         return this;
     }
 
+    /**
+     * Adds an event filter to the current subcommand.
+     *
+     * @param filter the event filter; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the filter is null
+     */
     public JfrCLIBuilder eventFilter(String filter) {
         Objects.requireNonNull(filter, "Event filter cannot be null");
         this.arguments.add("--events " + filter);
         return this;
     }
 
+    /**
+     * Sets the stack depth for the current subcommand.
+     *
+     * @param depth the stack depth; must be non-negative
+     * @return the current `JfrCLIBuilder` instance
+     * @throws IllegalArgumentException if the depth is negative
+     */
     public JfrCLIBuilder stackDepth(int depth) {
         if (depth < 0)
             throw new IllegalArgumentException("Stack depth cannot be negative");
@@ -174,49 +294,105 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds the "--verbose" option to the "view" subcommand.
+     *
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder viewVerbose() {
         this.arguments.add("--verbose");
         return this;
     }
 
+    /**
+     * Sets the width for the "view" subcommand.
+     *
+     * @param width the width value
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder viewWidth(int width) {
         this.arguments.add("--width " + width);
         return this;
     }
 
+    /**
+     * Sets the truncate mode for the "view" subcommand.
+     *
+     * @param mode the truncate mode; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the mode is null
+     */
     public JfrCLIBuilder viewTruncateMode(String mode) {
         Objects.requireNonNull(mode, "Truncate mode cannot be null");
         this.arguments.add("--truncate " + mode);
         return this;
     }
 
+    /**
+     * Sets the cell height for the "view" subcommand.
+     *
+     * @param height the cell height value
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder viewCellHeight(int height) {
         this.arguments.add("--cell-height " + height);
         return this;
     }
 
+    /**
+     * Adds the "--interactive" option to the "configure" subcommand.
+     *
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder configureInteractive() {
         this.arguments.add("--interactive");
         return this;
     }
 
+    /**
+     * Adds the "--verbose" option to the "configure" subcommand.
+     *
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder configureVerbose() {
         this.arguments.add("--verbose");
         return this;
     }
 
+    /**
+     * Sets the input files for the "configure" subcommand.
+     *
+     * @param files the input files; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the files are null
+     */
     public JfrCLIBuilder configureInput(String files) {
         Objects.requireNonNull(files, "Input files cannot be null");
         this.arguments.add("--input " + files);
         return this;
     }
 
+    /**
+     * Sets the output file for the "configure" subcommand.
+     *
+     * @param file the output file; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the file is null
+     */
     public JfrCLIBuilder configureOutput(Path file) {
         Objects.requireNonNull(file, "Output file cannot be null");
         this.arguments.add("--output " + file);
         return this;
     }
 
+    /**
+     * Adds an option and its value to the "configure" subcommand.
+     *
+     * @param option the option name; must not be null
+     * @param value  the option value; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the option or value is null
+     */
     public JfrCLIBuilder configureOption(String option, String value) {
         Objects.requireNonNull(option, "Option cannot be null");
         Objects.requireNonNull(value, "Value cannot be null");
@@ -224,6 +400,14 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds an event setting and its value to the "configure" subcommand.
+     *
+     * @param setting the event setting name; must not be null
+     * @param value   the event setting value; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the setting or value is null
+     */
     public JfrCLIBuilder configureEventSetting(String setting, String value) {
         Objects.requireNonNull(setting, "Setting cannot be null");
         Objects.requireNonNull(value, "Value cannot be null");
@@ -231,60 +415,130 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a category filter to the "metadata" subcommand.
+     *
+     * @param filter the category filter; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the filter is null
+     */
     public JfrCLIBuilder metadataCategoryFilter(String filter) {
         Objects.requireNonNull(filter, "Category filter cannot be null");
         this.arguments.add("--categories " + filter);
         return this;
     }
 
+    /**
+     * Adds an event filter to the "metadata" subcommand.
+     *
+     * @param filter the event filter; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the filter is null
+     */
     public JfrCLIBuilder metadataEventFilter(String filter) {
         Objects.requireNonNull(filter, "Event filter cannot be null");
         this.arguments.add("--events " + filter);
         return this;
     }
 
+    /**
+     * Adds an include events filter to the "scrub" subcommand.
+     *
+     * @param filter the include events filter; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the filter is null
+     */
     public JfrCLIBuilder scrubIncludeEvents(String filter) {
         Objects.requireNonNull(filter, "Include events filter cannot be null");
         this.arguments.add("--include-events " + filter);
         return this;
     }
 
+    /**
+     * Adds an exclude events filter to the "scrub" subcommand.
+     *
+     * @param filter the exclude events filter; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the filter is null
+     */
     public JfrCLIBuilder scrubExcludeEvents(String filter) {
         Objects.requireNonNull(filter, "Exclude events filter cannot be null");
         this.arguments.add("--exclude-events " + filter);
         return this;
     }
 
+    /**
+     * Adds an include categories filter to the "scrub" subcommand.
+     *
+     * @param filter the include categories filter; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the filter is null
+     */
     public JfrCLIBuilder scrubIncludeCategories(String filter) {
         Objects.requireNonNull(filter, "Include categories filter cannot be null");
         this.arguments.add("--include-categories " + filter);
         return this;
     }
 
+    /**
+     * Adds an exclude categories filter to the "scrub" subcommand.
+     *
+     * @param filter the exclude categories filter; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the filter is null
+     */
     public JfrCLIBuilder scrubExcludeCategories(String filter) {
         Objects.requireNonNull(filter, "Exclude categories filter cannot be null");
         this.arguments.add("--exclude-categories " + filter);
         return this;
     }
 
+    /**
+     * Adds an include threads filter to the "scrub" subcommand.
+     *
+     * @param filter the include threads filter; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the filter is null
+     */
     public JfrCLIBuilder scrubIncludeThreads(String filter) {
         Objects.requireNonNull(filter, "Include threads filter cannot be null");
         this.arguments.add("--include-threads " + filter);
         return this;
     }
 
+    /**
+     * Adds an exclude threads filter to the "scrub" subcommand.
+     *
+     * @param filter the exclude threads filter; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the filter is null
+     */
     public JfrCLIBuilder scrubExcludeThreads(String filter) {
         Objects.requireNonNull(filter, "Exclude threads filter cannot be null");
         this.arguments.add("--exclude-threads " + filter);
         return this;
     }
 
+    /**
+     * Sets the output directory for the "disassemble" subcommand.
+     *
+     * @param directory the output directory; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the directory is null
+     */
     public JfrCLIBuilder disassembleOutput(Path directory) {
         Objects.requireNonNull(directory, "Output directory cannot be null");
         this.arguments.add("--output " + directory);
         return this;
     }
 
+    /**
+     * Sets the maximum number of chunks for the "disassemble" subcommand.
+     *
+     * @param chunks the maximum number of chunks; must be positive
+     * @return the current `JfrCLIBuilder` instance
+     * @throws IllegalArgumentException if the chunks value is not positive
+     */
     public JfrCLIBuilder disassembleMaxChunks(int chunks) {
         if (chunks <= 0)
             throw new IllegalArgumentException("Max chunks must be positive");
@@ -293,22 +547,46 @@ public class JfrCLIBuilder implements CLIBuilder<Process, JfrCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the maximum size for the "disassemble" subcommand.
+     *
+     * @param size the maximum size; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the size is null
+     */
     public JfrCLIBuilder disassembleMaxSize(String size) {
         Objects.requireNonNull(size, "Max size cannot be null");
         this.arguments.add("--max-size " + size);
         return this;
     }
 
+    /**
+     * Adds a "version" subcommand to the JFR CLI.
+     *
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder version() {
         this.subcommand = Subcommand.VERSION;
         return this;
     }
 
+    /**
+     * Adds a "help" subcommand to the JFR CLI.
+     *
+     * @return the current `JfrCLIBuilder` instance
+     */
     public JfrCLIBuilder help() {
         this.subcommand = Subcommand.HELP;
         return this;
     }
 
+    /**
+     * Adds a "help" subcommand to the JFR CLI with the specified subcommand.
+     *
+     * @param subcommand the subcommand to display help for; must not be null
+     * @return the current `JfrCLIBuilder` instance
+     * @throws NullPointerException if the subcommand is null
+     */
     public JfrCLIBuilder help(String subcommand) {
         Objects.requireNonNull(subcommand, "Subcommand cannot be null");
         this.subcommand = Subcommand.HELP;

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JinfoCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JinfoCLIBuilder.java
@@ -9,6 +9,14 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder for configuring {@code jinfo} invocations against a specific {@link JDK}.
+ * <p>
+ * Supports toggling JVM flags, printing system properties, and targeting particular JVM processes.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jinfo.html">jinfo command documentation</a>
+ */
 public class JinfoCLIBuilder implements CLIBuilder<Process, JinfoCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jinfo.exe" : "jinfo";
 
@@ -67,6 +75,13 @@ public class JinfoCLIBuilder implements CLIBuilder<Process, JinfoCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the process ID for the `jinfo` command using a long value.
+     *
+     * @param pid the process ID; must be positive
+     * @return the current `JinfoCLIBuilder` instance
+     * @throws IllegalArgumentException if the PID is not positive
+     */
     public JinfoCLIBuilder processId(long pid) {
         if (pid <= 0)
             throw new IllegalArgumentException("PID must be positive");
@@ -75,24 +90,54 @@ public class JinfoCLIBuilder implements CLIBuilder<Process, JinfoCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the process ID for the `jinfo` command using a string value.
+     *
+     * @param pid the process ID as a string; must not be null
+     * @return the current `JinfoCLIBuilder` instance
+     * @throws NullPointerException if the PID is null
+     */
     public JinfoCLIBuilder processId(String pid) {
         Objects.requireNonNull(pid, "PID cannot be null");
         this.processId = pid;
         return this;
     }
 
+    /**
+     * Adds a flag to the `jinfo` command.
+     *
+     * @param name the name of the flag; must not be null
+     * @return the current `JinfoCLIBuilder` instance
+     * @throws NullPointerException if the flag name is null
+     */
     public JinfoCLIBuilder flag(String name) {
         Objects.requireNonNull(name, "Flag name cannot be null");
         this.arguments.add("-flag " + name);
         return this;
     }
 
+    /**
+     * Adds a flag to the `jinfo` command with an enabled or disabled state.
+     *
+     * @param name    the name of the flag; must not be null
+     * @param enabled whether the flag is enabled (true) or disabled (false)
+     * @return the current `JinfoCLIBuilder` instance
+     * @throws NullPointerException if the flag name is null
+     */
     public JinfoCLIBuilder flag(String name, boolean enabled) {
         Objects.requireNonNull(name, "Flag name cannot be null");
         this.arguments.add("-flag " + (enabled ? "+" : "-") + name);
         return this;
     }
 
+    /**
+     * Adds a flag to the `jinfo` command with a specific value.
+     *
+     * @param name  the name of the flag; must not be null
+     * @param value the value of the flag; must not be null
+     * @return the current `JinfoCLIBuilder` instance
+     * @throws NullPointerException if the flag name or value is null
+     */
     public JinfoCLIBuilder flag(String name, String value) {
         Objects.requireNonNull(name, "Flag name cannot be null");
         Objects.requireNonNull(value, "Flag value cannot be null");
@@ -100,21 +145,43 @@ public class JinfoCLIBuilder implements CLIBuilder<Process, JinfoCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds the `-flags` option to the `jinfo` command to print all flags.
+     *
+     * @return the current `JinfoCLIBuilder` instance
+     */
     public JinfoCLIBuilder printFlags() {
         this.arguments.add("-flags");
         return this;
     }
 
+    /**
+     * Adds the `-sysprops` option to the `jinfo` command to print all system properties.
+     *
+     * @return the current `JinfoCLIBuilder` instance
+     */
     public JinfoCLIBuilder printSystemProperties() {
         this.arguments.add("-sysprops");
         return this;
     }
 
+    /**
+     * Adds the `-help` option to the `jinfo` command to display help information.
+     *
+     * @return the current `JinfoCLIBuilder` instance
+     */
     public JinfoCLIBuilder help() {
         this.arguments.add("-help");
         return this;
     }
 
+    /**
+     * Adds a Java option to the `jinfo` command.
+     *
+     * @param option the Java option; must not be null
+     * @return the current `JinfoCLIBuilder` instance
+     * @throws NullPointerException if the Java option is null
+     */
     public JinfoCLIBuilder javaOption(String option) {
         Objects.requireNonNull(option, "Java option cannot be null");
         this.arguments.add("-J" + option);

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JinfoCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JinfoCLIBuilder.java
@@ -1,0 +1,157 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JinfoCLIBuilder implements CLIBuilder<Process, JinfoCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jinfo.exe" : "jinfo";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private String processId;
+
+    private JinfoCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JinfoCLIBuilder create(JDK jdk) {
+        return new JinfoCLIBuilder(jdk);
+    }
+
+    @Override
+    public JinfoCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JinfoCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JinfoCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JinfoCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JinfoCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JinfoCLIBuilder processId(long pid) {
+        if (pid <= 0)
+            throw new IllegalArgumentException("PID must be positive");
+
+        this.processId = Long.toString(pid);
+        return this;
+    }
+
+    public JinfoCLIBuilder processId(String pid) {
+        Objects.requireNonNull(pid, "PID cannot be null");
+        this.processId = pid;
+        return this;
+    }
+
+    public JinfoCLIBuilder flag(String name) {
+        Objects.requireNonNull(name, "Flag name cannot be null");
+        this.arguments.add("-flag " + name);
+        return this;
+    }
+
+    public JinfoCLIBuilder flag(String name, boolean enabled) {
+        Objects.requireNonNull(name, "Flag name cannot be null");
+        this.arguments.add("-flag " + (enabled ? "+" : "-") + name);
+        return this;
+    }
+
+    public JinfoCLIBuilder flag(String name, String value) {
+        Objects.requireNonNull(name, "Flag name cannot be null");
+        Objects.requireNonNull(value, "Flag value cannot be null");
+        this.arguments.add("-flag " + name + "=" + value);
+        return this;
+    }
+
+    public JinfoCLIBuilder printFlags() {
+        this.arguments.add("-flags");
+        return this;
+    }
+
+    public JinfoCLIBuilder printSystemProperties() {
+        this.arguments.add("-sysprops");
+        return this;
+    }
+
+    public JinfoCLIBuilder help() {
+        this.arguments.add("-help");
+        return this;
+    }
+
+    public JinfoCLIBuilder javaOption(String option) {
+        Objects.requireNonNull(option, "Java option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        if (processId == null)
+            throw new IllegalStateException("A process ID must be specified for jinfo.");
+
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        command.add(processId);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jinfo");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jinfo process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JlinkCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JlinkCLIBuilder.java
@@ -10,6 +10,14 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder to construct {@code jlink} commands for creating custom runtime images.
+ * <p>
+ * Allows configuration of modules, compression, plugins, launchers, and other packaging flags.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jlink.html">jlink command documentation</a>
+ */
 public class JlinkCLIBuilder implements CLIBuilder<Process, JlinkCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jlink.exe" : "jlink";
 
@@ -67,17 +75,36 @@ public class JlinkCLIBuilder implements CLIBuilder<Process, JlinkCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds the specified modules to the `jlink` command.
+     *
+     * @param modules the modules to add; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the modules are null
+     */
     public JlinkCLIBuilder addModules(String... modules) {
         Objects.requireNonNull(modules, "Modules cannot be null");
         this.arguments.add("--add-modules " + String.join(",", modules));
         return this;
     }
 
+    /**
+     * Adds the `--bind-services` option to the `jlink` command.
+     *
+     * @return the current `JlinkCLIBuilder` instance
+     */
     public JlinkCLIBuilder bindServices() {
         this.arguments.add("--bind-services");
         return this;
     }
 
+    /**
+     * Sets the compression level for the `jlink` command.
+     *
+     * @param level the compression level (0, 1, or 2)
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws IllegalArgumentException if the level is not 0, 1, or 2
+     */
     public JlinkCLIBuilder compressionLevel(int level) {
         if (level < 0 || level > 2)
             throw new IllegalArgumentException("Compression level must be 0, 1, or 2");
@@ -86,6 +113,15 @@ public class JlinkCLIBuilder implements CLIBuilder<Process, JlinkCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the compression level and filter pattern for the `jlink` command.
+     *
+     * @param level         the compression level (0, 1, or 2)
+     * @param filterPattern the filter pattern; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws IllegalArgumentException if the level is not 0, 1, or 2
+     * @throws NullPointerException     if the filter pattern is null
+     */
     public JlinkCLIBuilder compressionLevel(int level, String filterPattern) {
         if (level < 0 || level > 2)
             throw new IllegalArgumentException("Compression level must be 0, 1, or 2");
@@ -95,28 +131,60 @@ public class JlinkCLIBuilder implements CLIBuilder<Process, JlinkCLIBuilder> {
         return this;
     }
 
+    /**
+     * Disables the specified plugin in the `jlink` command.
+     *
+     * @param pluginName the name of the plugin to disable; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the plugin name is null
+     */
     public JlinkCLIBuilder disablePlugin(String pluginName) {
         Objects.requireNonNull(pluginName, "Plugin name cannot be null");
         this.arguments.add("--disable-plugin " + pluginName);
         return this;
     }
 
+    /**
+     * Sets the endian option for the `jlink` command.
+     *
+     * @param endian the endian value; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the endian value is null
+     */
     public JlinkCLIBuilder endian(String endian) {
         Objects.requireNonNull(endian, "Endian cannot be null");
         this.arguments.add("--endian " + endian);
         return this;
     }
 
+    /**
+     * Adds the `--help` option to the `jlink` command.
+     *
+     * @return the current `JlinkCLIBuilder` instance
+     */
     public JlinkCLIBuilder help() {
         this.arguments.add("--help");
         return this;
     }
 
+    /**
+     * Adds the `--ignore-signing-information` option to the `jlink` command.
+     *
+     * @return the current `JlinkCLIBuilder` instance
+     */
     public JlinkCLIBuilder ignoreSigningInformation() {
         this.arguments.add("--ignore-signing-information");
         return this;
     }
 
+    /**
+     * Adds a launcher definition to the `jlink` command.
+     *
+     * @param commandName  the name of the launcher command; must not be null
+     * @param moduleOrMain the module or main class definition; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the command name or module definition is null
+     */
     public JlinkCLIBuilder launcher(String commandName, String moduleOrMain) {
         Objects.requireNonNull(commandName, "Command name cannot be null");
         Objects.requireNonNull(moduleOrMain, "Module definition cannot be null");
@@ -124,50 +192,106 @@ public class JlinkCLIBuilder implements CLIBuilder<Process, JlinkCLIBuilder> {
         return this;
     }
 
+    /**
+     * Limits the modules included in the `jlink` command.
+     *
+     * @param modules the modules to include; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the modules are null
+     */
     public JlinkCLIBuilder limitModules(String... modules) {
         Objects.requireNonNull(modules, "Module names cannot be null");
         this.arguments.add("--limit-modules " + String.join(",", modules));
         return this;
     }
 
+    /**
+     * Adds the `--list-plugins` option to the `jlink` command.
+     *
+     * @return the current `JlinkCLIBuilder` instance
+     */
     public JlinkCLIBuilder listPlugins() {
         this.arguments.add("--list-plugins");
         return this;
     }
 
+    /**
+     * Sets the module path for the `jlink` command.
+     *
+     * @param modulePaths the module path entries; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the module path entries are null
+     */
     public JlinkCLIBuilder modulePath(String... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
         this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
         return this;
     }
 
+    /**
+     * Sets the module path for the `jlink` command using `Path` objects.
+     *
+     * @param modulePaths the module path entries as `Path` objects; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the module path entries are null
+     */
     public JlinkCLIBuilder modulePath(Path... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
         return modulePath(Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new));
     }
 
+    /**
+     * Adds the `--no-header-files` option to the `jlink` command.
+     *
+     * @return the current `JlinkCLIBuilder` instance
+     */
     public JlinkCLIBuilder noHeaderFiles() {
         this.arguments.add("--no-header-files");
         return this;
     }
 
+    /**
+     * Adds the `--no-man-pages` option to the `jlink` command.
+     *
+     * @return the current `JlinkCLIBuilder` instance
+     */
     public JlinkCLIBuilder noManPages() {
         this.arguments.add("--no-man-pages");
         return this;
     }
 
+    /**
+     * Sets the output directory for the `jlink` command.
+     *
+     * @param path the output directory; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the output path is null
+     */
     public JlinkCLIBuilder output(Path path) {
         Objects.requireNonNull(path, "Output path cannot be null");
         this.arguments.add("--output " + path);
         return this;
     }
 
+    /**
+     * Saves the options used in the `jlink` command to a file.
+     *
+     * @param file the file to save the options to; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the file is null
+     */
     public JlinkCLIBuilder saveOptions(Path file) {
         Objects.requireNonNull(file, "Options file cannot be null");
         this.arguments.add("--save-opts " + file);
         return this;
     }
 
+    /**
+     * Suggests providers for the `jlink` command.
+     *
+     * @param serviceTypes the service types to suggest providers for; can be empty
+     * @return the current `JlinkCLIBuilder` instance
+     */
     public JlinkCLIBuilder suggestProviders(String... serviceTypes) {
         if (serviceTypes == null || serviceTypes.length == 0) {
             this.arguments.add("--suggest-providers");
@@ -178,33 +302,69 @@ public class JlinkCLIBuilder implements CLIBuilder<Process, JlinkCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds the `--version` option to the `jlink` command.
+     *
+     * @return the current `JlinkCLIBuilder` instance
+     */
     public JlinkCLIBuilder version() {
         this.arguments.add("--version");
         return this;
     }
 
+    /**
+     * Includes the specified locales in the `jlink` command.
+     *
+     * @param locales the locales to include; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the locales are null
+     */
     public JlinkCLIBuilder includeLocales(String... locales) {
         Objects.requireNonNull(locales, "Locales cannot be null");
         this.arguments.add("--include-locales=" + String.join(",", locales));
         return this;
     }
 
+    /**
+     * Sets the resource ordering pattern for the `jlink` command.
+     *
+     * @param patternList the pattern list; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the pattern list is null
+     */
     public JlinkCLIBuilder orderResources(String patternList) {
         Objects.requireNonNull(patternList, "Pattern list cannot be null");
         this.arguments.add("--order-resources=" + patternList);
         return this;
     }
 
+    /**
+     * Adds the `--strip-debug` option to the `jlink` command.
+     *
+     * @return the current `JlinkCLIBuilder` instance
+     */
     public JlinkCLIBuilder stripDebug() {
         this.arguments.add("--strip-debug");
         return this;
     }
 
+    /**
+     * Adds the `--generate-cds-archive` option to the `jlink` command.
+     *
+     * @return the current `JlinkCLIBuilder` instance
+     */
     public JlinkCLIBuilder generateCdsArchive() {
         this.arguments.add("--generate-cds-archive");
         return this;
     }
 
+    /**
+     * Adds an argument file to the `jlink` command.
+     *
+     * @param file the argument file; must not be null
+     * @return the current `JlinkCLIBuilder` instance
+     * @throws NullPointerException if the argument file is null
+     */
     public JlinkCLIBuilder addArgumentFile(Path file) {
         Objects.requireNonNull(file, "Argument file cannot be null");
         this.arguments.add("@" + file);

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JlinkCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JlinkCLIBuilder.java
@@ -1,0 +1,243 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JlinkCLIBuilder implements CLIBuilder<Process, JlinkCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jlink.exe" : "jlink";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private JlinkCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JlinkCLIBuilder create(JDK jdk) {
+        return new JlinkCLIBuilder(jdk);
+    }
+
+    @Override
+    public JlinkCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JlinkCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JlinkCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JlinkCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JlinkCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JlinkCLIBuilder addModules(String... modules) {
+        Objects.requireNonNull(modules, "Modules cannot be null");
+        this.arguments.add("--add-modules " + String.join(",", modules));
+        return this;
+    }
+
+    public JlinkCLIBuilder bindServices() {
+        this.arguments.add("--bind-services");
+        return this;
+    }
+
+    public JlinkCLIBuilder compressionLevel(int level) {
+        if (level < 0 || level > 2)
+            throw new IllegalArgumentException("Compression level must be 0, 1, or 2");
+
+        this.arguments.add("--compress=" + level);
+        return this;
+    }
+
+    public JlinkCLIBuilder compressionLevel(int level, String filterPattern) {
+        if (level < 0 || level > 2)
+            throw new IllegalArgumentException("Compression level must be 0, 1, or 2");
+
+        Objects.requireNonNull(filterPattern, "Filter pattern cannot be null");
+        this.arguments.add("--compress=" + level + ":filter=" + filterPattern);
+        return this;
+    }
+
+    public JlinkCLIBuilder disablePlugin(String pluginName) {
+        Objects.requireNonNull(pluginName, "Plugin name cannot be null");
+        this.arguments.add("--disable-plugin " + pluginName);
+        return this;
+    }
+
+    public JlinkCLIBuilder endian(String endian) {
+        Objects.requireNonNull(endian, "Endian cannot be null");
+        this.arguments.add("--endian " + endian);
+        return this;
+    }
+
+    public JlinkCLIBuilder help() {
+        this.arguments.add("--help");
+        return this;
+    }
+
+    public JlinkCLIBuilder ignoreSigningInformation() {
+        this.arguments.add("--ignore-signing-information");
+        return this;
+    }
+
+    public JlinkCLIBuilder launcher(String commandName, String moduleOrMain) {
+        Objects.requireNonNull(commandName, "Command name cannot be null");
+        Objects.requireNonNull(moduleOrMain, "Module definition cannot be null");
+        this.arguments.add("--launcher " + commandName + "=" + moduleOrMain);
+        return this;
+    }
+
+    public JlinkCLIBuilder limitModules(String... modules) {
+        Objects.requireNonNull(modules, "Module names cannot be null");
+        this.arguments.add("--limit-modules " + String.join(",", modules));
+        return this;
+    }
+
+    public JlinkCLIBuilder listPlugins() {
+        this.arguments.add("--list-plugins");
+        return this;
+    }
+
+    public JlinkCLIBuilder modulePath(String... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
+        this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
+        return this;
+    }
+
+    public JlinkCLIBuilder modulePath(Path... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
+        return modulePath(Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new));
+    }
+
+    public JlinkCLIBuilder noHeaderFiles() {
+        this.arguments.add("--no-header-files");
+        return this;
+    }
+
+    public JlinkCLIBuilder noManPages() {
+        this.arguments.add("--no-man-pages");
+        return this;
+    }
+
+    public JlinkCLIBuilder output(Path path) {
+        Objects.requireNonNull(path, "Output path cannot be null");
+        this.arguments.add("--output " + path);
+        return this;
+    }
+
+    public JlinkCLIBuilder saveOptions(Path file) {
+        Objects.requireNonNull(file, "Options file cannot be null");
+        this.arguments.add("--save-opts " + file);
+        return this;
+    }
+
+    public JlinkCLIBuilder suggestProviders(String... serviceTypes) {
+        if (serviceTypes == null || serviceTypes.length == 0) {
+            this.arguments.add("--suggest-providers");
+            return this;
+        }
+
+        this.arguments.add("--suggest-providers " + String.join(",", serviceTypes));
+        return this;
+    }
+
+    public JlinkCLIBuilder version() {
+        this.arguments.add("--version");
+        return this;
+    }
+
+    public JlinkCLIBuilder includeLocales(String... locales) {
+        Objects.requireNonNull(locales, "Locales cannot be null");
+        this.arguments.add("--include-locales=" + String.join(",", locales));
+        return this;
+    }
+
+    public JlinkCLIBuilder orderResources(String patternList) {
+        Objects.requireNonNull(patternList, "Pattern list cannot be null");
+        this.arguments.add("--order-resources=" + patternList);
+        return this;
+    }
+
+    public JlinkCLIBuilder stripDebug() {
+        this.arguments.add("--strip-debug");
+        return this;
+    }
+
+    public JlinkCLIBuilder generateCdsArchive() {
+        this.arguments.add("--generate-cds-archive");
+        return this;
+    }
+
+    public JlinkCLIBuilder addArgumentFile(Path file) {
+        Objects.requireNonNull(file, "Argument file cannot be null");
+        this.arguments.add("@" + file);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jlink");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jlink process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JmapCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JmapCLIBuilder.java
@@ -9,6 +9,14 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder for composing {@code jmap} commands to inspect heap and class metadata.
+ * <p>
+ * Enables selecting targets, histogram options, and dumping heap/configurations.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jmap.html">jmap command documentation</a>
+ */
 public class JmapCLIBuilder implements CLIBuilder<Process, JmapCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jmap.exe" : "jmap";
 
@@ -75,27 +83,61 @@ public class JmapCLIBuilder implements CLIBuilder<Process, JmapCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the process ID for the `jmap` command using a string value.
+     *
+     * @param pid the process ID as a string; must not be null
+     * @return the current `JmapCLIBuilder` instance
+     * @throws NullPointerException if the PID is null
+     */
     public JmapCLIBuilder processId(String pid) {
         Objects.requireNonNull(pid, "PID cannot be null");
         this.processId = pid;
         return this;
     }
 
+    /**
+     * Adds the `-clstats` option to the `jmap` command to display class loader statistics.
+     *
+     * @return the current `JmapCLIBuilder` instance
+     */
     public JmapCLIBuilder classLoaderStats() {
         this.arguments.add("-clstats");
         return this;
     }
 
+    /**
+     * Adds the `-finalizerinfo` option to the `jmap` command to display information about objects
+     * pending finalization.
+     *
+     * @return the current `JmapCLIBuilder` instance
+     */
     public JmapCLIBuilder finalizerInfo() {
         this.arguments.add("-finalizerinfo");
         return this;
     }
 
+    /**
+     * Adds the `-histo` or `-histo:live` option to the `jmap` command to display a histogram of
+     * the heap.
+     *
+     * @param liveOnly whether to include only live objects in the histogram
+     * @return the current `JmapCLIBuilder` instance
+     */
     public JmapCLIBuilder histogram(boolean liveOnly) {
         this.arguments.add(liveOnly ? "-histo:live" : "-histo");
         return this;
     }
 
+    /**
+     * Adds the `-dump` option to the `jmap` command to dump the heap with the specified options.
+     *
+     * @param liveOnly whether to include only live objects in the dump
+     * @param format   the format of the dump; must not be null
+     * @param file     the file to save the dump to; must not be null
+     * @return the current `JmapCLIBuilder` instance
+     * @throws NullPointerException if the format or file is null
+     */
     public JmapCLIBuilder dumpHeap(boolean liveOnly, String format, Path file) {
         Objects.requireNonNull(format, "Dump format cannot be null");
         Objects.requireNonNull(file, "Dump file cannot be null");
@@ -109,17 +151,36 @@ public class JmapCLIBuilder implements CLIBuilder<Process, JmapCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds the `-dump` option to the `jmap` command with the specified options.
+     *
+     * @param options the dump options as a string; must not be null
+     * @return the current `JmapCLIBuilder` instance
+     * @throws NullPointerException if the options are null
+     */
     public JmapCLIBuilder dumpHeap(String options) {
         Objects.requireNonNull(options, "Dump options cannot be null");
         this.arguments.add("-dump:" + options);
         return this;
     }
 
+    /**
+     * Adds the `-help` option to the `jmap` command to display help information.
+     *
+     * @return the current `JmapCLIBuilder` instance
+     */
     public JmapCLIBuilder help() {
         this.arguments.add("-help");
         return this;
     }
 
+    /**
+     * Adds a Java option to the `jmap` command.
+     *
+     * @param option the Java option; must not be null
+     * @return the current `JmapCLIBuilder` instance
+     * @throws NullPointerException if the option is null
+     */
     public JmapCLIBuilder javaOption(String option) {
         Objects.requireNonNull(option, "Java option cannot be null");
         this.arguments.add("-J" + option);

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JmapCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JmapCLIBuilder.java
@@ -1,0 +1,162 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JmapCLIBuilder implements CLIBuilder<Process, JmapCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jmap.exe" : "jmap";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private String processId;
+
+    private JmapCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JmapCLIBuilder create(JDK jdk) {
+        return new JmapCLIBuilder(jdk);
+    }
+
+    @Override
+    public JmapCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JmapCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JmapCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JmapCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JmapCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JmapCLIBuilder processId(long pid) {
+        if (pid <= 0)
+            throw new IllegalArgumentException("PID must be positive");
+
+        this.processId = Long.toString(pid);
+        return this;
+    }
+
+    public JmapCLIBuilder processId(String pid) {
+        Objects.requireNonNull(pid, "PID cannot be null");
+        this.processId = pid;
+        return this;
+    }
+
+    public JmapCLIBuilder classLoaderStats() {
+        this.arguments.add("-clstats");
+        return this;
+    }
+
+    public JmapCLIBuilder finalizerInfo() {
+        this.arguments.add("-finalizerinfo");
+        return this;
+    }
+
+    public JmapCLIBuilder histogram(boolean liveOnly) {
+        this.arguments.add(liveOnly ? "-histo:live" : "-histo");
+        return this;
+    }
+
+    public JmapCLIBuilder dumpHeap(boolean liveOnly, String format, Path file) {
+        Objects.requireNonNull(format, "Dump format cannot be null");
+        Objects.requireNonNull(file, "Dump file cannot be null");
+
+        var options = new StringJoiner(",");
+        if (liveOnly)
+            options.add("live");
+        options.add("format=" + format);
+        options.add("file=" + file);
+        this.arguments.add("-dump:" + options);
+        return this;
+    }
+
+    public JmapCLIBuilder dumpHeap(String options) {
+        Objects.requireNonNull(options, "Dump options cannot be null");
+        this.arguments.add("-dump:" + options);
+        return this;
+    }
+
+    public JmapCLIBuilder help() {
+        this.arguments.add("-help");
+        return this;
+    }
+
+    public JmapCLIBuilder javaOption(String option) {
+        Objects.requireNonNull(option, "Java option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        if (processId == null)
+            throw new IllegalStateException("A process ID must be specified for jmap.");
+
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        command.add(processId);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jmap");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jmap process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JmodCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JmodCLIBuilder.java
@@ -9,6 +9,14 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder that wraps the {@code jmod} tool to create, inspect, and manipulate JMOD files.
+ * <p>
+ * Offers helpers for different operation modes, routing of paths, and advanced options exposed by {@code jmod}.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jmod.html">jmod command documentation</a>
+ */
 public class JmodCLIBuilder implements CLIBuilder<Process, JmodCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jmod.exe" : "jmod";
 
@@ -68,6 +76,13 @@ public class JmodCLIBuilder implements CLIBuilder<Process, JmodCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the operation mode to "create" and specifies the JMOD file to create.
+     *
+     * @param jmodFile the JMOD file to create; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the JMOD file is null
+     */
     public JmodCLIBuilder create(Path jmodFile) {
         Objects.requireNonNull(jmodFile, "JMOD file cannot be null");
         this.operationMode = OperationMode.CREATE;
@@ -75,6 +90,13 @@ public class JmodCLIBuilder implements CLIBuilder<Process, JmodCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the operation mode to "extract" and specifies the JMOD file to extract.
+     *
+     * @param jmodFile the JMOD file to extract; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the JMOD file is null
+     */
     public JmodCLIBuilder extract(Path jmodFile) {
         Objects.requireNonNull(jmodFile, "JMOD file cannot be null");
         this.operationMode = OperationMode.EXTRACT;
@@ -82,6 +104,13 @@ public class JmodCLIBuilder implements CLIBuilder<Process, JmodCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the operation mode to "list" and specifies the JMOD file to list.
+     *
+     * @param jmodFile the JMOD file to list; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the JMOD file is null
+     */
     public JmodCLIBuilder list(Path jmodFile) {
         Objects.requireNonNull(jmodFile, "JMOD file cannot be null");
         this.operationMode = OperationMode.LIST;
@@ -89,6 +118,13 @@ public class JmodCLIBuilder implements CLIBuilder<Process, JmodCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the operation mode to "describe" and specifies the JMOD file to describe.
+     *
+     * @param jmodFile the JMOD file to describe; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the JMOD file is null
+     */
     public JmodCLIBuilder describe(Path jmodFile) {
         Objects.requireNonNull(jmodFile, "JMOD file cannot be null");
         this.operationMode = OperationMode.DESCRIBE;
@@ -96,6 +132,13 @@ public class JmodCLIBuilder implements CLIBuilder<Process, JmodCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the operation mode to "hash" and specifies the JMOD file to hash.
+     *
+     * @param jmodFile the JMOD file to hash; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the JMOD file is null
+     */
     public JmodCLIBuilder hash(Path jmodFile) {
         Objects.requireNonNull(jmodFile, "JMOD file cannot be null");
         this.operationMode = OperationMode.HASH;
@@ -103,133 +146,284 @@ public class JmodCLIBuilder implements CLIBuilder<Process, JmodCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds the `--class-path` option to the JMOD command with the specified class path.
+     *
+     * @param path the class path to add; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the class path is null
+     */
     public JmodCLIBuilder classPath(String path) {
         Objects.requireNonNull(path, "Class path cannot be null");
         this.arguments.add("--class-path " + path);
         return this;
     }
 
+    /**
+     * Adds the `--cmds` option to the JMOD command with the specified command path.
+     *
+     * @param path the command path to add; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the command path is null
+     */
     public JmodCLIBuilder cmds(Path path) {
         Objects.requireNonNull(path, "Command path cannot be null");
         this.arguments.add("--cmds " + path);
         return this;
     }
 
+    /**
+     * Adds the `--compress` option to the JMOD command with the specified compression level.
+     *
+     * @param compression the compression level to set; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the compression level is null
+     */
     public JmodCLIBuilder compression(String compression) {
         Objects.requireNonNull(compression, "Compression cannot be null");
         this.arguments.add("--compress " + compression);
         return this;
     }
 
+    /**
+     * Adds the `--config` option to the JMOD command with the specified configuration path.
+     *
+     * @param path the configuration path to add; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the configuration path is null
+     */
     public JmodCLIBuilder config(Path path) {
         Objects.requireNonNull(path, "Config path cannot be null");
         this.arguments.add("--config " + path);
         return this;
     }
 
+    /**
+     * Adds the `--date` option to the JMOD command with the specified entry timestamp.
+     *
+     * @param timestamp the entry timestamp to set; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the timestamp is null
+     */
     public JmodCLIBuilder entryTimestamp(String timestamp) {
         Objects.requireNonNull(timestamp, "Timestamp cannot be null");
         this.arguments.add("--date " + timestamp);
         return this;
     }
 
+    /**
+     * Adds the `--dir` option to the JMOD command with the specified extraction directory.
+     *
+     * @param path the extraction directory to set; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the extraction directory is null
+     */
     public JmodCLIBuilder extractionDirectory(Path path) {
         Objects.requireNonNull(path, "Extraction directory cannot be null");
         this.arguments.add("--dir " + path);
         return this;
     }
 
+    /**
+     * Adds the `--dry-run` option to the JMOD command.
+     *
+     * @return the current `JmodCLIBuilder` instance
+     */
     public JmodCLIBuilder dryRun() {
         this.arguments.add("--dry-run");
         return this;
     }
 
+    /**
+     * Adds the `--exclude` option to the JMOD command with the specified pattern list.
+     *
+     * @param patternList the pattern list to exclude; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the pattern list is null
+     */
     public JmodCLIBuilder exclude(String patternList) {
         Objects.requireNonNull(patternList, "Pattern list cannot be null");
         this.arguments.add("--exclude " + patternList);
         return this;
     }
 
+    /**
+     * Adds the `--hash-modules` option to the JMOD command with the specified regex pattern.
+     *
+     * @param regexPattern the regex pattern to hash modules; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the regex pattern is null
+     */
     public JmodCLIBuilder hashModules(String regexPattern) {
         Objects.requireNonNull(regexPattern, "Regex pattern cannot be null");
         this.arguments.add("--hash-modules " + regexPattern);
         return this;
     }
 
+    /**
+     * Adds the `--header-files` option to the JMOD command with the specified header files path.
+     *
+     * @param path the header files path to add; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the header files path is null
+     */
     public JmodCLIBuilder headerFiles(Path path) {
         Objects.requireNonNull(path, "Header files path cannot be null");
         this.arguments.add("--header-files " + path);
         return this;
     }
 
+    /**
+     * Adds the `--help` option to the JMOD command.
+     *
+     * @return the current `JmodCLIBuilder` instance
+     */
     public JmodCLIBuilder help() {
         this.arguments.add("--help");
         return this;
     }
 
+    /**
+     * Adds the `--help-extra` option to the JMOD command.
+     *
+     * @return the current `JmodCLIBuilder` instance
+     */
     public JmodCLIBuilder helpExtra() {
         this.arguments.add("--help-extra");
         return this;
     }
 
+    /**
+     * Adds the `--legal-notices` option to the JMOD command with the specified legal notices path.
+     *
+     * @param path the legal notices path to add; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the legal notices path is null
+     */
     public JmodCLIBuilder legalNotices(Path path) {
         Objects.requireNonNull(path, "Legal notices path cannot be null");
         this.arguments.add("--legal-notices " + path);
         return this;
     }
 
+    /**
+     * Adds the `--libs` option to the JMOD command with the specified libraries path.
+     *
+     * @param path the libraries path to add; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the libraries path is null
+     */
     public JmodCLIBuilder libs(Path path) {
         Objects.requireNonNull(path, "Libraries path cannot be null");
         this.arguments.add("--libs " + path);
         return this;
     }
 
+    /**
+     * Adds the `--main-class` option to the JMOD command with the specified main class.
+     *
+     * @param className the main class to set; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the main class is null
+     */
     public JmodCLIBuilder mainClass(String className) {
         Objects.requireNonNull(className, "Main class cannot be null");
         this.arguments.add("--main-class " + className);
         return this;
     }
 
+    /**
+     * Adds the `--man-pages` option to the JMOD command with the specified man pages path.
+     *
+     * @param path the man pages path to add; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the man pages path is null
+     */
     public JmodCLIBuilder manPages(Path path) {
         Objects.requireNonNull(path, "Man pages path cannot be null");
         this.arguments.add("--man-pages " + path);
         return this;
     }
 
+    /**
+     * Adds the `--module-version` option to the JMOD command with the specified module version.
+     *
+     * @param version the module version to set; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the module version is null
+     */
     public JmodCLIBuilder moduleVersion(String version) {
         Objects.requireNonNull(version, "Module version cannot be null");
         this.arguments.add("--module-version " + version);
         return this;
     }
 
+    /**
+     * Adds the `--module-path` option to the JMOD command with the specified module path.
+     *
+     * @param path the module path to add; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the module path is null
+     */
     public JmodCLIBuilder modulePath(String path) {
         Objects.requireNonNull(path, "Module path cannot be null");
         this.arguments.add("--module-path " + path);
         return this;
     }
 
+    /**
+     * Adds the `--target-platform` option to the JMOD command with the specified platform.
+     *
+     * @param platform the target platform to set; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the platform is null
+     */
     public JmodCLIBuilder targetPlatform(String platform) {
         Objects.requireNonNull(platform, "Platform cannot be null");
         this.arguments.add("--target-platform " + platform);
         return this;
     }
 
+    /**
+     * Adds the `--version` option to the JMOD command.
+     *
+     * @return the current `JmodCLIBuilder` instance
+     */
     public JmodCLIBuilder version() {
         this.arguments.add("--version");
         return this;
     }
 
+    /**
+     * Adds an argument file to the JMOD command.
+     *
+     * @param file the argument file to add; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the argument file is null
+     */
     public JmodCLIBuilder argumentFile(Path file) {
         Objects.requireNonNull(file, "Argument file cannot be null");
         this.arguments.add("@" + file);
         return this;
     }
 
+    /**
+     * Adds the `--do-not-resolve-by-default` option to the JMOD command.
+     *
+     * @return the current `JmodCLIBuilder` instance
+     */
     public JmodCLIBuilder doNotResolveByDefault() {
         this.arguments.add("--do-not-resolve-by-default");
         return this;
     }
 
+    /**
+     * Adds the `--warn-if-resolved` option to the JMOD command with the specified hint.
+     *
+     * @param hint the hint to warn if resolved; must not be null
+     * @return the current `JmodCLIBuilder` instance
+     * @throws NullPointerException if the hint is null
+     */
     public JmodCLIBuilder warnIfResolved(String hint) {
         Objects.requireNonNull(hint, "Warning hint cannot be null");
         this.arguments.add("--warn-if-resolved=" + hint);

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JmodCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JmodCLIBuilder.java
@@ -1,0 +1,293 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JmodCLIBuilder implements CLIBuilder<Process, JmodCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jmod.exe" : "jmod";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private OperationMode operationMode;
+    private String jmodFile;
+
+    private JmodCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JmodCLIBuilder create(JDK jdk) {
+        return new JmodCLIBuilder(jdk);
+    }
+
+    @Override
+    public JmodCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JmodCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JmodCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JmodCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JmodCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JmodCLIBuilder create(Path jmodFile) {
+        Objects.requireNonNull(jmodFile, "JMOD file cannot be null");
+        this.operationMode = OperationMode.CREATE;
+        this.jmodFile = jmodFile.toString();
+        return this;
+    }
+
+    public JmodCLIBuilder extract(Path jmodFile) {
+        Objects.requireNonNull(jmodFile, "JMOD file cannot be null");
+        this.operationMode = OperationMode.EXTRACT;
+        this.jmodFile = jmodFile.toString();
+        return this;
+    }
+
+    public JmodCLIBuilder list(Path jmodFile) {
+        Objects.requireNonNull(jmodFile, "JMOD file cannot be null");
+        this.operationMode = OperationMode.LIST;
+        this.jmodFile = jmodFile.toString();
+        return this;
+    }
+
+    public JmodCLIBuilder describe(Path jmodFile) {
+        Objects.requireNonNull(jmodFile, "JMOD file cannot be null");
+        this.operationMode = OperationMode.DESCRIBE;
+        this.jmodFile = jmodFile.toString();
+        return this;
+    }
+
+    public JmodCLIBuilder hash(Path jmodFile) {
+        Objects.requireNonNull(jmodFile, "JMOD file cannot be null");
+        this.operationMode = OperationMode.HASH;
+        this.jmodFile = jmodFile.toString();
+        return this;
+    }
+
+    public JmodCLIBuilder classPath(String path) {
+        Objects.requireNonNull(path, "Class path cannot be null");
+        this.arguments.add("--class-path " + path);
+        return this;
+    }
+
+    public JmodCLIBuilder cmds(Path path) {
+        Objects.requireNonNull(path, "Command path cannot be null");
+        this.arguments.add("--cmds " + path);
+        return this;
+    }
+
+    public JmodCLIBuilder compression(String compression) {
+        Objects.requireNonNull(compression, "Compression cannot be null");
+        this.arguments.add("--compress " + compression);
+        return this;
+    }
+
+    public JmodCLIBuilder config(Path path) {
+        Objects.requireNonNull(path, "Config path cannot be null");
+        this.arguments.add("--config " + path);
+        return this;
+    }
+
+    public JmodCLIBuilder entryTimestamp(String timestamp) {
+        Objects.requireNonNull(timestamp, "Timestamp cannot be null");
+        this.arguments.add("--date " + timestamp);
+        return this;
+    }
+
+    public JmodCLIBuilder extractionDirectory(Path path) {
+        Objects.requireNonNull(path, "Extraction directory cannot be null");
+        this.arguments.add("--dir " + path);
+        return this;
+    }
+
+    public JmodCLIBuilder dryRun() {
+        this.arguments.add("--dry-run");
+        return this;
+    }
+
+    public JmodCLIBuilder exclude(String patternList) {
+        Objects.requireNonNull(patternList, "Pattern list cannot be null");
+        this.arguments.add("--exclude " + patternList);
+        return this;
+    }
+
+    public JmodCLIBuilder hashModules(String regexPattern) {
+        Objects.requireNonNull(regexPattern, "Regex pattern cannot be null");
+        this.arguments.add("--hash-modules " + regexPattern);
+        return this;
+    }
+
+    public JmodCLIBuilder headerFiles(Path path) {
+        Objects.requireNonNull(path, "Header files path cannot be null");
+        this.arguments.add("--header-files " + path);
+        return this;
+    }
+
+    public JmodCLIBuilder help() {
+        this.arguments.add("--help");
+        return this;
+    }
+
+    public JmodCLIBuilder helpExtra() {
+        this.arguments.add("--help-extra");
+        return this;
+    }
+
+    public JmodCLIBuilder legalNotices(Path path) {
+        Objects.requireNonNull(path, "Legal notices path cannot be null");
+        this.arguments.add("--legal-notices " + path);
+        return this;
+    }
+
+    public JmodCLIBuilder libs(Path path) {
+        Objects.requireNonNull(path, "Libraries path cannot be null");
+        this.arguments.add("--libs " + path);
+        return this;
+    }
+
+    public JmodCLIBuilder mainClass(String className) {
+        Objects.requireNonNull(className, "Main class cannot be null");
+        this.arguments.add("--main-class " + className);
+        return this;
+    }
+
+    public JmodCLIBuilder manPages(Path path) {
+        Objects.requireNonNull(path, "Man pages path cannot be null");
+        this.arguments.add("--man-pages " + path);
+        return this;
+    }
+
+    public JmodCLIBuilder moduleVersion(String version) {
+        Objects.requireNonNull(version, "Module version cannot be null");
+        this.arguments.add("--module-version " + version);
+        return this;
+    }
+
+    public JmodCLIBuilder modulePath(String path) {
+        Objects.requireNonNull(path, "Module path cannot be null");
+        this.arguments.add("--module-path " + path);
+        return this;
+    }
+
+    public JmodCLIBuilder targetPlatform(String platform) {
+        Objects.requireNonNull(platform, "Platform cannot be null");
+        this.arguments.add("--target-platform " + platform);
+        return this;
+    }
+
+    public JmodCLIBuilder version() {
+        this.arguments.add("--version");
+        return this;
+    }
+
+    public JmodCLIBuilder argumentFile(Path file) {
+        Objects.requireNonNull(file, "Argument file cannot be null");
+        this.arguments.add("@" + file);
+        return this;
+    }
+
+    public JmodCLIBuilder doNotResolveByDefault() {
+        this.arguments.add("--do-not-resolve-by-default");
+        return this;
+    }
+
+    public JmodCLIBuilder warnIfResolved(String hint) {
+        Objects.requireNonNull(hint, "Warning hint cannot be null");
+        this.arguments.add("--warn-if-resolved=" + hint);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        if (operationMode == null)
+            throw new IllegalStateException("An operation mode must be specified.");
+        if (jmodFile == null)
+            throw new IllegalStateException("A JMOD file must be provided.");
+
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.add(operationMode.command());
+        command.addAll(arguments);
+        command.add(jmodFile);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jmod");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jmod process", exception);
+        }
+    }
+
+    private enum OperationMode {
+        CREATE("create"),
+        EXTRACT("extract"),
+        LIST("list"),
+        DESCRIBE("describe"),
+        HASH("hash");
+
+        private final String command;
+
+        OperationMode(String command) {
+            this.command = command;
+        }
+
+        public String command() {
+            return command;
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JpackageCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JpackageCLIBuilder.java
@@ -1,0 +1,298 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JpackageCLIBuilder implements CLIBuilder<Process, JpackageCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jpackage.exe" : "jpackage";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private JpackageCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JpackageCLIBuilder create(JDK jdk) {
+        return new JpackageCLIBuilder(jdk);
+    }
+
+    @Override
+    public JpackageCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JpackageCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JpackageCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JpackageCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JpackageCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JpackageCLIBuilder optionFile(Path optionFile) {
+        Objects.requireNonNull(optionFile, "Option file cannot be null");
+        this.arguments.add("@" + optionFile);
+        return this;
+    }
+
+    public JpackageCLIBuilder packageType(String type) {
+        Objects.requireNonNull(type, "Package type cannot be null");
+        this.arguments.add("--type " + type);
+        return this;
+    }
+
+    public JpackageCLIBuilder appVersion(String version) {
+        Objects.requireNonNull(version, "Version cannot be null");
+        this.arguments.add("--app-version " + version);
+        return this;
+    }
+
+    public JpackageCLIBuilder copyright(String copyright) {
+        Objects.requireNonNull(copyright, "Copyright cannot be null");
+        this.arguments.add("--copyright " + copyright);
+        return this;
+    }
+
+    public JpackageCLIBuilder description(String description) {
+        Objects.requireNonNull(description, "Description cannot be null");
+        this.arguments.add("--description " + description);
+        return this;
+    }
+
+    public JpackageCLIBuilder help() {
+        this.arguments.add("--help");
+        return this;
+    }
+
+    public JpackageCLIBuilder icon(Path iconPath) {
+        Objects.requireNonNull(iconPath, "Icon path cannot be null");
+        this.arguments.add("--icon " + iconPath);
+        return this;
+    }
+
+    public JpackageCLIBuilder applicationName(String name) {
+        Objects.requireNonNull(name, "Application name cannot be null");
+        this.arguments.add("--name " + name);
+        return this;
+    }
+
+    public JpackageCLIBuilder destination(Path destination) {
+        Objects.requireNonNull(destination, "Destination cannot be null");
+        this.arguments.add("--dest " + destination);
+        return this;
+    }
+
+    public JpackageCLIBuilder resourceDirectory(Path resourceDir) {
+        Objects.requireNonNull(resourceDir, "Resource directory cannot be null");
+        this.arguments.add("--resource-dir " + resourceDir);
+        return this;
+    }
+
+    public JpackageCLIBuilder tempDirectory(Path tempDir) {
+        Objects.requireNonNull(tempDir, "Temp directory cannot be null");
+        this.arguments.add("--temp " + tempDir);
+        return this;
+    }
+
+    public JpackageCLIBuilder vendor(String vendor) {
+        Objects.requireNonNull(vendor, "Vendor cannot be null");
+        this.arguments.add("--vendor " + vendor);
+        return this;
+    }
+
+    public JpackageCLIBuilder verbose() {
+        this.arguments.add("--verbose");
+        return this;
+    }
+
+    public JpackageCLIBuilder versionInfo() {
+        this.arguments.add("--version");
+        return this;
+    }
+
+    public JpackageCLIBuilder addModules(String... modules) {
+        Objects.requireNonNull(modules, "Modules cannot be null");
+        this.arguments.add("--add-modules " + String.join(",", modules));
+        return this;
+    }
+
+    public JpackageCLIBuilder modulePath(String... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
+        this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
+        return this;
+    }
+
+    public JpackageCLIBuilder modulePath(Path... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
+        return modulePath(Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new));
+    }
+
+    public JpackageCLIBuilder jlinkOptions(String... options) {
+        Objects.requireNonNull(options, "jlink options cannot be null");
+        this.arguments.add("--jlink-options " + String.join(" ", options));
+        return this;
+    }
+
+    public JpackageCLIBuilder runtimeImage(Path runtimeImage) {
+        Objects.requireNonNull(runtimeImage, "Runtime image path cannot be null");
+        this.arguments.add("--runtime-image " + runtimeImage);
+        return this;
+    }
+
+    public JpackageCLIBuilder input(Path inputDirectory) {
+        Objects.requireNonNull(inputDirectory, "Input directory cannot be null");
+        this.arguments.add("--input " + inputDirectory);
+        return this;
+    }
+
+    public JpackageCLIBuilder appContent(String... contentPaths) {
+        Objects.requireNonNull(contentPaths, "App content paths cannot be null");
+        this.arguments.add("--app-content " + String.join(",", contentPaths));
+        return this;
+    }
+
+    public JpackageCLIBuilder addLauncher(String name, Path propertiesFile) {
+        Objects.requireNonNull(name, "Launcher name cannot be null");
+        Objects.requireNonNull(propertiesFile, "Launcher properties files cannot be null");
+        this.arguments.add("--add-launcher " + name + "=" + propertiesFile);
+        return this;
+    }
+
+    public JpackageCLIBuilder launcherArguments(String arguments) {
+        Objects.requireNonNull(arguments, "Launcher arguments cannot be null");
+        this.arguments.add("--arguments " + arguments);
+        return this;
+    }
+
+    public JpackageCLIBuilder launcherJavaOptions(String options) {
+        Objects.requireNonNull(options, "Java options cannot be null");
+        this.arguments.add("--java-options " + options);
+        return this;
+    }
+
+    public JpackageCLIBuilder mainClass(String mainClass) {
+        Objects.requireNonNull(mainClass, "Main class cannot be null");
+        this.arguments.add("--main-class " + mainClass);
+        return this;
+    }
+
+    public JpackageCLIBuilder mainJar(String jarPath) {
+        Objects.requireNonNull(jarPath, "Main JAR path cannot be null");
+        this.arguments.add("--main-jar " + jarPath);
+        return this;
+    }
+
+    public JpackageCLIBuilder module(String module) {
+        Objects.requireNonNull(module, "Module cannot be null");
+        this.arguments.add("--module " + module);
+        return this;
+    }
+
+    public JpackageCLIBuilder windowsConsole() {
+        this.arguments.add("--win-console");
+        return this;
+    }
+
+    public JpackageCLIBuilder macPackageIdentifier(String identifier) {
+        Objects.requireNonNull(identifier, "Identifier cannot be null");
+        this.arguments.add("--mac-package-identifier " + identifier);
+        return this;
+    }
+
+    public JpackageCLIBuilder macPackageName(String name) {
+        Objects.requireNonNull(name, "Mac package name cannot be null");
+        this.arguments.add("--mac-package-name " + name);
+        return this;
+    }
+
+    public JpackageCLIBuilder macPackageSigningPrefix(String prefix) {
+        Objects.requireNonNull(prefix, "Signing prefix cannot be null");
+        this.arguments.add("--mac-package-signing-prefix " + prefix);
+        return this;
+    }
+
+    public JpackageCLIBuilder macSign() {
+        this.arguments.add("--mac-sign");
+        return this;
+    }
+
+    public JpackageCLIBuilder macSigningKeychain(String keychain) {
+        Objects.requireNonNull(keychain, "Keychain cannot be null");
+        this.arguments.add("--mac-signing-keychain " + keychain);
+        return this;
+    }
+
+    public JpackageCLIBuilder macSigningKeyUser(String userName) {
+        Objects.requireNonNull(userName, "User name cannot be null");
+        this.arguments.add("--mac-signing-key-user-name " + userName);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jpackage");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jpackage process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JpackageCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JpackageCLIBuilder.java
@@ -25,6 +25,12 @@ public class JpackageCLIBuilder implements CLIBuilder<Process, JpackageCLIBuilde
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a fresh builder tied to the provided {@link JDK}.
+     *
+     * @param jdk the JDK whose tools should be used
+     * @return a new builder instance
+     */
     public static JpackageCLIBuilder create(JDK jdk) {
         return new JpackageCLIBuilder(jdk);
     }
@@ -67,128 +73,258 @@ public class JpackageCLIBuilder implements CLIBuilder<Process, JpackageCLIBuilde
         return this;
     }
 
+    /**
+     * Instructs {@code jpackage} to read arguments from the given option file.
+     *
+     * @param optionFile path to the option file
+     * @return this builder
+     */
     public JpackageCLIBuilder optionFile(Path optionFile) {
         Objects.requireNonNull(optionFile, "Option file cannot be null");
         this.arguments.add("@" + optionFile);
         return this;
     }
 
+    /**
+     * Sets the target package type.
+     *
+     * @param type package type (e.g., {@code pkg}, {@code exe})
+     * @return this builder
+     */
     public JpackageCLIBuilder packageType(String type) {
         Objects.requireNonNull(type, "Package type cannot be null");
         this.arguments.add("--type " + type);
         return this;
     }
 
+    /**
+     * Declares the application version passed to {@code jpackage}.
+     *
+     * @param version version string
+     * @return this builder
+     */
     public JpackageCLIBuilder appVersion(String version) {
         Objects.requireNonNull(version, "Version cannot be null");
         this.arguments.add("--app-version " + version);
         return this;
     }
 
+    /**
+     * Sets the copyright notice inside the generated package.
+     *
+     * @param copyright copyright text
+     * @return this builder
+     */
     public JpackageCLIBuilder copyright(String copyright) {
         Objects.requireNonNull(copyright, "Copyright cannot be null");
         this.arguments.add("--copyright " + copyright);
         return this;
     }
 
+    /**
+     * Provides a description for the packaged application.
+     *
+     * @param description description text
+     * @return this builder
+     */
     public JpackageCLIBuilder description(String description) {
         Objects.requireNonNull(description, "Description cannot be null");
         this.arguments.add("--description " + description);
         return this;
     }
 
+    /**
+     * Requests {@code --help} output from {@code jpackage}.
+     *
+     * @return this builder
+     */
     public JpackageCLIBuilder help() {
         this.arguments.add("--help");
         return this;
     }
 
+    /**
+     * Includes an icon for the application bundle.
+     *
+     * @param iconPath path to the icon file
+     * @return this builder
+     */
     public JpackageCLIBuilder icon(Path iconPath) {
         Objects.requireNonNull(iconPath, "Icon path cannot be null");
         this.arguments.add("--icon " + iconPath);
         return this;
     }
 
+    /**
+     * Names the generated application.
+     *
+     * @param name application name
+     * @return this builder
+     */
     public JpackageCLIBuilder applicationName(String name) {
         Objects.requireNonNull(name, "Application name cannot be null");
         this.arguments.add("--name " + name);
         return this;
     }
 
+    /**
+     * Configures the output directory for the package.
+     *
+     * @param destination destination directory
+     * @return this builder
+     */
     public JpackageCLIBuilder destination(Path destination) {
         Objects.requireNonNull(destination, "Destination cannot be null");
         this.arguments.add("--dest " + destination);
         return this;
     }
 
+    /**
+     * Points {@code jpackage} at extra resource files.
+     *
+     * @param resourceDir path to the resource directory
+     * @return this builder
+     */
     public JpackageCLIBuilder resourceDirectory(Path resourceDir) {
         Objects.requireNonNull(resourceDir, "Resource directory cannot be null");
         this.arguments.add("--resource-dir " + resourceDir);
         return this;
     }
 
+    /**
+     * Defines a temporary directory to use during packaging.
+     *
+     * @param tempDir temp directory
+     * @return this builder
+     */
     public JpackageCLIBuilder tempDirectory(Path tempDir) {
         Objects.requireNonNull(tempDir, "Temp directory cannot be null");
         this.arguments.add("--temp " + tempDir);
         return this;
     }
 
+    /**
+     * Adds vendor metadata to the package.
+     *
+     * @param vendor vendor name
+     * @return this builder
+     */
     public JpackageCLIBuilder vendor(String vendor) {
         Objects.requireNonNull(vendor, "Vendor cannot be null");
         this.arguments.add("--vendor " + vendor);
         return this;
     }
 
+    /**
+     * Enables verbose logging for {@code jpackage}.
+     *
+     * @return this builder
+     */
     public JpackageCLIBuilder verbose() {
         this.arguments.add("--verbose");
         return this;
     }
 
+    /**
+     * Adds {@code --version} to the CLI arguments.
+     *
+     * @return this builder
+     */
     public JpackageCLIBuilder versionInfo() {
         this.arguments.add("--version");
         return this;
     }
 
+    /**
+     * Passes module names to the launcher.
+     *
+     * @param modules module names
+     * @return this builder
+     */
     public JpackageCLIBuilder addModules(String... modules) {
         Objects.requireNonNull(modules, "Modules cannot be null");
         this.arguments.add("--add-modules " + String.join(",", modules));
         return this;
     }
 
+    /**
+     * Sets module path entries via string representations.
+     *
+     * @param modulePaths module path elements
+     * @return this builder
+     */
     public JpackageCLIBuilder modulePath(String... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
         this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
         return this;
     }
 
+    /**
+     * Sets module path entries via {@link Path} instances.
+     *
+     * @param modulePaths module path elements
+     * @return this builder
+     */
     public JpackageCLIBuilder modulePath(Path... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module path entries cannot be null");
         return modulePath(Arrays.stream(modulePaths).map(Path::toString).toArray(String[]::new));
     }
 
+    /**
+     * Forwards arguments to the bundled {@code jlink} step.
+     *
+     * @param options jlink options
+     * @return this builder
+     */
     public JpackageCLIBuilder jlinkOptions(String... options) {
         Objects.requireNonNull(options, "jlink options cannot be null");
         this.arguments.add("--jlink-options " + String.join(" ", options));
         return this;
     }
 
+    /**
+     * Points {@code jpackage} at a custom runtime image.
+     *
+     * @param runtimeImage runtime image path
+     * @return this builder
+     */
     public JpackageCLIBuilder runtimeImage(Path runtimeImage) {
         Objects.requireNonNull(runtimeImage, "Runtime image path cannot be null");
         this.arguments.add("--runtime-image " + runtimeImage);
         return this;
     }
 
+    /**
+     * Sets the input directory containing application files.
+     *
+     * @param inputDirectory input folder
+     * @return this builder
+     */
     public JpackageCLIBuilder input(Path inputDirectory) {
         Objects.requireNonNull(inputDirectory, "Input directory cannot be null");
         this.arguments.add("--input " + inputDirectory);
         return this;
     }
 
+    /**
+     * Adds additional application content directories.
+     *
+     * @param contentPaths content paths
+     * @return this builder
+     */
     public JpackageCLIBuilder appContent(String... contentPaths) {
         Objects.requireNonNull(contentPaths, "App content paths cannot be null");
         this.arguments.add("--app-content " + String.join(",", contentPaths));
         return this;
     }
 
+    /**
+     * Declares an extra launcher with its properties file.
+     *
+     * @param name           launcher name
+     * @param propertiesFile launcher properties path
+     * @return this builder
+     */
     public JpackageCLIBuilder addLauncher(String name, Path propertiesFile) {
         Objects.requireNonNull(name, "Launcher name cannot be null");
         Objects.requireNonNull(propertiesFile, "Launcher properties files cannot be null");
@@ -196,70 +332,140 @@ public class JpackageCLIBuilder implements CLIBuilder<Process, JpackageCLIBuilde
         return this;
     }
 
+    /**
+     * Provides launcher-specific arguments to include in the bundle metadata.
+     *
+     * @param arguments launcher arguments
+     * @return this builder
+     */
     public JpackageCLIBuilder launcherArguments(String arguments) {
         Objects.requireNonNull(arguments, "Launcher arguments cannot be null");
         this.arguments.add("--arguments " + arguments);
         return this;
     }
 
+    /**
+     * Supplies JVM options for the launcher.
+     *
+     * @param options JVM options string
+     * @return this builder
+     */
     public JpackageCLIBuilder launcherJavaOptions(String options) {
         Objects.requireNonNull(options, "Java options cannot be null");
         this.arguments.add("--java-options " + options);
         return this;
     }
 
+    /**
+     * Provides the fully qualified main class name.
+     *
+     * @param mainClass main class
+     * @return this builder
+     */
     public JpackageCLIBuilder mainClass(String mainClass) {
         Objects.requireNonNull(mainClass, "Main class cannot be null");
         this.arguments.add("--main-class " + mainClass);
         return this;
     }
 
+    /**
+     * Sets the main JAR file to launch.
+     *
+     * @param jarPath path to the main JAR
+     * @return this builder
+     */
     public JpackageCLIBuilder mainJar(String jarPath) {
         Objects.requireNonNull(jarPath, "Main JAR path cannot be null");
         this.arguments.add("--main-jar " + jarPath);
         return this;
     }
 
+    /**
+     * Declares the primary module to launch.
+     *
+     * @param module module name
+     * @return this builder
+     */
     public JpackageCLIBuilder module(String module) {
         Objects.requireNonNull(module, "Module cannot be null");
         this.arguments.add("--module " + module);
         return this;
     }
 
+    /**
+     * Requests a Windows console application.
+     *
+     * @return this builder
+     */
     public JpackageCLIBuilder windowsConsole() {
         this.arguments.add("--win-console");
         return this;
     }
 
+    /**
+     * Sets the macOS bundle identifier.
+     *
+     * @param identifier bundle identifier
+     * @return this builder
+     */
     public JpackageCLIBuilder macPackageIdentifier(String identifier) {
         Objects.requireNonNull(identifier, "Identifier cannot be null");
         this.arguments.add("--mac-package-identifier " + identifier);
         return this;
     }
 
+    /**
+     * Sets the macOS package name.
+     *
+     * @param name mac package name
+     * @return this builder
+     */
     public JpackageCLIBuilder macPackageName(String name) {
         Objects.requireNonNull(name, "Mac package name cannot be null");
         this.arguments.add("--mac-package-name " + name);
         return this;
     }
 
+    /**
+     * Adds the signing prefix for macOS packages.
+     *
+     * @param prefix signing prefix
+     * @return this builder
+     */
     public JpackageCLIBuilder macPackageSigningPrefix(String prefix) {
         Objects.requireNonNull(prefix, "Signing prefix cannot be null");
         this.arguments.add("--mac-package-signing-prefix " + prefix);
         return this;
     }
 
+    /**
+     * Enables macOS signing for the package.
+     *
+     * @return this builder
+     */
     public JpackageCLIBuilder macSign() {
         this.arguments.add("--mac-sign");
         return this;
     }
 
+    /**
+     * Provides the macOS keychain used for signing.
+     *
+     * @param keychain keychain name
+     * @return this builder
+     */
     public JpackageCLIBuilder macSigningKeychain(String keychain) {
         Objects.requireNonNull(keychain, "Keychain cannot be null");
         this.arguments.add("--mac-signing-keychain " + keychain);
         return this;
     }
 
+    /**
+     * Sets the username for the macOS signing key.
+     *
+     * @param userName mac signing user name
+     * @return this builder
+     */
     public JpackageCLIBuilder macSigningKeyUser(String userName) {
         Objects.requireNonNull(userName, "User name cannot be null");
         this.arguments.add("--mac-signing-key-user-name " + userName);

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JpsCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JpsCLIBuilder.java
@@ -1,0 +1,137 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JpsCLIBuilder implements CLIBuilder<Process, JpsCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jps.exe" : "jps";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private String hostIdentifier;
+
+    private JpsCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JpsCLIBuilder create(JDK jdk) {
+        return new JpsCLIBuilder(jdk);
+    }
+
+    @Override
+    public JpsCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JpsCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JpsCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JpsCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JpsCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JpsCLIBuilder quiet() {
+        this.arguments.add("-q");
+        return this;
+    }
+
+    public JpsCLIBuilder showMainArguments() {
+        this.arguments.add("-m");
+        return this;
+    }
+
+    public JpsCLIBuilder showMainClassOrJar() {
+        this.arguments.add("-l");
+        return this;
+    }
+
+    public JpsCLIBuilder showJvmArguments() {
+        this.arguments.add("-v");
+        return this;
+    }
+
+    public JpsCLIBuilder showOnlyIdentifiers() {
+        this.arguments.add("-V");
+        return this;
+    }
+
+    public JpsCLIBuilder host(String hostIdentifier) {
+        Objects.requireNonNull(hostIdentifier, "Host identifier cannot be null");
+        this.hostIdentifier = hostIdentifier;
+        return this;
+    }
+
+    public JpsCLIBuilder help() {
+        this.arguments.add("-help");
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        if (hostIdentifier != null)
+            command.add(hostIdentifier);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jps");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jps process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JpsCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JpsCLIBuilder.java
@@ -25,10 +25,22 @@ public class JpsCLIBuilder implements CLIBuilder<Process, JpsCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new builder instance tied to the provided {@link JDK}.
+     *
+     * @param jdk the JDK to use
+     * @return builder ready for configuration
+     */
     public static JpsCLIBuilder create(JDK jdk) {
         return new JpsCLIBuilder(jdk);
     }
 
+    /**
+     * Adds a raw CLI argument to {@code jps}.
+     *
+     * @param arg argument value
+     * @return this builder
+     */
     @Override
     public JpsCLIBuilder addArgument(String arg) {
         Objects.requireNonNull(arg, "Argument cannot be null");
@@ -36,12 +48,25 @@ public class JpsCLIBuilder implements CLIBuilder<Process, JpsCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the working directory for the {@code jps} process.
+     *
+     * @param path working directory
+     * @return this builder
+     */
     @Override
     public JpsCLIBuilder setWorkingDirectory(Path path) {
         this.workingDirectory = path;
         return this;
     }
 
+    /**
+     * Adds or overrides an environment variable for the spawned process.
+     *
+     * @param key   variable name
+     * @param value variable value
+     * @return this builder
+     */
     @Override
     public JpsCLIBuilder setEnvironmentVariable(String key, String value) {
         Objects.requireNonNull(key, "Environment variable key cannot be null");
@@ -50,12 +75,25 @@ public class JpsCLIBuilder implements CLIBuilder<Process, JpsCLIBuilder> {
         return this;
     }
 
+    /**
+     * Controls whether the new process inherits the system environment variables.
+     *
+     * @param useSystemVars whether to inherit system variables
+     * @return this builder
+     */
     @Override
     public JpsCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
         this.useSystemEnvVars = useSystemVars;
         return this;
     }
 
+    /**
+     * Sets a timeout applied when enforcing process termination.
+     *
+     * @param duration timeout duration
+     * @param unit     time unit
+     * @return this builder
+     */
     @Override
     public JpsCLIBuilder setTimeout(long duration, TimeUnit unit) {
         if (duration < 0)
@@ -67,42 +105,83 @@ public class JpsCLIBuilder implements CLIBuilder<Process, JpsCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds the {@code -q} flag to suppress headers.
+     *
+     * @return this builder
+     */
     public JpsCLIBuilder quiet() {
         this.arguments.add("-q");
         return this;
     }
 
+    /**
+     * Adds {@code -m} to show main arguments for each JVM.
+     *
+     * @return this builder
+     */
     public JpsCLIBuilder showMainArguments() {
         this.arguments.add("-m");
         return this;
     }
 
+    /**
+     * Adds {@code -l} to show the main class or JAR for each JVM.
+     *
+     * @return this builder
+     */
     public JpsCLIBuilder showMainClassOrJar() {
         this.arguments.add("-l");
         return this;
     }
 
+    /**
+     * Adds {@code -v} to include JVM arguments in the output.
+     *
+     * @return this builder
+     */
     public JpsCLIBuilder showJvmArguments() {
         this.arguments.add("-v");
         return this;
     }
 
+    /**
+     * Adds {@code -V} to show only JVM identifiers.
+     *
+     * @return this builder
+     */
     public JpsCLIBuilder showOnlyIdentifiers() {
         this.arguments.add("-V");
         return this;
     }
 
+    /**
+     * Targets a remote host identifier.
+     *
+     * @param hostIdentifier host address or name
+     * @return this builder
+     */
     public JpsCLIBuilder host(String hostIdentifier) {
         Objects.requireNonNull(hostIdentifier, "Host identifier cannot be null");
         this.hostIdentifier = hostIdentifier;
         return this;
     }
 
+    /**
+     * Adds {@code -help} to the argument list.
+     *
+     * @return this builder
+     */
     public JpsCLIBuilder help() {
         this.arguments.add("-help");
         return this;
     }
 
+    /**
+     * Starts the configured {@code jps} process enforcing the timeout policy.
+     *
+     * @return started process
+     */
     @Override
     public Process run() {
         List<String> command = new ArrayList<>();

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JshellCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JshellCLIBuilder.java
@@ -11,6 +11,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder that exposes the {@code jshell} launcher backed by a specific {@link JDK}.
+ * <p>
+ * Fluent helpers configure exports, modules, classpath settings, and various feedback toggles
+ * before the interactive shell process is executed.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jshell.html">jshell command documentation</a>
+ */
 public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jshell.exe" : "jshell";
 
@@ -27,6 +36,12 @@ public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Starts a builder tied to the provided {@link JDK}.
+     *
+     * @param jdk JDK supplying {@code jshell}
+     * @return a new builder instance
+     */
     public static JshellCLIBuilder create(JDK jdk) {
         return new JshellCLIBuilder(jdk);
     }
@@ -69,18 +84,37 @@ public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds an {@code --add-exports} directive.
+     *
+     * @param moduleAndPackage the module/package pair (e.g. {@code java.base/java.lang})
+     * @return this builder
+     */
     public JshellCLIBuilder addExports(String moduleAndPackage) {
         Objects.requireNonNull(moduleAndPackage, "Module/package cannot be null");
         this.arguments.add("--add-exports " + moduleAndPackage);
         return this;
     }
 
+    /**
+     * Adds an {@code --add-exports} directive by splitting module and package arguments.
+     *
+     * @param moduleName  module name
+     * @param packageName package name
+     * @return this builder
+     */
     public JshellCLIBuilder addExports(String moduleName, String packageName) {
         Objects.requireNonNull(moduleName, "Module name cannot be null");
         Objects.requireNonNull(packageName, "Package name cannot be null");
         return addExports(moduleName + "/" + packageName);
     }
 
+    /**
+     * Adds {@code --add-modules} with the provided module list.
+     *
+     * @param modules module names
+     * @return this builder
+     */
     public JshellCLIBuilder addModules(String... modules) {
         Objects.requireNonNull(modules, "Modules cannot be null");
         if (modules.length == 0)
@@ -94,6 +128,12 @@ public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
         return this;
     }
 
+    /**
+     * Attaches compiler-specific options via {@code -C}.
+     *
+     * @param options compiler options
+     * @return this builder
+     */
     public JshellCLIBuilder compilerOptions(String... options) {
         Objects.requireNonNull(options, "Compiler options cannot be null");
         for (String option : options) {
@@ -104,6 +144,12 @@ public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the compilation classpath for {@code jshell}.
+     *
+     * @param entries classpath entries
+     * @return this builder
+     */
     public JshellCLIBuilder classPath(String... entries) {
         Objects.requireNonNull(entries, "Classpath entries cannot be null");
         if (entries.length == 0)
@@ -113,44 +159,89 @@ public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets classpath entries using {@link Path} values.
+     *
+     * @param entries classpath entries
+     * @return this builder
+     */
     public JshellCLIBuilder classPath(Path... entries) {
         Objects.requireNonNull(entries, "Classpath entries cannot be null");
         String[] entryStrings = Arrays.stream(entries).map(path -> Objects.requireNonNull(path, "Classpath path cannot be null").toString()).toArray(String[]::new);
         return classPath(entryStrings);
     }
 
+    /**
+     * Enables preview language features via {@code --enable-preview}.
+     *
+     * @return this builder
+     */
     public JshellCLIBuilder enablePreview() {
         this.arguments.add("--enable-preview");
         return this;
     }
 
+    /**
+     * Sets the execution engine (like {@code java} or {@code jshell} implementations).
+     *
+     * @param specification engine name or specification
+     * @return this builder
+     */
     public JshellCLIBuilder executionEngine(String specification) {
         Objects.requireNonNull(specification, "Execution specification cannot be null");
         this.arguments.add("--execution " + specification);
         return this;
     }
 
+    /**
+     * Chooses the feedback mode by keyword.
+     *
+     * @param mode feedback keyword
+     * @return this builder
+     */
     public JshellCLIBuilder feedbackMode(String mode) {
         Objects.requireNonNull(mode, "Feedback mode cannot be null");
         this.arguments.add("--feedback " + mode);
         return this;
     }
 
+    /**
+     * Chooses the feedback mode via {@link FeedbackMode}.
+     *
+     * @param mode feedback mode
+     * @return this builder
+     */
     public JshellCLIBuilder feedbackMode(FeedbackMode mode) {
         Objects.requireNonNull(mode, "Feedback mode cannot be null");
         return feedbackMode(mode.getMode());
     }
 
+    /**
+     * Requests {@code --help} output.
+     *
+     * @return this builder
+     */
     public JshellCLIBuilder help() {
         this.arguments.add("--help");
         return this;
     }
 
+    /**
+     * Enables {@code --help-extra} to include additional guidance.
+     *
+     * @return this builder
+     */
     public JshellCLIBuilder helpExtra() {
         this.arguments.add("--help-extra");
         return this;
     }
 
+    /**
+     * Supplies JVM options prefixed with {@code -J}.
+     *
+     * @param options JVM options
+     * @return this builder
+     */
     public JshellCLIBuilder jvmOptions(String... options) {
         Objects.requireNonNull(options, "JVM options cannot be null");
         for (String option : options) {
@@ -161,6 +252,12 @@ public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
         return this;
     }
 
+    /**
+     * Configures the module path for this {@code jshell} session.
+     *
+     * @param modulePaths module path entries
+     * @return this builder
+     */
     public JshellCLIBuilder modulePath(String... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module paths cannot be null");
         if (modulePaths.length == 0)
@@ -170,22 +267,44 @@ public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
         return this;
     }
 
+    /**
+     * Configures the module path via {@link Path} instances.
+     *
+     * @param modulePaths module path entries
+     * @return this builder
+     */
     public JshellCLIBuilder modulePath(Path... modulePaths) {
         Objects.requireNonNull(modulePaths, "Module paths cannot be null");
         String[] pathStrings = Arrays.stream(modulePaths).map(path -> Objects.requireNonNull(path, "Module path cannot be null").toString()).toArray(String[]::new);
         return modulePath(pathStrings);
     }
 
+    /**
+     * Disables loading of startup scripts.
+     *
+     * @return this builder
+     */
     public JshellCLIBuilder noStartupScripts() {
         this.arguments.add("--no-startup");
         return this;
     }
 
+    /**
+     * Requests concise feedback with {@code -q}.
+     *
+     * @return this builder
+     */
     public JshellCLIBuilder conciseFeedback() {
         this.arguments.add("-q");
         return this;
     }
 
+    /**
+     * Adds runtime options prefixed with {@code -R}.
+     *
+     * @param options runtime options
+     * @return this builder
+     */
     public JshellCLIBuilder runtimeOptions(String... options) {
         Objects.requireNonNull(options, "Runtime options cannot be null");
         for (String option : options) {
@@ -196,48 +315,97 @@ public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
         return this;
     }
 
+    /**
+     * Requests silent mode via {@code -s}.
+     *
+     * @return this builder
+     */
     public JshellCLIBuilder silentFeedback() {
         this.arguments.add("-s");
         return this;
     }
 
+    /**
+     * Prints version information and enters the shell.
+     *
+     * @return this builder
+     */
     public JshellCLIBuilder showVersionAndEnter() {
         this.arguments.add("--show-version");
         return this;
     }
 
+    /**
+     * Loads a startup script by name.
+     *
+     * @param scriptName script file name
+     * @return this builder
+     */
     public JshellCLIBuilder startupScript(String scriptName) {
         Objects.requireNonNull(scriptName, "Startup script cannot be null");
         this.arguments.add("--startup " + scriptName);
         return this;
     }
 
+    /**
+     * Loads a startup script from a {@link Path}.
+     *
+     * @param scriptPath path to the startup script
+     * @return this builder
+     */
     public JshellCLIBuilder startupScript(Path scriptPath) {
         Objects.requireNonNull(scriptPath, "Startup script path cannot be null");
         return startupScript(scriptPath.toString());
     }
 
+    /**
+     * Enables verbose feedback via {@code -v}.
+     *
+     * @return this builder
+     */
     public JshellCLIBuilder verboseFeedback() {
         this.arguments.add("-v");
         return this;
     }
 
+    /**
+     * Prints the JShell version.
+     *
+     * @return this builder
+     */
     public JshellCLIBuilder version() {
         this.arguments.add("--version");
         return this;
     }
 
+    /**
+     * Queues a file to load after {@code jshell} starts.
+     *
+     * @param loadFile load file path or {@code -} to read from stdin
+     * @return this builder
+     */
     public JshellCLIBuilder addLoadFile(String loadFile) {
         Objects.requireNonNull(loadFile, "Load file cannot be null");
         this.loadFiles.add(loadFile);
         return this;
     }
 
+    /**
+     * Queues a {@link Path}-based file to load.
+     *
+     * @param path load file path
+     * @return this builder
+     */
     public JshellCLIBuilder addLoadFile(Path path) {
         Objects.requireNonNull(path, "Load file path cannot be null");
         return addLoadFile(path.toString());
     }
 
+    /**
+     * Allows {@code jshell} to accept input from {@code stdin}.
+     *
+     * @return this builder
+     */
     public JshellCLIBuilder acceptInputFromStdin() {
         this.loadFiles.add("-");
         return this;
@@ -274,6 +442,9 @@ public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
         }
     }
 
+    /**
+     * Encapsulates the supported feedback modes for JShell.
+     */
     @Getter
     public enum FeedbackMode {
         VERBOSE("verbose"),

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JshellCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JshellCLIBuilder.java
@@ -1,0 +1,291 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+import lombok.Getter;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JshellCLIBuilder implements CLIBuilder<Process, JshellCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jshell.exe" : "jshell";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<String> loadFiles = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private JshellCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JshellCLIBuilder create(JDK jdk) {
+        return new JshellCLIBuilder(jdk);
+    }
+
+    @Override
+    public JshellCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JshellCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JshellCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JshellCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JshellCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JshellCLIBuilder addExports(String moduleAndPackage) {
+        Objects.requireNonNull(moduleAndPackage, "Module/package cannot be null");
+        this.arguments.add("--add-exports " + moduleAndPackage);
+        return this;
+    }
+
+    public JshellCLIBuilder addExports(String moduleName, String packageName) {
+        Objects.requireNonNull(moduleName, "Module name cannot be null");
+        Objects.requireNonNull(packageName, "Package name cannot be null");
+        return addExports(moduleName + "/" + packageName);
+    }
+
+    public JshellCLIBuilder addModules(String... modules) {
+        Objects.requireNonNull(modules, "Modules cannot be null");
+        if (modules.length == 0)
+            throw new IllegalArgumentException("At least one module must be provided");
+
+        for (String module : modules) {
+            Objects.requireNonNull(module, "Module name cannot be null");
+        }
+
+        this.arguments.add("--add-modules " + String.join(",", modules));
+        return this;
+    }
+
+    public JshellCLIBuilder compilerOptions(String... options) {
+        Objects.requireNonNull(options, "Compiler options cannot be null");
+        for (String option : options) {
+            Objects.requireNonNull(option, "Compiler option cannot be null");
+            this.arguments.add("-C" + option);
+        }
+
+        return this;
+    }
+
+    public JshellCLIBuilder classPath(String... entries) {
+        Objects.requireNonNull(entries, "Classpath entries cannot be null");
+        if (entries.length == 0)
+            throw new IllegalArgumentException("At least one classpath entry must be provided");
+
+        this.arguments.add("--class-path " + String.join(File.pathSeparator, entries));
+        return this;
+    }
+
+    public JshellCLIBuilder classPath(Path... entries) {
+        Objects.requireNonNull(entries, "Classpath entries cannot be null");
+        String[] entryStrings = Arrays.stream(entries).map(path -> Objects.requireNonNull(path, "Classpath path cannot be null").toString()).toArray(String[]::new);
+        return classPath(entryStrings);
+    }
+
+    public JshellCLIBuilder enablePreview() {
+        this.arguments.add("--enable-preview");
+        return this;
+    }
+
+    public JshellCLIBuilder executionEngine(String specification) {
+        Objects.requireNonNull(specification, "Execution specification cannot be null");
+        this.arguments.add("--execution " + specification);
+        return this;
+    }
+
+    public JshellCLIBuilder feedbackMode(String mode) {
+        Objects.requireNonNull(mode, "Feedback mode cannot be null");
+        this.arguments.add("--feedback " + mode);
+        return this;
+    }
+
+    public JshellCLIBuilder feedbackMode(FeedbackMode mode) {
+        Objects.requireNonNull(mode, "Feedback mode cannot be null");
+        return feedbackMode(mode.getMode());
+    }
+
+    public JshellCLIBuilder help() {
+        this.arguments.add("--help");
+        return this;
+    }
+
+    public JshellCLIBuilder helpExtra() {
+        this.arguments.add("--help-extra");
+        return this;
+    }
+
+    public JshellCLIBuilder jvmOptions(String... options) {
+        Objects.requireNonNull(options, "JVM options cannot be null");
+        for (String option : options) {
+            Objects.requireNonNull(option, "JVM option cannot be null");
+            this.arguments.add("-J" + option);
+        }
+
+        return this;
+    }
+
+    public JshellCLIBuilder modulePath(String... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module paths cannot be null");
+        if (modulePaths.length == 0)
+            throw new IllegalArgumentException("At least one module path must be provided");
+
+        this.arguments.add("--module-path " + String.join(File.pathSeparator, modulePaths));
+        return this;
+    }
+
+    public JshellCLIBuilder modulePath(Path... modulePaths) {
+        Objects.requireNonNull(modulePaths, "Module paths cannot be null");
+        String[] pathStrings = Arrays.stream(modulePaths).map(path -> Objects.requireNonNull(path, "Module path cannot be null").toString()).toArray(String[]::new);
+        return modulePath(pathStrings);
+    }
+
+    public JshellCLIBuilder noStartupScripts() {
+        this.arguments.add("--no-startup");
+        return this;
+    }
+
+    public JshellCLIBuilder conciseFeedback() {
+        this.arguments.add("-q");
+        return this;
+    }
+
+    public JshellCLIBuilder runtimeOptions(String... options) {
+        Objects.requireNonNull(options, "Runtime options cannot be null");
+        for (String option : options) {
+            Objects.requireNonNull(option, "Runtime option cannot be null");
+            this.arguments.add("-R" + option);
+        }
+
+        return this;
+    }
+
+    public JshellCLIBuilder silentFeedback() {
+        this.arguments.add("-s");
+        return this;
+    }
+
+    public JshellCLIBuilder showVersionAndEnter() {
+        this.arguments.add("--show-version");
+        return this;
+    }
+
+    public JshellCLIBuilder startupScript(String scriptName) {
+        Objects.requireNonNull(scriptName, "Startup script cannot be null");
+        this.arguments.add("--startup " + scriptName);
+        return this;
+    }
+
+    public JshellCLIBuilder startupScript(Path scriptPath) {
+        Objects.requireNonNull(scriptPath, "Startup script path cannot be null");
+        return startupScript(scriptPath.toString());
+    }
+
+    public JshellCLIBuilder verboseFeedback() {
+        this.arguments.add("-v");
+        return this;
+    }
+
+    public JshellCLIBuilder version() {
+        this.arguments.add("--version");
+        return this;
+    }
+
+    public JshellCLIBuilder addLoadFile(String loadFile) {
+        Objects.requireNonNull(loadFile, "Load file cannot be null");
+        this.loadFiles.add(loadFile);
+        return this;
+    }
+
+    public JshellCLIBuilder addLoadFile(Path path) {
+        Objects.requireNonNull(path, "Load file path cannot be null");
+        return addLoadFile(path.toString());
+    }
+
+    public JshellCLIBuilder acceptInputFromStdin() {
+        this.loadFiles.add("-");
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        command.addAll(loadFiles);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jshell");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jshell process", exception);
+        }
+    }
+
+    @Getter
+    public enum FeedbackMode {
+        VERBOSE("verbose"),
+        NORMAL("normal"),
+        CONCISE("concise"),
+        SILENT("silent"),
+        CUSTOM("custom");
+
+        private final String mode;
+
+        FeedbackMode(String mode) {
+            this.mode = mode;
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JstackCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JstackCLIBuilder.java
@@ -9,6 +9,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder for configuring and executing {@code jstack} backed by a {@link JDK}.
+ * <p>
+ * Provides helpers to point {@code jstack} at a target process, toggle verbosity,
+ * and pass through Java launcher options before running the tool.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jstack.html">jstack command documentation</a>
+ */
 public class JstackCLIBuilder implements CLIBuilder<Process, JstackCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jstack.exe" : "jstack";
 
@@ -25,6 +34,12 @@ public class JstackCLIBuilder implements CLIBuilder<Process, JstackCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Constructs a new builder that uses the supplied {@link JDK}.
+     *
+     * @param jdk the JDK to invoke {@code jstack} from
+     * @return a builder ready for configuration
+     */
     public static JstackCLIBuilder create(JDK jdk) {
         return new JstackCLIBuilder(jdk);
     }
@@ -67,6 +82,12 @@ public class JstackCLIBuilder implements CLIBuilder<Process, JstackCLIBuilder> {
         return this;
     }
 
+    /**
+     * Targets {@code jstack} at a numeric process ID.
+     *
+     * @param pid positive process identifier
+     * @return this builder
+     */
     public JstackCLIBuilder processId(long pid) {
         if (pid <= 0)
             throw new IllegalArgumentException("PID must be positive");
@@ -75,27 +96,54 @@ public class JstackCLIBuilder implements CLIBuilder<Process, JstackCLIBuilder> {
         return this;
     }
 
+    /**
+     * Targets {@code jstack} at a string-based process identifier (host:pid style).
+     *
+     * @param pid process identifier
+     * @return this builder
+     */
     public JstackCLIBuilder processId(String pid) {
         Objects.requireNonNull(pid, "PID cannot be null");
         this.processId = pid;
         return this;
     }
 
+    /**
+     * Adds {@code -l} for a long thread listing.
+     *
+     * @return this builder
+     */
     public JstackCLIBuilder longListing() {
         this.arguments.add("-l");
         return this;
     }
 
+    /**
+     * Requests the {@code -help} summary.
+     *
+     * @return this builder
+     */
     public JstackCLIBuilder help() {
         this.arguments.add("-help");
         return this;
     }
 
+    /**
+     * Requests the short {@code -h} help output.
+     *
+     * @return this builder
+     */
     public JstackCLIBuilder shortHelp() {
         this.arguments.add("-h");
         return this;
     }
 
+    /**
+     * Passes a JVM option through {@code -J}.
+     *
+     * @param option JVM argument
+     * @return this builder
+     */
     public JstackCLIBuilder javaOption(String option) {
         Objects.requireNonNull(option, "Java option cannot be null");
         this.arguments.add("-J" + option);

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JstackCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JstackCLIBuilder.java
@@ -1,0 +1,138 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JstackCLIBuilder implements CLIBuilder<Process, JstackCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jstack.exe" : "jstack";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private String processId;
+
+    private JstackCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JstackCLIBuilder create(JDK jdk) {
+        return new JstackCLIBuilder(jdk);
+    }
+
+    @Override
+    public JstackCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JstackCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JstackCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JstackCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JstackCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JstackCLIBuilder processId(long pid) {
+        if (pid <= 0)
+            throw new IllegalArgumentException("PID must be positive");
+
+        this.processId = Long.toString(pid);
+        return this;
+    }
+
+    public JstackCLIBuilder processId(String pid) {
+        Objects.requireNonNull(pid, "PID cannot be null");
+        this.processId = pid;
+        return this;
+    }
+
+    public JstackCLIBuilder longListing() {
+        this.arguments.add("-l");
+        return this;
+    }
+
+    public JstackCLIBuilder help() {
+        this.arguments.add("-help");
+        return this;
+    }
+
+    public JstackCLIBuilder shortHelp() {
+        this.arguments.add("-h");
+        return this;
+    }
+
+    public JstackCLIBuilder javaOption(String option) {
+        Objects.requireNonNull(option, "Java option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        if (processId == null)
+            throw new IllegalStateException("A process ID must be specified for jstack.");
+
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        command.add(processId);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jstack");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jstack process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JstatCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JstatCLIBuilder.java
@@ -9,6 +9,15 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Fluent builder for configuring and running the {@code jstat} diagnostic utility shipped with a {@link JDK}.
+ * <p>
+ * Provides helpers for selecting general options, stat counters, VM identifiers, and sampling intervals
+ * before executing {@code jstat} via {@link ProcessExecution}.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jstat.html">jstat command documentation</a>
+ */
 public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jstat.exe" : "jstat";
 
@@ -30,6 +39,12 @@ public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Instantiates a builder bound to the given {@link JDK}.
+     *
+     * @param jdk the JDK that provides {@code jstat}
+     * @return a new builder instance
+     */
     public static JstatCLIBuilder create(JDK jdk) {
         return new JstatCLIBuilder(jdk);
     }
@@ -73,21 +88,43 @@ public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
         return this;
     }
 
+    /**
+     * Requests {@code -help} output from {@code jstat}.
+     *
+     * @return this builder
+     */
     public JstatCLIBuilder help() {
         selectGeneralOption("-help");
         return this;
     }
 
+    /**
+     * Adds {@code -options} to list available statistics.
+     *
+     * @return this builder
+     */
     public JstatCLIBuilder listStatOptions() {
         selectGeneralOption("-options");
         return this;
     }
 
+    /**
+     * Specifies a pre-defined stat option.
+     *
+     * @param option stat option
+     * @return this builder
+     */
     public JstatCLIBuilder statOption(StatOption option) {
         Objects.requireNonNull(option, "Stat option cannot be null");
         return statOption(option.getFlag());
     }
 
+    /**
+     * Specifies a custom stat option flag.
+     *
+     * @param option stat option flag
+     * @return this builder
+     */
     public JstatCLIBuilder statOption(String option) {
         ensureGeneralOptionNotSet();
         Objects.requireNonNull(option, "Stat option cannot be null");
@@ -98,12 +135,23 @@ public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
         return this;
     }
 
+    /**
+     * Requests timestamps via {@code -t}.
+     *
+     * @return this builder
+     */
     public JstatCLIBuilder showTimestamp() {
         ensureGeneralOptionNotSet();
         this.arguments.add("-t");
         return this;
     }
 
+    /**
+     * Inserts {@code -h <lines>} to repeat headers.
+     *
+     * @param lines header frequency
+     * @return this builder
+     */
     public JstatCLIBuilder headerEvery(int lines) {
         ensureGeneralOptionNotSet();
         if (lines < 0)
@@ -114,6 +162,12 @@ public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a JVM argument with {@code -J}.
+     *
+     * @param option JVM option
+     * @return this builder
+     */
     public JstatCLIBuilder javaOption(String option) {
         ensureGeneralOptionNotSet();
         Objects.requireNonNull(option, "Java option cannot be null");
@@ -124,6 +178,12 @@ public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds multiple JVM options.
+     *
+     * @param options JVM options
+     * @return this builder
+     */
     public JstatCLIBuilder javaOptions(String... options) {
         Objects.requireNonNull(options, "Java options cannot be null");
         for (String option : options) {
@@ -133,6 +193,12 @@ public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
         return this;
     }
 
+    /**
+     * Targets a VM using its numeric PID.
+     *
+     * @param pid process identifier
+     * @return this builder
+     */
     public JstatCLIBuilder vmId(long pid) {
         ensureGeneralOptionNotSet();
         if (pid <= 0)
@@ -142,6 +208,12 @@ public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
         return this;
     }
 
+    /**
+     * Targets a VM using a string identifier.
+     *
+     * @param vmIdentifier VM identifier
+     * @return this builder
+     */
     public JstatCLIBuilder vmId(String vmIdentifier) {
         ensureGeneralOptionNotSet();
         Objects.requireNonNull(vmIdentifier, "VM identifier cannot be null");
@@ -152,6 +224,13 @@ public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the sampling interval via {@code <value><unit>}.
+     *
+     * @param interval interval value
+     * @param unit     time unit
+     * @return this builder
+     */
     public JstatCLIBuilder samplingInterval(long interval, TimeUnit unit) {
         ensureGeneralOptionNotSet();
         if (interval <= 0)
@@ -162,6 +241,12 @@ public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
         return this;
     }
 
+    /**
+     * Configures the number of samples to collect.
+     *
+     * @param count sample count
+     * @return this builder
+     */
     public JstatCLIBuilder sampleCount(int count) {
         ensureGeneralOptionNotSet();
         if (count <= 0)

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JstatCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JstatCLIBuilder.java
@@ -1,0 +1,271 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JstatCLIBuilder implements CLIBuilder<Process, JstatCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jstat.exe" : "jstat";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private String generalOption;
+    private String statOption;
+    private String vmId;
+    private String intervalExpression;
+    private Integer sampleCount;
+
+    private JstatCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JstatCLIBuilder create(JDK jdk) {
+        return new JstatCLIBuilder(jdk);
+    }
+
+    @Override
+    public JstatCLIBuilder addArgument(String arg) {
+        ensureGeneralOptionNotSet();
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JstatCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JstatCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JstatCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JstatCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JstatCLIBuilder help() {
+        selectGeneralOption("-help");
+        return this;
+    }
+
+    public JstatCLIBuilder listStatOptions() {
+        selectGeneralOption("-options");
+        return this;
+    }
+
+    public JstatCLIBuilder statOption(StatOption option) {
+        Objects.requireNonNull(option, "Stat option cannot be null");
+        return statOption(option.getFlag());
+    }
+
+    public JstatCLIBuilder statOption(String option) {
+        ensureGeneralOptionNotSet();
+        Objects.requireNonNull(option, "Stat option cannot be null");
+        if (option.isBlank())
+            throw new IllegalArgumentException("Stat option cannot be blank");
+
+        this.statOption = option.startsWith("-") ? option : "-" + option;
+        return this;
+    }
+
+    public JstatCLIBuilder showTimestamp() {
+        ensureGeneralOptionNotSet();
+        this.arguments.add("-t");
+        return this;
+    }
+
+    public JstatCLIBuilder headerEvery(int lines) {
+        ensureGeneralOptionNotSet();
+        if (lines < 0)
+            throw new IllegalArgumentException("Header frequency must be zero or greater");
+
+        this.arguments.add("-h");
+        this.arguments.add(Integer.toString(lines));
+        return this;
+    }
+
+    public JstatCLIBuilder javaOption(String option) {
+        ensureGeneralOptionNotSet();
+        Objects.requireNonNull(option, "Java option cannot be null");
+        if (option.isBlank())
+            throw new IllegalArgumentException("Java option cannot be blank");
+
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    public JstatCLIBuilder javaOptions(String... options) {
+        Objects.requireNonNull(options, "Java options cannot be null");
+        for (String option : options) {
+            javaOption(option);
+        }
+
+        return this;
+    }
+
+    public JstatCLIBuilder vmId(long pid) {
+        ensureGeneralOptionNotSet();
+        if (pid <= 0)
+            throw new IllegalArgumentException("PID must be positive");
+
+        this.vmId = Long.toString(pid);
+        return this;
+    }
+
+    public JstatCLIBuilder vmId(String vmIdentifier) {
+        ensureGeneralOptionNotSet();
+        Objects.requireNonNull(vmIdentifier, "VM identifier cannot be null");
+        if (vmIdentifier.isBlank())
+            throw new IllegalArgumentException("VM identifier cannot be blank");
+
+        this.vmId = vmIdentifier;
+        return this;
+    }
+
+    public JstatCLIBuilder samplingInterval(long interval, TimeUnit unit) {
+        ensureGeneralOptionNotSet();
+        if (interval <= 0)
+            throw new IllegalArgumentException("Interval must be positive");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.intervalExpression = formatInterval(interval, unit);
+        return this;
+    }
+
+    public JstatCLIBuilder sampleCount(int count) {
+        ensureGeneralOptionNotSet();
+        if (count <= 0)
+            throw new IllegalArgumentException("Sample count must be positive");
+
+        this.sampleCount = count;
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+
+        if (generalOption != null) {
+            command.add(generalOption);
+        } else {
+            if (statOption == null)
+                throw new IllegalStateException("A stat option must be specified when not using a general option.");
+            if (vmId == null)
+                throw new IllegalStateException("A VM identifier must be specified when using jstat output options.");
+            if (sampleCount != null && intervalExpression == null)
+                throw new IllegalStateException("A sampling interval must be specified before setting a sample count.");
+
+            command.add(statOption);
+            command.addAll(arguments);
+            command.add(vmId);
+
+            if (intervalExpression != null) {
+                command.add(intervalExpression);
+                if (sampleCount != null)
+                    command.add(Integer.toString(sampleCount));
+            }
+        }
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jstat");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jstat process", exception);
+        }
+    }
+
+    private void selectGeneralOption(String optionFlag) {
+        if (this.generalOption != null)
+            throw new IllegalStateException("Only one jstat general option can be specified.");
+
+        if (statOption != null || vmId != null || intervalExpression != null || sampleCount != null || !arguments.isEmpty())
+            throw new IllegalStateException("General options cannot be combined with other jstat configuration.");
+
+        this.generalOption = optionFlag;
+    }
+
+    private void ensureGeneralOptionNotSet() {
+        if (generalOption != null)
+            throw new IllegalStateException("Cannot combine general jstat options with other configuration.");
+    }
+
+    private static String formatInterval(long interval, TimeUnit unit) {
+        return switch (unit) {
+            case MILLISECONDS -> interval + "ms";
+            case SECONDS -> interval + "s";
+            default -> throw new IllegalArgumentException("jstat intervals support only seconds or milliseconds");
+        };
+    }
+
+    public enum StatOption {
+        CLASS("class"),
+        COMPILER("compiler"),
+        GC("gc"),
+        GC_CAPACITY("gccapacity"),
+        GC_CAUSE("gccause"),
+        GC_NEW("gcnew"),
+        GC_NEW_CAPACITY("gcnewcapacity"),
+        GC_OLD("gcold"),
+        GC_OLD_CAPACITY("gcoldcapacity"),
+        GC_META_CAPACITY("gcmetacapacity"),
+        GC_UTIL("gcutil"),
+        PRINT_COMPILATION("printcompilation");
+
+        private final String flag;
+
+        StatOption(String flag) {
+            this.flag = flag;
+        }
+
+        public String getFlag() {
+            return "-" + flag;
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JstatdCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JstatdCLIBuilder.java
@@ -1,0 +1,138 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class JstatdCLIBuilder implements CLIBuilder<Process, JstatdCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jstatd.exe" : "jstatd";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private JstatdCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static JstatdCLIBuilder create(JDK jdk) {
+        return new JstatdCLIBuilder(jdk);
+    }
+
+    @Override
+    public JstatdCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public JstatdCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public JstatdCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public JstatdCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public JstatdCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public JstatdCLIBuilder noInternalRegistry() {
+        this.arguments.add("-nr");
+        return this;
+    }
+
+    public JstatdCLIBuilder registryPort(int port) {
+        validatePort(port, "Registry port must be between 1 and 65535");
+        this.arguments.add("-p");
+        this.arguments.add(Integer.toString(port));
+        return this;
+    }
+
+    public JstatdCLIBuilder connectorPort(int port) {
+        validatePort(port, "Connector port must be between 1 and 65535");
+        this.arguments.add("-r");
+        this.arguments.add(Integer.toString(port));
+        return this;
+    }
+
+    public JstatdCLIBuilder rmiObjectName(String name) {
+        Objects.requireNonNull(name, "RMI object name cannot be null");
+        if (name.isBlank())
+            throw new IllegalArgumentException("RMI object name cannot be blank");
+
+        this.arguments.add("-n");
+        this.arguments.add(name);
+        return this;
+    }
+
+    public JstatdCLIBuilder javaOption(String option) {
+        Objects.requireNonNull(option, "Java option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "jstatd");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start jstatd process", exception);
+        }
+    }
+
+    private static void validatePort(int port, String message) {
+        if (port <= 0 || port > 65535)
+            throw new IllegalArgumentException(message);
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/JstatdCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/JstatdCLIBuilder.java
@@ -9,6 +9,14 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder to configure {@code jstatd} daemon processes using a specific {@link JDK}.
+ * <p>
+ * Enables toggles for registry/connector ports, RMI object names, and runtime options.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/jstatd.html">jstatd command documentation</a>
+ */
 public class JstatdCLIBuilder implements CLIBuilder<Process, JstatdCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "jstatd.exe" : "jstatd";
 
@@ -24,6 +32,12 @@ public class JstatdCLIBuilder implements CLIBuilder<Process, JstatdCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a builder tied to the provided {@link JDK}.
+     *
+     * @param jdk the JDK providing {@code jstatd}
+     * @return a new builder instance
+     */
     public static JstatdCLIBuilder create(JDK jdk) {
         return new JstatdCLIBuilder(jdk);
     }
@@ -66,11 +80,22 @@ public class JstatdCLIBuilder implements CLIBuilder<Process, JstatdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds {@code -nr} to disable the internal registry.
+     *
+     * @return this builder
+     */
     public JstatdCLIBuilder noInternalRegistry() {
         this.arguments.add("-nr");
         return this;
     }
 
+    /**
+     * Sets a specific registry port with {@code -p}.
+     *
+     * @param port registry port
+     * @return this builder
+     */
     public JstatdCLIBuilder registryPort(int port) {
         validatePort(port, "Registry port must be between 1 and 65535");
         this.arguments.add("-p");
@@ -78,6 +103,12 @@ public class JstatdCLIBuilder implements CLIBuilder<Process, JstatdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets a connector port via {@code -r}.
+     *
+     * @param port connector port
+     * @return this builder
+     */
     public JstatdCLIBuilder connectorPort(int port) {
         validatePort(port, "Connector port must be between 1 and 65535");
         this.arguments.add("-r");
@@ -85,6 +116,12 @@ public class JstatdCLIBuilder implements CLIBuilder<Process, JstatdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Provides an RMI object name using {@code -n}.
+     *
+     * @param name object name
+     * @return this builder
+     */
     public JstatdCLIBuilder rmiObjectName(String name) {
         Objects.requireNonNull(name, "RMI object name cannot be null");
         if (name.isBlank())
@@ -95,6 +132,12 @@ public class JstatdCLIBuilder implements CLIBuilder<Process, JstatdCLIBuilder> {
         return this;
     }
 
+    /**
+     * Supplies a JVM option via {@code -J}.
+     *
+     * @param option JVM option
+     * @return this builder
+     */
     public JstatdCLIBuilder javaOption(String option) {
         Objects.requireNonNull(option, "Java option cannot be null");
         this.arguments.add("-J" + option);

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/KeytoolCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/KeytoolCLIBuilder.java
@@ -1,0 +1,571 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+import lombok.Getter;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Builder for invoking the {@code keytool} command.
+ */
+public class KeytoolCLIBuilder implements CLIBuilder<Process, KeytoolCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "keytool.exe" : "keytool";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private Path workingDirectory;
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private KeytoolCommand selectedCommand;
+
+    private KeytoolCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static KeytoolCLIBuilder create(JDK jdk) {
+        return new KeytoolCLIBuilder(jdk);
+    }
+
+    @Override
+    public KeytoolCLIBuilder addArgument(String arg) {
+        this.arguments.add(Objects.requireNonNull(arg, "Argument cannot be null"));
+        return this;
+    }
+
+    @Override
+    public KeytoolCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = Objects.requireNonNull(path, "Working directory cannot be null");
+        return this;
+    }
+
+    @Override
+    public KeytoolCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment key cannot be null");
+        Objects.requireNonNull(value, "Environment value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public KeytoolCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public KeytoolCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        this.timeoutDuration = duration;
+        this.timeoutUnit = Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        return this;
+    }
+
+    /**
+     * Sets the keytool command to run. Only a single command may be selected.
+     */
+    public KeytoolCLIBuilder command(KeytoolCommand command) {
+        Objects.requireNonNull(command, "Command cannot be null");
+        if (this.selectedCommand != null)
+            throw new IllegalStateException("Only one keytool command can be specified per invocation.");
+
+        this.arguments.add(command.getFlag());
+        this.selectedCommand = command;
+        return this;
+    }
+
+    public KeytoolCLIBuilder certreq() {
+        return command(KeytoolCommand.CERTREQ);
+    }
+
+    public KeytoolCLIBuilder changeAlias() {
+        return command(KeytoolCommand.CHANGE_ALIAS);
+    }
+
+    public KeytoolCLIBuilder deleteEntry() {
+        return command(KeytoolCommand.DELETE);
+    }
+
+    public KeytoolCLIBuilder exportCertificate() {
+        return command(KeytoolCommand.EXPORT_CERT);
+    }
+
+    public KeytoolCLIBuilder generateCertificate() {
+        return command(KeytoolCommand.GEN_CERT);
+    }
+
+    public KeytoolCLIBuilder generateKeyPair() {
+        return command(KeytoolCommand.GEN_KEYPAIR);
+    }
+
+    public KeytoolCLIBuilder generateSecretKey() {
+        return command(KeytoolCommand.GEN_SECKEY);
+    }
+
+    public KeytoolCLIBuilder importCertificate() {
+        return command(KeytoolCommand.IMPORT_CERT);
+    }
+
+    public KeytoolCLIBuilder importPassword() {
+        return command(KeytoolCommand.IMPORT_PASS);
+    }
+
+    public KeytoolCLIBuilder importKeystore() {
+        return command(KeytoolCommand.IMPORT_KEYSTORE);
+    }
+
+    public KeytoolCLIBuilder keyPasswordCommand() {
+        return command(KeytoolCommand.KEY_PASSWD);
+    }
+
+    public KeytoolCLIBuilder listEntries() {
+        return command(KeytoolCommand.LIST);
+    }
+
+    public KeytoolCLIBuilder printCertificate() {
+        return command(KeytoolCommand.PRINT_CERT);
+    }
+
+    public KeytoolCLIBuilder printCertificateRequest() {
+        return command(KeytoolCommand.PRINT_CERT_REQ);
+    }
+
+    public KeytoolCLIBuilder printCRL() {
+        return command(KeytoolCommand.PRINT_CRL);
+    }
+
+    public KeytoolCLIBuilder storePasswordCommand() {
+        return command(KeytoolCommand.STORE_PASSWD);
+    }
+
+    public KeytoolCLIBuilder showInfo() {
+        return command(KeytoolCommand.SHOW_INFO);
+    }
+
+    public KeytoolCLIBuilder version() {
+        return command(KeytoolCommand.VERSION);
+    }
+
+    public KeytoolCLIBuilder help() {
+        this.arguments.add("-help");
+        return this;
+    }
+
+    public KeytoolCLIBuilder rfcOutput() {
+        this.arguments.add("-rfc");
+        return this;
+    }
+
+    public KeytoolCLIBuilder verbose() {
+        this.arguments.add("-v");
+        return this;
+    }
+
+    public KeytoolCLIBuilder protectedMode() {
+        this.arguments.add("-protected");
+        return this;
+    }
+
+    public KeytoolCLIBuilder trustCaCerts() {
+        this.arguments.add("-trustcacerts");
+        return this;
+    }
+
+    public KeytoolCLIBuilder useDefaultCacerts() {
+        this.arguments.add("-cacerts");
+        return this;
+    }
+
+    public KeytoolCLIBuilder includeCertChain() {
+        this.arguments.add("-certs");
+        return this;
+    }
+
+    public KeytoolCLIBuilder noPrompt() {
+        this.arguments.add("-noprompt");
+        return this;
+    }
+
+    public KeytoolCLIBuilder outputToStdout() {
+        this.arguments.add("-stdout");
+        return this;
+    }
+
+    public KeytoolCLIBuilder tlsInfo(String protocols) {
+        Objects.requireNonNull(protocols, "Protocols cannot be null");
+        this.arguments.add("-tls " + protocols);
+        return this;
+    }
+
+    public KeytoolCLIBuilder sslServer(String server) {
+        Objects.requireNonNull(server, "Server cannot be null");
+        this.arguments.add("-sslserver " + server);
+        return this;
+    }
+
+    public KeytoolCLIBuilder alias(String alias) {
+        Objects.requireNonNull(alias, "Alias cannot be null");
+        this.arguments.add("-alias " + alias);
+        return this;
+    }
+
+    public KeytoolCLIBuilder destAlias(String alias) {
+        Objects.requireNonNull(alias, "Destination alias cannot be null");
+        this.arguments.add("-destalias " + alias);
+        return this;
+    }
+
+    public KeytoolCLIBuilder srcAlias(String alias) {
+        Objects.requireNonNull(alias, "Source alias cannot be null");
+        this.arguments.add("-srcalias " + alias);
+        return this;
+    }
+
+    public KeytoolCLIBuilder dname(String distinguishedName) {
+        Objects.requireNonNull(distinguishedName, "Distinguished name cannot be null");
+        this.arguments.add("-dname " + distinguishedName);
+        return this;
+    }
+
+    public KeytoolCLIBuilder keyAlgorithm(String algorithm) {
+        Objects.requireNonNull(algorithm, "Key algorithm cannot be null");
+        this.arguments.add("-keyalg " + algorithm);
+        return this;
+    }
+
+    public KeytoolCLIBuilder keySize(int size) {
+        if (size <= 0)
+            throw new IllegalArgumentException("Key size must be positive");
+        this.arguments.add("-keysize " + size);
+        return this;
+    }
+
+    public KeytoolCLIBuilder signatureAlgorithm(String algorithm) {
+        Objects.requireNonNull(algorithm, "Signature algorithm cannot be null");
+        this.arguments.add("-sigalg " + algorithm);
+        return this;
+    }
+
+    public KeytoolCLIBuilder validityDays(int days) {
+        if (days <= 0)
+            throw new IllegalArgumentException("Validity days must be positive");
+        this.arguments.add("-validity " + days);
+        return this;
+    }
+
+    public KeytoolCLIBuilder startDate(String date) {
+        Objects.requireNonNull(date, "Start date cannot be null");
+        this.arguments.add("-startdate " + date);
+        return this;
+    }
+
+    public KeytoolCLIBuilder groupName(String group) {
+        Objects.requireNonNull(group, "Group name cannot be null");
+        this.arguments.add("-groupname " + group);
+        return this;
+    }
+
+    public KeytoolCLIBuilder keyPass(String password) {
+        Objects.requireNonNull(password, "Key password cannot be null");
+        this.arguments.add("-keypass " + password);
+        return this;
+    }
+
+    public KeytoolCLIBuilder newPassword(String password) {
+        Objects.requireNonNull(password, "New password cannot be null");
+        this.arguments.add("-new " + password);
+        return this;
+    }
+
+    public KeytoolCLIBuilder signer(String signerAlias) {
+        Objects.requireNonNull(signerAlias, "Signer alias cannot be null");
+        this.arguments.add("-signer " + signerAlias);
+        return this;
+    }
+
+    public KeytoolCLIBuilder signerKeyPass(String password) {
+        Objects.requireNonNull(password, "Signer key password cannot be null");
+        this.arguments.add("-signerkeypass " + password);
+        return this;
+    }
+
+    public KeytoolCLIBuilder keystore(String keystore) {
+        Objects.requireNonNull(keystore, "Keystore cannot be null");
+        this.arguments.add("-keystore " + keystore);
+        return this;
+    }
+
+    public KeytoolCLIBuilder keystore(Path keystorePath) {
+        Objects.requireNonNull(keystorePath, "Keystore path cannot be null");
+        return keystore(keystorePath.toString());
+    }
+
+    public KeytoolCLIBuilder storePass(String password) {
+        Objects.requireNonNull(password, "Store password cannot be null");
+        this.arguments.add("-storepass " + password);
+        return this;
+    }
+
+    public KeytoolCLIBuilder storeType(String type) {
+        Objects.requireNonNull(type, "Store type cannot be null");
+        this.arguments.add("-storetype " + type);
+        return this;
+    }
+
+    public KeytoolCLIBuilder destKeystore(String path) {
+        Objects.requireNonNull(path, "Destination keystore cannot be null");
+        this.arguments.add("-destkeystore " + path);
+        return this;
+    }
+
+    public KeytoolCLIBuilder destKeystore(Path path) {
+        Objects.requireNonNull(path, "Destination keystore path cannot be null");
+        return destKeystore(path.toString());
+    }
+
+    public KeytoolCLIBuilder destStorePass(String password) {
+        Objects.requireNonNull(password, "Destination store password cannot be null");
+        this.arguments.add("-deststorepass " + password);
+        return this;
+    }
+
+    public KeytoolCLIBuilder destStoreType(String type) {
+        Objects.requireNonNull(type, "Destination store type cannot be null");
+        this.arguments.add("-deststoretype " + type);
+        return this;
+    }
+
+    public KeytoolCLIBuilder destKeyPass(String password) {
+        Objects.requireNonNull(password, "Destination key password cannot be null");
+        this.arguments.add("-destkeypass " + password);
+        return this;
+    }
+
+    public KeytoolCLIBuilder destProviderName(String providerName) {
+        Objects.requireNonNull(providerName, "Destination provider name cannot be null");
+        this.arguments.add("-destprovidername " + providerName);
+        return this;
+    }
+
+    public KeytoolCLIBuilder destProtected() {
+        this.arguments.add("-destprotected");
+        return this;
+    }
+
+    public KeytoolCLIBuilder srcKeystore(String path) {
+        Objects.requireNonNull(path, "Source keystore cannot be null");
+        this.arguments.add("-srckeystore " + path);
+        return this;
+    }
+
+    public KeytoolCLIBuilder srcKeystore(Path path) {
+        Objects.requireNonNull(path, "Source keystore path cannot be null");
+        return srcKeystore(path.toString());
+    }
+
+    public KeytoolCLIBuilder srcStorePass(String password) {
+        Objects.requireNonNull(password, "Source store password cannot be null");
+        this.arguments.add("-srcstorepass " + password);
+        return this;
+    }
+
+    public KeytoolCLIBuilder srcStoreType(String type) {
+        Objects.requireNonNull(type, "Source store type cannot be null");
+        this.arguments.add("-srcstoretype " + type);
+        return this;
+    }
+
+    public KeytoolCLIBuilder srcProviderName(String providerName) {
+        Objects.requireNonNull(providerName, "Source provider name cannot be null");
+        this.arguments.add("-srcprovidername " + providerName);
+        return this;
+    }
+
+    public KeytoolCLIBuilder srcKeyPass(String password) {
+        Objects.requireNonNull(password, "Source key password cannot be null");
+        this.arguments.add("-srckeypass " + password);
+        return this;
+    }
+
+    public KeytoolCLIBuilder srcProtected() {
+        this.arguments.add("-srcprotected");
+        return this;
+    }
+
+    public KeytoolCLIBuilder providerName(String name) {
+        Objects.requireNonNull(name, "Provider name cannot be null");
+        this.arguments.add("-providername " + name);
+        return this;
+    }
+
+    public KeytoolCLIBuilder providerClass(String className) {
+        Objects.requireNonNull(className, "Provider class cannot be null");
+        this.arguments.add("-providerclass " + className);
+        return this;
+    }
+
+    public KeytoolCLIBuilder providerArg(String arg) {
+        Objects.requireNonNull(arg, "Provider argument cannot be null");
+        this.arguments.add("-providerarg " + arg);
+        return this;
+    }
+
+    public KeytoolCLIBuilder providerPath(String... paths) {
+        Objects.requireNonNull(paths, "Provider paths cannot be null");
+        String joined = String.join(File.pathSeparator, Arrays.asList(paths));
+        this.arguments.add("-providerpath " + joined);
+        return this;
+    }
+
+    public KeytoolCLIBuilder addProvider(String providerName) {
+        Objects.requireNonNull(providerName, "Provider name cannot be null");
+        this.arguments.add("-addprovider " + providerName);
+        return this;
+    }
+
+    public KeytoolCLIBuilder inFile(String file) {
+        Objects.requireNonNull(file, "Input file cannot be null");
+        this.arguments.add("-infile " + file);
+        return this;
+    }
+
+    public KeytoolCLIBuilder inFile(Path file) {
+        Objects.requireNonNull(file, "Input file path cannot be null");
+        return inFile(file.toString());
+    }
+
+    public KeytoolCLIBuilder outFile(String file) {
+        Objects.requireNonNull(file, "Output file cannot be null");
+        this.arguments.add("-outfile " + file);
+        return this;
+    }
+
+    public KeytoolCLIBuilder outFile(Path file) {
+        Objects.requireNonNull(file, "Output file path cannot be null");
+        return outFile(file.toString());
+    }
+
+    public KeytoolCLIBuilder file(String file) {
+        Objects.requireNonNull(file, "File cannot be null");
+        this.arguments.add("-file " + file);
+        return this;
+    }
+
+    public KeytoolCLIBuilder file(Path file) {
+        Objects.requireNonNull(file, "File path cannot be null");
+        return file(file.toString());
+    }
+
+    public KeytoolCLIBuilder jarFile(String file) {
+        Objects.requireNonNull(file, "JAR file cannot be null");
+        this.arguments.add("-jarfile " + file);
+        return this;
+    }
+
+    public KeytoolCLIBuilder jarFile(Path file) {
+        Objects.requireNonNull(file, "JAR file path cannot be null");
+        return jarFile(file.toString());
+    }
+
+    public KeytoolCLIBuilder confFile(String conf) {
+        Objects.requireNonNull(conf, "Configuration file cannot be null");
+        this.arguments.add("-conf " + conf);
+        return this;
+    }
+
+    public KeytoolCLIBuilder confFile(Path conf) {
+        Objects.requireNonNull(conf, "Configuration path cannot be null");
+        return confFile(conf.toString());
+    }
+
+    public KeytoolCLIBuilder extension(String extension) {
+        Objects.requireNonNull(extension, "Extension cannot be null");
+        this.arguments.add("-ext " + extension);
+        return this;
+    }
+
+    public KeytoolCLIBuilder extensions(String... extensions) {
+        Objects.requireNonNull(extensions, "Extensions cannot be null");
+        for (String extension : extensions) {
+            extension(extension);
+        }
+        return this;
+    }
+
+    public KeytoolCLIBuilder includeArgumentFile(Path argFile) {
+        Objects.requireNonNull(argFile, "Argument file cannot be null");
+        this.arguments.add("@" + argFile);
+        return this;
+    }
+
+    public KeytoolCLIBuilder jvmOption(String option) {
+        Objects.requireNonNull(option, "JVM option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+
+        ProcessBuilder processBuilder = new ProcessBuilder().command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            processBuilder.environment().putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "keytool");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start keytool process", exception);
+        }
+    }
+
+    @Getter
+    public enum KeytoolCommand {
+        CERTREQ("-certreq"),
+        CHANGE_ALIAS("-changealias"),
+        DELETE("-delete"),
+        EXPORT_CERT("-exportcert"),
+        GEN_CERT("-gencert"),
+        GEN_KEYPAIR("-genkeypair"),
+        GEN_SECKEY("-genseckey"),
+        IMPORT_CERT("-importcert"),
+        IMPORT_PASS("-importpass"),
+        IMPORT_KEYSTORE("-importkeystore"),
+        KEY_PASSWD("-keypasswd"),
+        LIST("-list"),
+        PRINT_CERT("-printcert"),
+        PRINT_CERT_REQ("-printcertreq"),
+        PRINT_CRL("-printcrl"),
+        STORE_PASSWD("-storepasswd"),
+        SHOW_INFO("-showinfo"),
+        VERSION("-version");
+
+        private final String flag;
+
+        KeytoolCommand(String flag) {
+            this.flag = flag;
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/KeytoolCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/KeytoolCLIBuilder.java
@@ -12,7 +12,13 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Builder for invoking the {@code keytool} command.
+ * Builder that constructs {@code keytool} invocations used to create and manage keystores,
+ * certificates, and related trust material.
+ *
+ * <p>Each helper method adds the appropriate flag to the argument list and validates
+ * required data before execution.</p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/keytool.html">keytool command documentation</a>
  */
 public class KeytoolCLIBuilder implements CLIBuilder<Process, KeytoolCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "keytool.exe" : "keytool";
@@ -30,6 +36,12 @@ public class KeytoolCLIBuilder implements CLIBuilder<Process, KeytoolCLIBuilder>
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a builder that executes {@code keytool} from the provided {@link JDK}.
+     *
+     * @param jdk the JDK to use when locating the executable; must not be null
+     * @return a new {@code KeytoolCLIBuilder} configured for the given JDK
+     */
     public static KeytoolCLIBuilder create(JDK jdk) {
         return new KeytoolCLIBuilder(jdk);
     }
@@ -72,6 +84,9 @@ public class KeytoolCLIBuilder implements CLIBuilder<Process, KeytoolCLIBuilder>
 
     /**
      * Sets the keytool command to run. Only a single command may be selected.
+     *
+     * @param command the command to run; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
      */
     public KeytoolCLIBuilder command(KeytoolCommand command) {
         Objects.requireNonNull(command, "Command cannot be null");
@@ -83,165 +98,348 @@ public class KeytoolCLIBuilder implements CLIBuilder<Process, KeytoolCLIBuilder>
         return this;
     }
 
+    /**
+     * Selects {@code -certreq} to generate a certificate signing request.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder certreq() {
         return command(KeytoolCommand.CERTREQ);
     }
 
+    /**
+     * Selects {@code -changealias} to change a certificate alias in a keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder changeAlias() {
         return command(KeytoolCommand.CHANGE_ALIAS);
     }
 
+    /**
+     * Selects {@code -delete} to remove an entry from a keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder deleteEntry() {
         return command(KeytoolCommand.DELETE);
     }
 
+    /**
+     * Selects {@code -exportcert} to export a certificate from the keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder exportCertificate() {
         return command(KeytoolCommand.EXPORT_CERT);
     }
 
+    /**
+     * Selects {@code -gencert} to generate a certificate using an existing certificate authority.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder generateCertificate() {
         return command(KeytoolCommand.GEN_CERT);
     }
 
+    /**
+     * Selects {@code -genkeypair} to generate a new key pair and self-signed certificate.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder generateKeyPair() {
         return command(KeytoolCommand.GEN_KEYPAIR);
     }
 
+    /**
+     * Selects {@code -genseckey} to generate a secret key entry in the keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder generateSecretKey() {
         return command(KeytoolCommand.GEN_SECKEY);
     }
 
+    /**
+     * Selects {@code -importcert} to import a certificate into the keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder importCertificate() {
         return command(KeytoolCommand.IMPORT_CERT);
     }
 
+    /**
+     * Selects {@code -importpass} to import a password entry from another keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder importPassword() {
         return command(KeytoolCommand.IMPORT_PASS);
     }
 
+    /**
+     * Selects {@code -importkeystore} to import entries from a different keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder importKeystore() {
         return command(KeytoolCommand.IMPORT_KEYSTORE);
     }
 
+    /**
+     * Selects {@code -keypasswd} to change the password of a key pair.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder keyPasswordCommand() {
         return command(KeytoolCommand.KEY_PASSWD);
     }
 
+    /**
+     * Selects {@code -list} to list the entries contained in the keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder listEntries() {
         return command(KeytoolCommand.LIST);
     }
 
+    /**
+     * Selects {@code -printcert} to display the contents of a certificate.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder printCertificate() {
         return command(KeytoolCommand.PRINT_CERT);
     }
 
+    /**
+     * Selects {@code -printcertreq} to display a certificate request.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder printCertificateRequest() {
         return command(KeytoolCommand.PRINT_CERT_REQ);
     }
 
+    /**
+     * Selects {@code -printcrl} to display a certificate revocation list.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder printCRL() {
         return command(KeytoolCommand.PRINT_CRL);
     }
 
+    /**
+     * Selects {@code -storepasswd} to change a keystore password.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder storePasswordCommand() {
         return command(KeytoolCommand.STORE_PASSWD);
     }
 
+    /**
+     * Selects {@code -showinfo} to display keystore metadata and provider information.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder showInfo() {
         return command(KeytoolCommand.SHOW_INFO);
     }
 
+    /**
+     * Selects {@code -version} to print the tool's version.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder version() {
         return command(KeytoolCommand.VERSION);
     }
 
+    /**
+     * Adds {@code -help} to print usage for the selected command.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder help() {
         this.arguments.add("-help");
         return this;
     }
 
+    /**
+     * Adds {@code -rfc} to format certificate output in RFC style.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder rfcOutput() {
         this.arguments.add("-rfc");
         return this;
     }
 
+    /**
+     * Adds {@code -v} to enable verbose logging.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder verbose() {
         this.arguments.add("-v");
         return this;
     }
 
+    /**
+     * Adds {@code -protected} to run operations in protected mode.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder protectedMode() {
         this.arguments.add("-protected");
         return this;
     }
 
+    /**
+     * Adds {@code -trustcacerts} to trust certificates from the default trust store.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder trustCaCerts() {
         this.arguments.add("-trustcacerts");
         return this;
     }
 
+    /**
+     * Adds {@code -cacerts} to operate on the default cacerts keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder useDefaultCacerts() {
         this.arguments.add("-cacerts");
         return this;
     }
 
+    /**
+     * Adds {@code -certs} to include the certificate chain in exports.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder includeCertChain() {
         this.arguments.add("-certs");
         return this;
     }
 
+    /**
+     * Adds {@code -noprompt} to skip confirmation prompts.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder noPrompt() {
         this.arguments.add("-noprompt");
         return this;
     }
 
+    /**
+     * Adds {@code -stdout} to route certificate output to {@code stdout}.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder outputToStdout() {
         this.arguments.add("-stdout");
         return this;
     }
 
+    /**
+     * Adds {@code -tls} with the provided protocols to request TLS information.
+     *
+     * @param protocols the TLS protocols to enable; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder tlsInfo(String protocols) {
         Objects.requireNonNull(protocols, "Protocols cannot be null");
         this.arguments.add("-tls " + protocols);
         return this;
     }
 
+    /**
+     * Adds {@code -sslserver} to contact a specific SSL server.
+     *
+     * @param server the SSL server; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder sslServer(String server) {
         Objects.requireNonNull(server, "Server cannot be null");
         this.arguments.add("-sslserver " + server);
         return this;
     }
 
+    /**
+     * Adds {@code -alias} to specify the alias of the entry to work with.
+     *
+     * @param alias the alias; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder alias(String alias) {
         Objects.requireNonNull(alias, "Alias cannot be null");
         this.arguments.add("-alias " + alias);
         return this;
     }
 
+    /**
+     * Adds {@code -destalias} for the destination alias when copying or moving entries.
+     *
+     * @param alias the destination alias; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder destAlias(String alias) {
         Objects.requireNonNull(alias, "Destination alias cannot be null");
         this.arguments.add("-destalias " + alias);
         return this;
     }
 
+    /**
+     * Adds {@code -srcalias} for the source alias when copying or converting entries.
+     *
+     * @param alias the source alias; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder srcAlias(String alias) {
         Objects.requireNonNull(alias, "Source alias cannot be null");
         this.arguments.add("-srcalias " + alias);
         return this;
     }
 
+    /**
+     * Adds {@code -dname} to define the distinguished name for certificate creation.
+     *
+     * @param distinguishedName the distinguished name; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder dname(String distinguishedName) {
         Objects.requireNonNull(distinguishedName, "Distinguished name cannot be null");
         this.arguments.add("-dname " + distinguishedName);
         return this;
     }
 
+    /**
+     * Adds {@code -keyalg} to specify the key algorithm.
+     *
+     * @param algorithm the key algorithm; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder keyAlgorithm(String algorithm) {
         Objects.requireNonNull(algorithm, "Key algorithm cannot be null");
         this.arguments.add("-keyalg " + algorithm);
         return this;
     }
 
+    /**
+     * Adds {@code -keysize} to request a specific key size.
+     *
+     * @param size the key size; must be positive
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder keySize(int size) {
         if (size <= 0)
             throw new IllegalArgumentException("Key size must be positive");
@@ -249,12 +447,24 @@ public class KeytoolCLIBuilder implements CLIBuilder<Process, KeytoolCLIBuilder>
         return this;
     }
 
+    /**
+     * Adds {@code -sigalg} to specify the signature algorithm.
+     *
+     * @param algorithm the signature algorithm; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder signatureAlgorithm(String algorithm) {
         Objects.requireNonNull(algorithm, "Signature algorithm cannot be null");
         this.arguments.add("-sigalg " + algorithm);
         return this;
     }
 
+    /**
+     * Adds {@code -validity} to define the validity duration of a certificate.
+     *
+     * @param days the number of days; must be positive
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder validityDays(int days) {
         if (days <= 0)
             throw new IllegalArgumentException("Validity days must be positive");
@@ -262,163 +472,329 @@ public class KeytoolCLIBuilder implements CLIBuilder<Process, KeytoolCLIBuilder>
         return this;
     }
 
+    /**
+     * Adds {@code -startdate} to specify when the certificate becomes valid.
+     *
+     * @param date the start date; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder startDate(String date) {
         Objects.requireNonNull(date, "Start date cannot be null");
         this.arguments.add("-startdate " + date);
         return this;
     }
 
+    /**
+     * Adds {@code -groupname} to specify a provider group name.
+     *
+     * @param group the group name; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder groupName(String group) {
         Objects.requireNonNull(group, "Group name cannot be null");
         this.arguments.add("-groupname " + group);
         return this;
     }
 
+    /**
+     * Adds {@code -keypass} to supply the password for a key entry.
+     *
+     * @param password the key password; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder keyPass(String password) {
         Objects.requireNonNull(password, "Key password cannot be null");
         this.arguments.add("-keypass " + password);
         return this;
     }
 
+    /**
+     * Adds {@code -new} to specify a new password.
+     *
+     * @param password the new password; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder newPassword(String password) {
         Objects.requireNonNull(password, "New password cannot be null");
         this.arguments.add("-new " + password);
         return this;
     }
 
+    /**
+     * Adds {@code -signer} to specify the alias of the signing certificate.
+     *
+     * @param signerAlias the signer alias; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder signer(String signerAlias) {
         Objects.requireNonNull(signerAlias, "Signer alias cannot be null");
         this.arguments.add("-signer " + signerAlias);
         return this;
     }
 
+    /**
+     * Adds {@code -signerkeypass} to supply the password for the signer.
+     *
+     * @param password the signer's key password; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder signerKeyPass(String password) {
         Objects.requireNonNull(password, "Signer key password cannot be null");
         this.arguments.add("-signerkeypass " + password);
         return this;
     }
 
+    /**
+     * Adds {@code -keystore} to specify the keystore path.
+     *
+     * @param keystore the keystore path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder keystore(String keystore) {
         Objects.requireNonNull(keystore, "Keystore cannot be null");
         this.arguments.add("-keystore " + keystore);
         return this;
     }
 
+    /**
+     * Adds {@code -keystore} using a {@link Path}.
+     *
+     * @param keystorePath the keystore path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder keystore(Path keystorePath) {
         Objects.requireNonNull(keystorePath, "Keystore path cannot be null");
         return keystore(keystorePath.toString());
     }
 
+    /**
+     * Adds {@code -storepass} to set the keystore password.
+     *
+     * @param password the keystore password; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder storePass(String password) {
         Objects.requireNonNull(password, "Store password cannot be null");
         this.arguments.add("-storepass " + password);
         return this;
     }
 
+    /**
+     * Adds {@code -storetype} to define the keystore type.
+     *
+     * @param type the keystore type; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder storeType(String type) {
         Objects.requireNonNull(type, "Store type cannot be null");
         this.arguments.add("-storetype " + type);
         return this;
     }
 
+    /**
+     * Adds {@code -destkeystore} to specify the destination keystore path.
+     *
+     * @param path the destination keystore; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder destKeystore(String path) {
         Objects.requireNonNull(path, "Destination keystore cannot be null");
         this.arguments.add("-destkeystore " + path);
         return this;
     }
 
+    /**
+     * Adds {@code -destkeystore} using a {@link Path}.
+     *
+     * @param path the destination keystore path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder destKeystore(Path path) {
         Objects.requireNonNull(path, "Destination keystore path cannot be null");
         return destKeystore(path.toString());
     }
 
+    /**
+     * Adds {@code -deststorepass} for the destination keystore password.
+     *
+     * @param password the destination store password; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder destStorePass(String password) {
         Objects.requireNonNull(password, "Destination store password cannot be null");
         this.arguments.add("-deststorepass " + password);
         return this;
     }
 
+    /**
+     * Adds {@code -deststoretype} to override the destination keystore type.
+     *
+     * @param type the destination store type; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder destStoreType(String type) {
         Objects.requireNonNull(type, "Destination store type cannot be null");
         this.arguments.add("-deststoretype " + type);
         return this;
     }
 
+    /**
+     * Adds {@code -destkeypass} to supply the password for the destination key entry.
+     *
+     * @param password the destination key password; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder destKeyPass(String password) {
         Objects.requireNonNull(password, "Destination key password cannot be null");
         this.arguments.add("-destkeypass " + password);
         return this;
     }
 
+    /**
+     * Adds {@code -destprovidername} for third-party providers when writing to the destination.
+     *
+     * @param providerName the provider name; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder destProviderName(String providerName) {
         Objects.requireNonNull(providerName, "Destination provider name cannot be null");
         this.arguments.add("-destprovidername " + providerName);
         return this;
     }
 
+    /**
+     * Adds {@code -destprotected} to request protected mode on the destination keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder destProtected() {
         this.arguments.add("-destprotected");
         return this;
     }
 
+    /**
+     * Adds {@code -srckeystore} for the source keystore path.
+     *
+     * @param path the source keystore; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder srcKeystore(String path) {
         Objects.requireNonNull(path, "Source keystore cannot be null");
         this.arguments.add("-srckeystore " + path);
         return this;
     }
 
+    /**
+     * Adds {@code -srckeystore} using a {@link Path}.
+     *
+     * @param path the source keystore path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder srcKeystore(Path path) {
         Objects.requireNonNull(path, "Source keystore path cannot be null");
         return srcKeystore(path.toString());
     }
 
+    /**
+     * Adds {@code -srcstorepass} to supply the source keystore password.
+     *
+     * @param password the source store password; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder srcStorePass(String password) {
         Objects.requireNonNull(password, "Source store password cannot be null");
         this.arguments.add("-srcstorepass " + password);
         return this;
     }
 
+    /**
+     * Adds {@code -srcstoretype} to override the source keystore type.
+     *
+     * @param type the source store type; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder srcStoreType(String type) {
         Objects.requireNonNull(type, "Source store type cannot be null");
         this.arguments.add("-srcstoretype " + type);
         return this;
     }
 
+    /**
+     * Adds {@code -srcprovidername} for custom source providers.
+     *
+     * @param providerName the source provider name; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder srcProviderName(String providerName) {
         Objects.requireNonNull(providerName, "Source provider name cannot be null");
         this.arguments.add("-srcprovidername " + providerName);
         return this;
     }
 
+    /**
+     * Adds {@code -srckeypass} to provide the source key password.
+     *
+     * @param password the source key password; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder srcKeyPass(String password) {
         Objects.requireNonNull(password, "Source key password cannot be null");
         this.arguments.add("-srckeypass " + password);
         return this;
     }
 
+    /**
+     * Adds {@code -srcprotected} to request protected mode on the source keystore.
+     *
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder srcProtected() {
         this.arguments.add("-srcprotected");
         return this;
     }
 
+    /**
+     * Adds {@code -providername} to specify the provider to load.
+     *
+     * @param name the provider name; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder providerName(String name) {
         Objects.requireNonNull(name, "Provider name cannot be null");
         this.arguments.add("-providername " + name);
         return this;
     }
 
+    /**
+     * Adds {@code -providerclass} to specify a provider implementation class.
+     *
+     * @param className the provider class name; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder providerClass(String className) {
         Objects.requireNonNull(className, "Provider class cannot be null");
         this.arguments.add("-providerclass " + className);
         return this;
     }
 
+    /**
+     * Adds {@code -providerarg} to pass an argument to the provider.
+     *
+     * @param arg the provider argument; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder providerArg(String arg) {
         Objects.requireNonNull(arg, "Provider argument cannot be null");
         this.arguments.add("-providerarg " + arg);
         return this;
     }
 
+    /**
+     * Adds {@code -providerpath} with one or more paths where providers are located.
+     *
+     * @param paths the provider paths; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder providerPath(String... paths) {
         Objects.requireNonNull(paths, "Provider paths cannot be null");
         String joined = String.join(File.pathSeparator, Arrays.asList(paths));
@@ -426,73 +802,151 @@ public class KeytoolCLIBuilder implements CLIBuilder<Process, KeytoolCLIBuilder>
         return this;
     }
 
+    /**
+     * Adds {@code -addprovider} to install a provider into the keystore.
+     *
+     * @param providerName the provider name; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder addProvider(String providerName) {
         Objects.requireNonNull(providerName, "Provider name cannot be null");
         this.arguments.add("-addprovider " + providerName);
         return this;
     }
 
+    /**
+     * Adds {@code -infile} to specify the input file.
+     *
+     * @param file the input file; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder inFile(String file) {
         Objects.requireNonNull(file, "Input file cannot be null");
         this.arguments.add("-infile " + file);
         return this;
     }
 
+    /**
+     * Adds {@code -infile} using a {@link Path}.
+     *
+     * @param file the input file path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder inFile(Path file) {
         Objects.requireNonNull(file, "Input file path cannot be null");
         return inFile(file.toString());
     }
 
+    /**
+     * Adds {@code -outfile} to specify the output file.
+     *
+     * @param file the output file; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder outFile(String file) {
         Objects.requireNonNull(file, "Output file cannot be null");
         this.arguments.add("-outfile " + file);
         return this;
     }
 
+    /**
+     * Adds {@code -outfile} using a {@link Path}.
+     *
+     * @param file the output file path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder outFile(Path file) {
         Objects.requireNonNull(file, "Output file path cannot be null");
         return outFile(file.toString());
     }
 
+    /**
+     * Adds {@code -file} to supply a general file argument.
+     *
+     * @param file the file path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder file(String file) {
         Objects.requireNonNull(file, "File cannot be null");
         this.arguments.add("-file " + file);
         return this;
     }
 
+    /**
+     * Adds {@code -file} using a {@link Path}.
+     *
+     * @param file the file path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder file(Path file) {
         Objects.requireNonNull(file, "File path cannot be null");
         return file(file.toString());
     }
 
+    /**
+     * Adds {@code -jarfile} to provide the signing JAR file.
+     *
+     * @param file the jar file path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder jarFile(String file) {
         Objects.requireNonNull(file, "JAR file cannot be null");
         this.arguments.add("-jarfile " + file);
         return this;
     }
 
+    /**
+     * Adds {@code -jarfile} using a {@link Path}.
+     *
+     * @param file the jar file path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder jarFile(Path file) {
         Objects.requireNonNull(file, "JAR file path cannot be null");
         return jarFile(file.toString());
     }
 
+    /**
+     * Adds {@code -conf} to specify the configuration file.
+     *
+     * @param conf the configuration file; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder confFile(String conf) {
         Objects.requireNonNull(conf, "Configuration file cannot be null");
         this.arguments.add("-conf " + conf);
         return this;
     }
 
+    /**
+     * Adds {@code -conf} using a {@link Path}.
+     *
+     * @param conf the configuration path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder confFile(Path conf) {
         Objects.requireNonNull(conf, "Configuration path cannot be null");
         return confFile(conf.toString());
     }
 
+    /**
+     * Adds {@code -ext} to provide an extension definition.
+     *
+     * @param extension the extension definition; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder extension(String extension) {
         Objects.requireNonNull(extension, "Extension cannot be null");
         this.arguments.add("-ext " + extension);
         return this;
     }
 
+    /**
+     * Adds multiple {@code -ext} definitions.
+     *
+     * @param extensions the extensions to add; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder extensions(String... extensions) {
         Objects.requireNonNull(extensions, "Extensions cannot be null");
         for (String extension : extensions) {
@@ -501,12 +955,24 @@ public class KeytoolCLIBuilder implements CLIBuilder<Process, KeytoolCLIBuilder>
         return this;
     }
 
+    /**
+     * Adds an argument file reference via {@code @file}.
+     *
+     * @param argFile the argument file path; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder includeArgumentFile(Path argFile) {
         Objects.requireNonNull(argFile, "Argument file cannot be null");
         this.arguments.add("@" + argFile);
         return this;
     }
 
+    /**
+     * Adds a JVM option prefixed with {@code -J}.
+     *
+     * @param option the JVM option; must not be null
+     * @return the current {@code KeytoolCLIBuilder}
+     */
     public KeytoolCLIBuilder jvmOption(String option) {
         Objects.requireNonNull(option, "JVM option cannot be null");
         this.arguments.add("-J" + option);
@@ -541,6 +1007,9 @@ public class KeytoolCLIBuilder implements CLIBuilder<Process, KeytoolCLIBuilder>
         }
     }
 
+    /**
+     * Represents the primary {@code keytool} commands that can be executed.
+     */
     @Getter
     public enum KeytoolCommand {
         CERTREQ("-certreq"),

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/RmicCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/RmicCLIBuilder.java
@@ -10,6 +10,14 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder that drives the {@code rmic} tool for generating RMI stubs and skeletons.
+ * <p>
+ * Wraps options for classpaths, destinations, protocols, and verbosity flags.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/rmic.html">rmic command documentation</a>
+ */
 public class RmicCLIBuilder implements CLIBuilder<Process, RmicCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "rmic.exe" : "rmic";
 
@@ -26,6 +34,13 @@ public class RmicCLIBuilder implements CLIBuilder<Process, RmicCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new builder instance for the supplied {@link JDK}.
+     *
+     * @param jdk the JDK installation that will run {@code rmic}; must not be null
+     * @return a fresh {@link RmicCLIBuilder}
+     * @throws NullPointerException if the JDK is null
+     */
     public static RmicCLIBuilder create(JDK jdk) {
         return new RmicCLIBuilder(jdk);
     }
@@ -68,6 +83,13 @@ public class RmicCLIBuilder implements CLIBuilder<Process, RmicCLIBuilder> {
         return this;
     }
 
+    /**
+     * Defines the bootstrap class path entries for the {@code rmic} command.
+     *
+     * @param paths the bootstrap entries; must not be null or contain null elements
+     * @return the current {@link RmicCLIBuilder} instance
+     * @throws NullPointerException if the entries array or any entry is null
+     */
     public RmicCLIBuilder bootClassPath(String... paths) {
         Objects.requireNonNull(paths, "Boot class path entries cannot be null");
         for (String path : paths) {
@@ -78,12 +100,26 @@ public class RmicCLIBuilder implements CLIBuilder<Process, RmicCLIBuilder> {
         return this;
     }
 
+    /**
+     * Defines the bootstrap class path entries for the {@code rmic} command using {@link Path} objects.
+     *
+     * @param paths the bootstrap entries as {@code Path} objects; must not be null or contain nulls
+     * @return the current {@link RmicCLIBuilder} instance
+     * @throws NullPointerException if the entries array or any entry is null
+     */
     public RmicCLIBuilder bootClassPath(Path... paths) {
         Objects.requireNonNull(paths, "Boot class path entries cannot be null");
         String[] entries = Arrays.stream(paths).map(Path::toString).toArray(String[]::new);
         return bootClassPath(entries);
     }
 
+    /**
+     * Sets the classpath entries for the {@code rmic} command.
+     *
+     * @param entries the classpath entries; must not be null or contain null values
+     * @return the current {@link RmicCLIBuilder} instance
+     * @throws NullPointerException if the array or included values are null
+     */
     public RmicCLIBuilder classpath(String... entries) {
         Objects.requireNonNull(entries, "Classpath entries cannot be null");
         for (String entry : entries) {
@@ -94,12 +130,26 @@ public class RmicCLIBuilder implements CLIBuilder<Process, RmicCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the classpath entries for the {@code rmic} command using {@link Path} objects.
+     *
+     * @param entries the classpath entries as {@code Path} values; must not be null
+     * @return the current {@link RmicCLIBuilder} instance
+     * @throws NullPointerException if the array or any element is null
+     */
     public RmicCLIBuilder classpath(Path... entries) {
         Objects.requireNonNull(entries, "Classpath entries cannot be null");
         String[] paths = Arrays.stream(entries).map(Path::toString).toArray(String[]::new);
         return classpath(paths);
     }
 
+    /**
+     * Sets the target directory where {@code rmic} will place generated files.
+     *
+     * @param directory the output directory; must not be null
+     * @return the current {@link RmicCLIBuilder} instance
+     * @throws NullPointerException if the directory is null
+     */
     public RmicCLIBuilder destinationDirectory(String directory) {
         Objects.requireNonNull(directory, "Destination directory cannot be null");
         this.arguments.add("-d");
@@ -107,57 +157,119 @@ public class RmicCLIBuilder implements CLIBuilder<Process, RmicCLIBuilder> {
         return this;
     }
 
+    /**
+     * Sets the target directory for generated sources using a {@link Path}.
+     *
+     * @param directory the output directory; must not be null
+     * @return the current {@link RmicCLIBuilder} instance
+     * @throws NullPointerException if the directory is null
+     */
     public RmicCLIBuilder destinationDirectory(Path directory) {
         Objects.requireNonNull(directory, "Destination directory cannot be null");
         return destinationDirectory(directory.toString());
     }
 
+    /**
+     * Enables debug information generation via the {@code -g} flag.
+     *
+     * @return the current {@link RmicCLIBuilder} instance
+     */
     public RmicCLIBuilder generateDebugInfo() {
         this.arguments.add("-g");
         return this;
     }
 
+    /**
+     * Adds a JVM option passed through to the underlying Java launcher.
+     *
+     * @param option the option to pass; must not be null
+     * @return the current {@link RmicCLIBuilder} instance
+     * @throws NullPointerException if the option is null
+     */
     public RmicCLIBuilder javaOption(String option) {
         Objects.requireNonNull(option, "Java option cannot be null");
         this.arguments.add("-J" + option);
         return this;
     }
 
+    /**
+     * Instructs {@code rmic} to keep the generated source files.
+     *
+     * @return the current {@link RmicCLIBuilder} instance
+     */
     public RmicCLIBuilder keepGeneratedSources() {
         this.arguments.add("-keepgenerated");
         return this;
     }
 
+    /**
+     * Suppresses warning output from {@code rmic}.
+     *
+     * @return the current {@link RmicCLIBuilder} instance
+     */
     public RmicCLIBuilder noWarnings() {
         this.arguments.add("-nowarn");
         return this;
     }
 
+    /**
+     * Prevents {@code rmic} from writing files to disk.
+     *
+     * @return the current {@link RmicCLIBuilder} instance
+     */
     public RmicCLIBuilder noWrite() {
         this.arguments.add("-nowrite");
         return this;
     }
 
+    /**
+     * Enables protocol compatibility mode with legacy RMI wire formats.
+     *
+     * @return the current {@link RmicCLIBuilder} instance
+     */
     public RmicCLIBuilder protocolCompat() {
         this.arguments.add("-vcompat");
         return this;
     }
 
+    /**
+     * Forces the use of the RMI protocol version 1.1.
+     *
+     * @return the current {@link RmicCLIBuilder} instance
+     */
     public RmicCLIBuilder protocolV11() {
         this.arguments.add("-v1.1");
         return this;
     }
 
+    /**
+     * Forces the use of the RMI protocol version 1.2.
+     *
+     * @return the current {@link RmicCLIBuilder} instance
+     */
     public RmicCLIBuilder protocolV12() {
         this.arguments.add("-v1.2");
         return this;
     }
 
+    /**
+     * Enables verbose output from {@code rmic}.
+     *
+     * @return the current {@link RmicCLIBuilder} instance
+     */
     public RmicCLIBuilder verbose() {
         this.arguments.add("-verbose");
         return this;
     }
 
+    /**
+     * Adds a fully qualified class name to process with {@code rmic}.
+     *
+     * @param className the class to process; must not be null or blank
+     * @return the current {@link RmicCLIBuilder} instance
+     * @throws NullPointerException     if the class name is null
+     * @throws IllegalArgumentException if the class name is blank
+     */
     public RmicCLIBuilder addClassName(String className) {
         Objects.requireNonNull(className, "Class name cannot be null");
         if (className.isBlank())
@@ -167,6 +279,13 @@ public class RmicCLIBuilder implements CLIBuilder<Process, RmicCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds multiple class names for {@code rmic} to process.
+     *
+     * @param classNames the classes to process; must not be null or contain nulls
+     * @return the current {@link RmicCLIBuilder} instance
+     * @throws NullPointerException if the class names array or an entry is null
+     */
     public RmicCLIBuilder addClassNames(String... classNames) {
         Objects.requireNonNull(classNames, "Class names cannot be null");
         for (String className : classNames) {

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/RmicCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/RmicCLIBuilder.java
@@ -1,0 +1,212 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class RmicCLIBuilder implements CLIBuilder<Process, RmicCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "rmic.exe" : "rmic";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<String> classNames = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private RmicCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static RmicCLIBuilder create(JDK jdk) {
+        return new RmicCLIBuilder(jdk);
+    }
+
+    @Override
+    public RmicCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public RmicCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public RmicCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public RmicCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public RmicCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public RmicCLIBuilder bootClassPath(String... paths) {
+        Objects.requireNonNull(paths, "Boot class path entries cannot be null");
+        for (String path : paths) {
+            Objects.requireNonNull(path, "Boot class path entry cannot be null");
+        }
+        this.arguments.add("-bootclasspath");
+        this.arguments.add(String.join(File.pathSeparator, paths));
+        return this;
+    }
+
+    public RmicCLIBuilder bootClassPath(Path... paths) {
+        Objects.requireNonNull(paths, "Boot class path entries cannot be null");
+        String[] entries = Arrays.stream(paths).map(Path::toString).toArray(String[]::new);
+        return bootClassPath(entries);
+    }
+
+    public RmicCLIBuilder classpath(String... entries) {
+        Objects.requireNonNull(entries, "Classpath entries cannot be null");
+        for (String entry : entries) {
+            Objects.requireNonNull(entry, "Classpath entry cannot be null");
+        }
+        this.arguments.add("-classpath");
+        this.arguments.add(String.join(File.pathSeparator, entries));
+        return this;
+    }
+
+    public RmicCLIBuilder classpath(Path... entries) {
+        Objects.requireNonNull(entries, "Classpath entries cannot be null");
+        String[] paths = Arrays.stream(entries).map(Path::toString).toArray(String[]::new);
+        return classpath(paths);
+    }
+
+    public RmicCLIBuilder destinationDirectory(String directory) {
+        Objects.requireNonNull(directory, "Destination directory cannot be null");
+        this.arguments.add("-d");
+        this.arguments.add(directory);
+        return this;
+    }
+
+    public RmicCLIBuilder destinationDirectory(Path directory) {
+        Objects.requireNonNull(directory, "Destination directory cannot be null");
+        return destinationDirectory(directory.toString());
+    }
+
+    public RmicCLIBuilder generateDebugInfo() {
+        this.arguments.add("-g");
+        return this;
+    }
+
+    public RmicCLIBuilder javaOption(String option) {
+        Objects.requireNonNull(option, "Java option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    public RmicCLIBuilder keepGeneratedSources() {
+        this.arguments.add("-keepgenerated");
+        return this;
+    }
+
+    public RmicCLIBuilder noWarnings() {
+        this.arguments.add("-nowarn");
+        return this;
+    }
+
+    public RmicCLIBuilder noWrite() {
+        this.arguments.add("-nowrite");
+        return this;
+    }
+
+    public RmicCLIBuilder protocolCompat() {
+        this.arguments.add("-vcompat");
+        return this;
+    }
+
+    public RmicCLIBuilder protocolV11() {
+        this.arguments.add("-v1.1");
+        return this;
+    }
+
+    public RmicCLIBuilder protocolV12() {
+        this.arguments.add("-v1.2");
+        return this;
+    }
+
+    public RmicCLIBuilder verbose() {
+        this.arguments.add("-verbose");
+        return this;
+    }
+
+    public RmicCLIBuilder addClassName(String className) {
+        Objects.requireNonNull(className, "Class name cannot be null");
+        if (className.isBlank())
+            throw new IllegalArgumentException("Class name cannot be blank");
+
+        this.classNames.add(className);
+        return this;
+    }
+
+    public RmicCLIBuilder addClassNames(String... classNames) {
+        Objects.requireNonNull(classNames, "Class names cannot be null");
+        for (String className : classNames) {
+            addClassName(className);
+        }
+
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        if (classNames.isEmpty())
+            throw new IllegalStateException("At least one class name must be specified for rmic.");
+
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        command.addAll(classNames);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "rmic");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start rmic process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/RmidCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/RmidCLIBuilder.java
@@ -1,0 +1,144 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class RmidCLIBuilder implements CLIBuilder<Process, RmidCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "rmid.exe" : "rmid";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private RmidCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static RmidCLIBuilder create(JDK jdk) {
+        return new RmidCLIBuilder(jdk);
+    }
+
+    @Override
+    public RmidCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public RmidCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public RmidCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public RmidCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public RmidCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public RmidCLIBuilder childProcessOption(String option) {
+        Objects.requireNonNull(option, "Child process option cannot be null");
+        this.arguments.add("-C" + option);
+        return this;
+    }
+
+    public RmidCLIBuilder javaOption(String option) {
+        Objects.requireNonNull(option, "Java option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    public RmidCLIBuilder execPolicy(String policy) {
+        Objects.requireNonNull(policy, "Execution policy cannot be null");
+        if (policy.isBlank())
+            throw new IllegalArgumentException("Execution policy cannot be blank");
+
+        this.arguments.add("-J-Dsun.rmi.activation.execPolicy=" + policy);
+        return this;
+    }
+
+    public RmidCLIBuilder logDirectory(String directory) {
+        Objects.requireNonNull(directory, "Log directory cannot be null");
+        this.arguments.add("-log");
+        this.arguments.add(directory);
+        return this;
+    }
+
+    public RmidCLIBuilder logDirectory(Path directory) {
+        Objects.requireNonNull(directory, "Log directory cannot be null");
+        return logDirectory(directory.toString());
+    }
+
+    public RmidCLIBuilder port(int port) {
+        if (port <= 0 || port > 65535)
+            throw new IllegalArgumentException("Port must be between 1 and 65535");
+        this.arguments.add("-port");
+        this.arguments.add(Integer.toString(port));
+        return this;
+    }
+
+    public RmidCLIBuilder stop() {
+        this.arguments.add("-stop");
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "rmid");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start rmid process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/RmidCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/RmidCLIBuilder.java
@@ -9,6 +9,14 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder for launching {@code rmid} daemons via a specified {@link JDK} installation.
+ * <p>
+ * Offers helpers for JVM options, policy files, logging, ports, and lifecycle controls.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/rmid.html">rmid command documentation</a>
+ */
 public class RmidCLIBuilder implements CLIBuilder<Process, RmidCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "rmid.exe" : "rmid";
 
@@ -24,6 +32,13 @@ public class RmidCLIBuilder implements CLIBuilder<Process, RmidCLIBuilder> {
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@link RmidCLIBuilder} for the provided {@link JDK}.
+     *
+     * @param jdk the JDK to use when launching {@code rmid}; must not be null
+     * @return a fresh {@link RmidCLIBuilder} instance
+     * @throws NullPointerException if the JDK is null
+     */
     public static RmidCLIBuilder create(JDK jdk) {
         return new RmidCLIBuilder(jdk);
     }
@@ -66,18 +81,40 @@ public class RmidCLIBuilder implements CLIBuilder<Process, RmidCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds a child process option flag (-C) to the {@code rmid} command.
+     *
+     * @param option the option to pass; must not be null
+     * @return the current {@link RmidCLIBuilder} instance
+     * @throws NullPointerException if the option is null
+     */
     public RmidCLIBuilder childProcessOption(String option) {
         Objects.requireNonNull(option, "Child process option cannot be null");
         this.arguments.add("-C" + option);
         return this;
     }
 
+    /**
+     * Passes a JVM argument through to the {@code java} launcher.
+     *
+     * @param option the JVM argument; must not be null
+     * @return the current {@link RmidCLIBuilder} instance
+     * @throws NullPointerException if the option is null
+     */
     public RmidCLIBuilder javaOption(String option) {
         Objects.requireNonNull(option, "Java option cannot be null");
         this.arguments.add("-J" + option);
         return this;
     }
 
+    /**
+     * Sets the activation execution policy for the {@code rmid} daemon.
+     *
+     * @param policy the execution policy; must not be null or blank
+     * @return the current {@link RmidCLIBuilder} instance
+     * @throws NullPointerException     if the policy is null
+     * @throws IllegalArgumentException if the policy is blank
+     */
     public RmidCLIBuilder execPolicy(String policy) {
         Objects.requireNonNull(policy, "Execution policy cannot be null");
         if (policy.isBlank())
@@ -87,6 +124,13 @@ public class RmidCLIBuilder implements CLIBuilder<Process, RmidCLIBuilder> {
         return this;
     }
 
+    /**
+     * Logs output from {@code rmid} to the specified directory.
+     *
+     * @param directory the directory for log files; must not be null
+     * @return the current {@link RmidCLIBuilder} instance
+     * @throws NullPointerException if the directory is null
+     */
     public RmidCLIBuilder logDirectory(String directory) {
         Objects.requireNonNull(directory, "Log directory cannot be null");
         this.arguments.add("-log");
@@ -94,11 +138,25 @@ public class RmidCLIBuilder implements CLIBuilder<Process, RmidCLIBuilder> {
         return this;
     }
 
+    /**
+     * Logs output from {@code rmid} to the specified directory.
+     *
+     * @param directory the directory for log files; must not be null
+     * @return the current {@link RmidCLIBuilder} instance
+     * @throws NullPointerException if the directory is null
+     */
     public RmidCLIBuilder logDirectory(Path directory) {
         Objects.requireNonNull(directory, "Log directory cannot be null");
         return logDirectory(directory.toString());
     }
 
+    /**
+     * Sets the port number for the {@code rmid} daemon.
+     *
+     * @param port the port to listen on (1-65535)
+     * @return the current {@link RmidCLIBuilder} instance
+     * @throws IllegalArgumentException if the port is outside the valid range
+     */
     public RmidCLIBuilder port(int port) {
         if (port <= 0 || port > 65535)
             throw new IllegalArgumentException("Port must be between 1 and 65535");
@@ -107,6 +165,11 @@ public class RmidCLIBuilder implements CLIBuilder<Process, RmidCLIBuilder> {
         return this;
     }
 
+    /**
+     * Adds the {@code -stop} flag to shut down a running {@code rmid} daemon.
+     *
+     * @return the current {@link RmidCLIBuilder} instance
+     */
     public RmidCLIBuilder stop() {
         this.arguments.add("-stop");
         return this;

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/RmiregistryCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/RmiregistryCLIBuilder.java
@@ -1,0 +1,114 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class RmiregistryCLIBuilder implements CLIBuilder<Process, RmiregistryCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "rmiregistry.exe" : "rmiregistry";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+    private Integer port;
+
+    private RmiregistryCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static RmiregistryCLIBuilder create(JDK jdk) {
+        return new RmiregistryCLIBuilder(jdk);
+    }
+
+    @Override
+    public RmiregistryCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public RmiregistryCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public RmiregistryCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public RmiregistryCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public RmiregistryCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public RmiregistryCLIBuilder javaOption(String option) {
+        Objects.requireNonNull(option, "Java option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    public RmiregistryCLIBuilder port(int port) {
+        if (port <= 0 || port > 65535)
+            throw new IllegalArgumentException("Port must be between 1 and 65535");
+        this.port = port;
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        if (port != null)
+            command.add(Integer.toString(port));
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "rmiregistry");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start rmiregistry process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/RmiregistryCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/RmiregistryCLIBuilder.java
@@ -9,6 +9,14 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Fluent builder for starting {@code rmiregistry} processes via a given {@link JDK}.
+ * <p>
+ * Supports setting ports and JVM options before launching the registry.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/rmiregistry.html">rmiregistry command documentation</a>
+ */
 public class RmiregistryCLIBuilder implements CLIBuilder<Process, RmiregistryCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "rmiregistry.exe" : "rmiregistry";
 
@@ -25,6 +33,13 @@ public class RmiregistryCLIBuilder implements CLIBuilder<Process, RmiregistryCLI
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a new {@link RmiregistryCLIBuilder} that will launch {@code rmiregistry} using the supplied {@link JDK}.
+     *
+     * @param jdk the JDK installation to use; must not be null
+     * @return a fresh {@link RmiregistryCLIBuilder}
+     * @throws NullPointerException if the JDK is null
+     */
     public static RmiregistryCLIBuilder create(JDK jdk) {
         return new RmiregistryCLIBuilder(jdk);
     }
@@ -67,12 +82,26 @@ public class RmiregistryCLIBuilder implements CLIBuilder<Process, RmiregistryCLI
         return this;
     }
 
+    /**
+     * Passes a JVM argument through the {@link JDK} launcher invoked by {@code rmiregistry}.
+     *
+     * @param option the JVM option to pass; must not be null
+     * @return the current {@link RmiregistryCLIBuilder} instance
+     * @throws NullPointerException if the option is null
+     */
     public RmiregistryCLIBuilder javaOption(String option) {
         Objects.requireNonNull(option, "Java option cannot be null");
         this.arguments.add("-J" + option);
         return this;
     }
 
+    /**
+     * Sets the port number {@code rmiregistry} should bind to.
+     *
+     * @param port the port value between 1 and 65535
+     * @return the current {@link RmiregistryCLIBuilder} instance
+     * @throws IllegalArgumentException if the port is outside the valid range
+     */
     public RmiregistryCLIBuilder port(int port) {
         if (port <= 0 || port > 65535)
             throw new IllegalArgumentException("Port must be between 1 and 65535");

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/SerialverCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/SerialverCLIBuilder.java
@@ -1,0 +1,145 @@
+package dev.railroadide.railroad.java.cli.impl;
+
+import dev.railroadide.core.utility.OperatingSystem;
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.cli.CLIBuilder;
+import dev.railroadide.railroad.java.cli.ProcessExecution;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+public class SerialverCLIBuilder implements CLIBuilder<Process, SerialverCLIBuilder> {
+    private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "serialver.exe" : "serialver";
+
+    private final JDK jdk;
+    private final List<String> arguments = new ArrayList<>();
+    private final List<String> classNames = new ArrayList<>();
+    private final Map<String, String> environmentVariables = new HashMap<>();
+    private Path workingDirectory;
+    private boolean useSystemEnvVars = true;
+    private long timeoutDuration = 0;
+    private TimeUnit timeoutUnit = TimeUnit.SECONDS;
+
+    private SerialverCLIBuilder(JDK jdk) {
+        this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
+    }
+
+    public static SerialverCLIBuilder create(JDK jdk) {
+        return new SerialverCLIBuilder(jdk);
+    }
+
+    @Override
+    public SerialverCLIBuilder addArgument(String arg) {
+        Objects.requireNonNull(arg, "Argument cannot be null");
+        this.arguments.add(arg);
+        return this;
+    }
+
+    @Override
+    public SerialverCLIBuilder setWorkingDirectory(Path path) {
+        this.workingDirectory = path;
+        return this;
+    }
+
+    @Override
+    public SerialverCLIBuilder setEnvironmentVariable(String key, String value) {
+        Objects.requireNonNull(key, "Environment variable key cannot be null");
+        Objects.requireNonNull(value, "Environment variable value cannot be null");
+        this.environmentVariables.put(key, value);
+        return this;
+    }
+
+    @Override
+    public SerialverCLIBuilder useSystemEnvironmentVariables(boolean useSystemVars) {
+        this.useSystemEnvVars = useSystemVars;
+        return this;
+    }
+
+    @Override
+    public SerialverCLIBuilder setTimeout(long duration, TimeUnit unit) {
+        if (duration < 0)
+            throw new IllegalArgumentException("Timeout duration cannot be negative");
+
+        Objects.requireNonNull(unit, "TimeUnit cannot be null");
+        this.timeoutDuration = duration;
+        this.timeoutUnit = unit;
+        return this;
+    }
+
+    public SerialverCLIBuilder classpath(String... entries) {
+        Objects.requireNonNull(entries, "Classpath entries cannot be null");
+        for (String entry : entries) {
+            Objects.requireNonNull(entry, "Classpath entry cannot be null");
+        }
+
+        this.arguments.add("-classpath");
+        this.arguments.add(String.join(File.pathSeparator, entries));
+        return this;
+    }
+
+    public SerialverCLIBuilder classpath(Path... entries) {
+        Objects.requireNonNull(entries, "Classpath entries cannot be null");
+        String[] paths = Arrays.stream(entries).map(Path::toString).toArray(String[]::new);
+        return classpath(paths);
+    }
+
+    public SerialverCLIBuilder javaOption(String option) {
+        Objects.requireNonNull(option, "Java option cannot be null");
+        this.arguments.add("-J" + option);
+        return this;
+    }
+
+    public SerialverCLIBuilder addClassName(String className) {
+        Objects.requireNonNull(className, "Class name cannot be null");
+        if (className.isBlank())
+            throw new IllegalArgumentException("Class name cannot be blank");
+
+        this.classNames.add(className);
+        return this;
+    }
+
+    public SerialverCLIBuilder addClassNames(String... classNames) {
+        Objects.requireNonNull(classNames, "Class names cannot be null");
+        for (String className : classNames) {
+            addClassName(className);
+        }
+
+        return this;
+    }
+
+    @Override
+    public Process run() {
+        if (classNames.isEmpty())
+            throw new IllegalStateException("At least one class name must be specified for serialver.");
+
+        List<String> command = new ArrayList<>();
+        command.add(jdk.executablePath(EXECUTABLE_NAME).toString());
+        command.addAll(arguments);
+        command.addAll(classNames);
+
+        var processBuilder = new ProcessBuilder();
+        processBuilder.command(command);
+        if (workingDirectory != null) {
+            processBuilder.directory(workingDirectory.toFile());
+        }
+
+        if (useSystemEnvVars) {
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environmentVariables);
+        } else {
+            processBuilder.environment().clear();
+            processBuilder.environment().putAll(environmentVariables);
+        }
+
+        try {
+            Process process = processBuilder.start();
+            ProcessExecution.enforceTimeout(process, timeoutDuration, timeoutUnit, "serialver");
+
+            return process;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to start serialver process", exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/java/cli/impl/SerialverCLIBuilder.java
+++ b/src/main/java/dev/railroadide/railroad/java/cli/impl/SerialverCLIBuilder.java
@@ -10,6 +10,14 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Builder for running {@code serialver} to print serialVersionUID values.
+ * <p>
+ * Allows configuring classpaths, JVM options, and the list of classes to analyze.
+ * </p>
+ *
+ * @see <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/man/serialver.html">serialver command documentation</a>
+ */
 public class SerialverCLIBuilder implements CLIBuilder<Process, SerialverCLIBuilder> {
     private static final String EXECUTABLE_NAME = OperatingSystem.isWindows() ? "serialver.exe" : "serialver";
 
@@ -26,6 +34,13 @@ public class SerialverCLIBuilder implements CLIBuilder<Process, SerialverCLIBuil
         this.jdk = Objects.requireNonNull(jdk, "JDK cannot be null");
     }
 
+    /**
+     * Creates a {@link SerialverCLIBuilder} that will run {@code serialver} using the provided {@link JDK}.
+     *
+     * @param jdk the JDK installation to use; must not be null
+     * @return a fresh {@link SerialverCLIBuilder}
+     * @throws NullPointerException if the JDK is null
+     */
     public static SerialverCLIBuilder create(JDK jdk) {
         return new SerialverCLIBuilder(jdk);
     }
@@ -68,6 +83,13 @@ public class SerialverCLIBuilder implements CLIBuilder<Process, SerialverCLIBuil
         return this;
     }
 
+    /**
+     * Sets the {@code -classpath} entries for {@code serialver}.
+     *
+     * @param entries the classpath entries; must not be null or contain null elements
+     * @return the current {@link SerialverCLIBuilder} instance
+     * @throws NullPointerException if the entries array or any entry is null
+     */
     public SerialverCLIBuilder classpath(String... entries) {
         Objects.requireNonNull(entries, "Classpath entries cannot be null");
         for (String entry : entries) {
@@ -79,18 +101,40 @@ public class SerialverCLIBuilder implements CLIBuilder<Process, SerialverCLIBuil
         return this;
     }
 
+    /**
+     * Sets the {@code -classpath} for {@code serialver} using {@link Path} values.
+     *
+     * @param entries the classpath entries as {@code Path}; must not be null
+     * @return the current {@link SerialverCLIBuilder} instance
+     * @throws NullPointerException if the array or any entry is null
+     */
     public SerialverCLIBuilder classpath(Path... entries) {
         Objects.requireNonNull(entries, "Classpath entries cannot be null");
         String[] paths = Arrays.stream(entries).map(Path::toString).toArray(String[]::new);
         return classpath(paths);
     }
 
+    /**
+     * Passes a JVM argument through the {@link JDK} launcher.
+     *
+     * @param option the JVM option to pass; must not be null
+     * @return the current {@link SerialverCLIBuilder} instance
+     * @throws NullPointerException if the option is null
+     */
     public SerialverCLIBuilder javaOption(String option) {
         Objects.requireNonNull(option, "Java option cannot be null");
         this.arguments.add("-J" + option);
         return this;
     }
 
+    /**
+     * Adds a fully qualified class name for {@code serialver} to analyze.
+     *
+     * @param className the class to inspect; must not be null or blank
+     * @return the current {@link SerialverCLIBuilder} instance
+     * @throws NullPointerException     if the class name is null
+     * @throws IllegalArgumentException if the class name is blank
+     */
     public SerialverCLIBuilder addClassName(String className) {
         Objects.requireNonNull(className, "Class name cannot be null");
         if (className.isBlank())
@@ -100,6 +144,13 @@ public class SerialverCLIBuilder implements CLIBuilder<Process, SerialverCLIBuil
         return this;
     }
 
+    /**
+     * Adds multiple class names to analyze in {@code serialver}.
+     *
+     * @param classNames the classes to inspect; must not be null or contain null elements
+     * @return the current {@link SerialverCLIBuilder} instance
+     * @throws NullPointerException if the class names array or an entry is null
+     */
     public SerialverCLIBuilder addClassNames(String... classNames) {
         Objects.requireNonNull(classNames, "Class names cannot be null");
         for (String className : classNames) {

--- a/src/test/java/dev/railroadide/railroad/java/cli/CLIReflection.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/CLIReflection.java
@@ -2,6 +2,9 @@ package dev.railroadide.railroad.java.cli;
 
 import java.lang.reflect.Field;
 
+/**
+ * Utility class for accessing private fields of CLI builder classes using reflection for testing purposes.
+ */
 final class CLIReflection {
     private CLIReflection() {
     }

--- a/src/test/java/dev/railroadide/railroad/java/cli/CLIReflection.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/CLIReflection.java
@@ -1,0 +1,31 @@
+package dev.railroadide.railroad.java.cli;
+
+import java.lang.reflect.Field;
+
+final class CLIReflection {
+    private CLIReflection() {
+    }
+
+    static <T> T readField(Object target, String fieldName, Class<T> type) {
+        try {
+            Field field = findField(target.getClass(), fieldName);
+            field.setAccessible(true);
+            return type.cast(field.get(target));
+        } catch (ReflectiveOperationException exception) {
+            throw new AssertionError("Failed to access field " + fieldName, exception);
+        }
+    }
+
+    private static Field findField(Class<?> type, String fieldName) throws NoSuchFieldException {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                return current.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+
+        throw new NoSuchFieldException(fieldName);
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/java/cli/JDKCLITest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/JDKCLITest.java
@@ -9,6 +9,9 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+/**
+ * Tests for the {@link JDKCLI} class, ensuring that CLI builders correctly reference the associated JDK.
+ */
 class JDKCLITest {
     private final JDK jdk = TestJdks.create(21);
 

--- a/src/test/java/dev/railroadide/railroad/java/cli/JDKCLITest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/JDKCLITest.java
@@ -1,0 +1,60 @@
+package dev.railroadide.railroad.java.cli;
+
+import dev.railroadide.railroad.java.JDK;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class JDKCLITest {
+    private final JDK jdk = TestJdks.create(21);
+
+    @Test
+    void launchBuildersReferenceProvidedJdk() {
+        JDKCLI cli = new JDKCLI(jdk);
+        assertBuilderHasJdk(cli.launchMainClass(Path.of("Main.class")), "launchMainClass");
+        assertBuilderHasJdk(cli.launchJar(Path.of("app.jar")), "launchJar");
+        assertBuilderHasJdk(cli.launchModule("module.name"), "launchModule");
+        assertBuilderHasJdk(cli.launchSourceFile(Path.of("Example.java")), "launchSourceFile");
+    }
+
+    @Test
+    void toolBuildersReferenceProvidedJdk() {
+        JDKCLI cli = new JDKCLI(jdk);
+        Map<String, Object> builders = new LinkedHashMap<>();
+        builders.put("jar", cli.jar());
+        builders.put("jarsigner", cli.jarsigner());
+        builders.put("javadoc", cli.javadoc());
+        builders.put("javap", cli.javap());
+        builders.put("jcmd", cli.jcmd());
+        builders.put("jdb", cli.jdb());
+        builders.put("jdeprscan", cli.jdeprscan());
+        builders.put("jdeps", cli.jdeps());
+        builders.put("jfr", cli.jfr());
+        builders.put("jinfo", cli.jinfo());
+        builders.put("jlink", cli.jlink());
+        builders.put("jmap", cli.jmap());
+        builders.put("jmod", cli.jmod());
+        builders.put("jpackage", cli.jpackage());
+        builders.put("jps", cli.jps());
+        builders.put("jshell", cli.jshell());
+        builders.put("jstack", cli.jstack());
+        builders.put("jstat", cli.jstat());
+        builders.put("jstatd", cli.jstatd());
+        builders.put("keytool", cli.keytool());
+        builders.put("rmic", cli.rmic());
+        builders.put("rmid", cli.rmid());
+        builders.put("rmiregistry", cli.rmiregistry());
+        builders.put("serialver", cli.serialver());
+
+        builders.forEach((name, builder) -> assertBuilderHasJdk(builder, name));
+    }
+
+    private void assertBuilderHasJdk(Object builder, String name) {
+        JDK stored = CLIReflection.readField(builder, "jdk", JDK.class);
+        assertSame(jdk, stored, () -> name + " should retain the original JDK reference");
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/java/cli/JDKCliToolExecutionTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/JDKCliToolExecutionTest.java
@@ -1,0 +1,62 @@
+package dev.railroadide.railroad.java.cli;
+
+import dev.railroadide.railroad.java.JDK;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JDKCliToolExecutionTest {
+
+    @Test
+    void keytoolVersionCommandRunsOnCurrentJdk() throws IOException {
+        JDK jdk = TestJdks.currentRuntime();
+        Process process = jdk.cli().keytool()
+            .version()
+            .setTimeout(5, TimeUnit.SECONDS)
+            .run();
+
+        assertEquals(0, process.exitValue(), "keytool -version should exit successfully");
+
+        String stdout = readFully(process.getInputStream());
+        String stderr = readFully(process.getErrorStream());
+        String output = stdout.isBlank() ? stderr : stdout;
+
+        assertFalse(output.isBlank(), "keytool should report its version");
+        assertTrue(output.toLowerCase(Locale.ROOT).contains("keytool"),
+            "version output should mention keytool");
+    }
+
+    @Test
+    void javaLauncherRunsSourceFile() throws IOException {
+        JDK jdk = TestJdks.currentRuntime();
+        Path tempDir = Files.createTempDirectory("jdk-cli-src");
+        Path sourceFile = tempDir.resolve("CliHello.java");
+        Files.writeString(sourceFile, """
+            public class CliHello {
+                public static void main(String[] args) {
+                    System.out.print("hello from java");
+                }
+            }
+            """);
+
+        Process process = jdk.cli().launchSourceFile(sourceFile)
+            .setTimeout(5, TimeUnit.SECONDS)
+            .run();
+
+        assertEquals(0, process.exitValue(), "java should execute the generated source file");
+        String stdout = readFully(process.getInputStream()).trim();
+        assertEquals("hello from java", stdout);
+    }
+
+    private static String readFully(InputStream stream) throws IOException {
+        return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/java/cli/JDKCliToolExecutionTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/JDKCliToolExecutionTest.java
@@ -13,6 +13,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests the execution of various CLI tools provided by a JDK, such as keytool and the Java launcher.
+ */
 class JDKCliToolExecutionTest {
 
     @Test

--- a/src/test/java/dev/railroadide/railroad/java/cli/JarCLIBuilderTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/JarCLIBuilderTest.java
@@ -9,6 +9,10 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests for the {@link JarCLIBuilder} class, ensuring correct argument construction and behavior
+ * for the `jar` command-line tool.
+ */
 class JarCLIBuilderTest {
 
     @Test

--- a/src/test/java/dev/railroadide/railroad/java/cli/JarCLIBuilderTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/JarCLIBuilderTest.java
@@ -1,0 +1,46 @@
+package dev.railroadide.railroad.java.cli;
+
+import dev.railroadide.railroad.java.cli.impl.JarCLIBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JarCLIBuilderTest {
+
+    @Test
+    void releaseEntriesRejectsVersionsBelowNine() {
+        JarCLIBuilder builder = JarCLIBuilder.create(TestJdks.create(21));
+        assertThrows(IllegalArgumentException.class, () -> builder.releaseEntries(8));
+        assertDoesNotThrow(() -> builder.releaseEntries(9));
+    }
+
+    @Test
+    void generateIndexSetsModeAndTarget() {
+        JarCLIBuilder builder = JarCLIBuilder.create(TestJdks.create(21));
+        Path jarPath = Path.of("libs", "app.jar");
+        builder.generateIndex(jarPath);
+
+        assertEquals(JarCLIBuilder.OperationMode.GENERATE_INDEX,
+            CLIReflection.readField(builder, "operationMode", JarCLIBuilder.OperationMode.class));
+        assertEquals(jarPath.toString(), CLIReflection.readField(builder, "generateIndexTarget", String.class));
+    }
+
+    @Test
+    void modulePathUsesPlatformSeparator() {
+        JarCLIBuilder builder = JarCLIBuilder.create(TestJdks.create(21));
+        builder.modulePath("mods/one", "mods/two");
+
+        List<String> arguments = CLIReflection.readField(builder, "arguments", List.class);
+        assertTrue(arguments.contains("--module-path mods/one" + File.pathSeparator + "mods/two"));
+    }
+
+    @Test
+    void runRequiresOperationMode() {
+        JarCLIBuilder builder = JarCLIBuilder.create(TestJdks.create(21));
+        assertThrows(IllegalStateException.class, builder::run);
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/java/cli/JarsignerCLIBuilderTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/JarsignerCLIBuilderTest.java
@@ -1,0 +1,48 @@
+package dev.railroadide.railroad.java.cli;
+
+import dev.railroadide.railroad.java.cli.impl.JarsignerCLIBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JarsignerCLIBuilderTest {
+
+    @Test
+    void signConfiguresOperationAndClearsVerifyAliases() {
+        JarsignerCLIBuilder builder = JarsignerCLIBuilder.create(TestJdks.create(21));
+        builder.verify("old.jar", "alpha");
+        builder.sign("app.jar", "releaseAlias");
+
+        Enum<?> operation = CLIReflection.readField(builder, "operationMode", Enum.class);
+        assertEquals("SIGN", operation.name());
+        assertEquals("app.jar", CLIReflection.readField(builder, "jarFile", String.class));
+        assertEquals("releaseAlias", CLIReflection.readField(builder, "signingAlias", String.class));
+        List<String> verifyAliases = CLIReflection.readField(builder, "verifyAliases", List.class);
+        assertTrue(verifyAliases.isEmpty(), "Verify aliases should be cleared when switching to sign mode");
+    }
+
+    @Test
+    void verifyCollectsAliasesAndClearsSigningAlias() {
+        JarsignerCLIBuilder builder = JarsignerCLIBuilder.create(TestJdks.create(21));
+        builder.sign("app.jar", "releaseAlias");
+        builder.verify("bundle.jar", "alpha", "beta");
+
+        Enum<?> operation = CLIReflection.readField(builder, "operationMode", Enum.class);
+        assertEquals("VERIFY", operation.name());
+        assertEquals("bundle.jar", CLIReflection.readField(builder, "jarFile", String.class));
+        assertNull(CLIReflection.readField(builder, "signingAlias", String.class));
+        List<String> verifyAliases = CLIReflection.readField(builder, "verifyAliases", List.class);
+        assertEquals(List.of("alpha", "beta"), verifyAliases);
+    }
+
+    @Test
+    void storePasswordFromEnvironmentUsesExpectedSyntax() {
+        JarsignerCLIBuilder builder = JarsignerCLIBuilder.create(TestJdks.create(21));
+        builder.storePasswordFromEnv("STORE_PASS");
+
+        List<String> arguments = CLIReflection.readField(builder, "arguments", List.class);
+        assertEquals("-storepass:env STORE_PASS", arguments.getLast());
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/java/cli/JarsignerCLIBuilderTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/JarsignerCLIBuilderTest.java
@@ -7,6 +7,10 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests for the {@link JarsignerCLIBuilder} class, ensuring correct argument construction and behavior
+ * for the `jarsigner` command-line tool.
+ */
 class JarsignerCLIBuilderTest {
 
     @Test

--- a/src/test/java/dev/railroadide/railroad/java/cli/JavaExecutableCLIBuilderTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/JavaExecutableCLIBuilderTest.java
@@ -1,0 +1,90 @@
+package dev.railroadide.railroad.java.cli;
+
+import dev.railroadide.railroad.java.cli.impl.JavaExecutableCLIBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JavaExecutableCLIBuilderTest {
+
+    @Test
+    void classFileRequiresClassExtension() {
+        assertThrows(IllegalArgumentException.class,
+            () -> JavaExecutableCLIBuilder.classFile(TestJdks.create(21), Path.of("Main.txt")));
+    }
+
+    @Test
+    void jarFileRequiresJarExtension() {
+        assertThrows(IllegalArgumentException.class,
+            () -> JavaExecutableCLIBuilder.jarFile(TestJdks.create(21), Path.of("launcher.zip")));
+    }
+
+    @Test
+    void sourceFileRequiresJavaExtension() {
+        assertThrows(IllegalArgumentException.class,
+            () -> JavaExecutableCLIBuilder.sourceFile(TestJdks.create(21), Path.of("Main.txt")));
+    }
+
+    @Test
+    void agentlibArgumentsInsertedAtBeginning() {
+        var builder = JavaExecutableCLIBuilder.module(TestJdks.create(21), "module");
+        builder.addArgument("--existing");
+        builder.agentlib("jdwp", "transport=dt_socket", "suspend=y");
+
+        List<String> arguments = CLIReflection.readField(builder, "arguments", List.class);
+        assertEquals("-agentlib:jdwp=transport=dt_socket,suspend=y", arguments.get(0));
+        assertEquals("--existing", arguments.get(1));
+    }
+
+    @Test
+    void enablePreviewFeaturesRequiresJdk12() {
+        var jdk11Builder = JavaExecutableCLIBuilder.module(TestJdks.create(11), "module");
+        assertThrows(UnsupportedOperationException.class, jdk11Builder::enablePreviewFeatures);
+
+        var jdk12Builder = JavaExecutableCLIBuilder.module(TestJdks.create(12), "module");
+        jdk12Builder.enablePreviewFeatures();
+        List<String> arguments = CLIReflection.readField(jdk12Builder, "arguments", List.class);
+        assertTrue(arguments.contains("--enable-preview"));
+    }
+
+    @Test
+    void enableNativeAccessRequiresJdk16() {
+        var jdk15Builder = JavaExecutableCLIBuilder.module(TestJdks.create(15), "module");
+        assertThrows(UnsupportedOperationException.class, () -> jdk15Builder.enableNativeAccess("mod"));
+
+        var jdk16Builder = JavaExecutableCLIBuilder.module(TestJdks.create(16), "module");
+        jdk16Builder.enableNativeAccess("com.example");
+        List<String> arguments = CLIReflection.readField(jdk16Builder, "arguments", List.class);
+        assertTrue(arguments.contains("--enable-native-access=com.example"));
+    }
+
+    @Test
+    void illegalNativeAccessValidatesVersionAndMode() {
+        var jdk23Builder = JavaExecutableCLIBuilder.module(TestJdks.create(23), "module");
+        assertThrows(UnsupportedOperationException.class,
+            () -> jdk23Builder.illegalNativeAccess(JavaExecutableCLIBuilder.AccessMode.ALLOW));
+
+        var jdk24Builder = JavaExecutableCLIBuilder.module(TestJdks.create(24), "module");
+        assertThrows(UnsupportedOperationException.class,
+            () -> jdk24Builder.illegalNativeAccess(JavaExecutableCLIBuilder.AccessMode.DEBUG));
+
+        jdk24Builder.illegalNativeAccess(JavaExecutableCLIBuilder.AccessMode.WARN);
+        List<String> arguments = CLIReflection.readField(jdk24Builder, "arguments", List.class);
+        assertTrue(arguments.contains("--illegal-native-access=warn"));
+    }
+
+    @Test
+    void finalizationRequiresJdk18() {
+        var jdk17Builder = JavaExecutableCLIBuilder.module(TestJdks.create(17), "module");
+        assertThrows(UnsupportedOperationException.class,
+            () -> jdk17Builder.finalization(JavaExecutableCLIBuilder.EnabledDisabled.ENABLED));
+
+        var jdk18Builder = JavaExecutableCLIBuilder.module(TestJdks.create(18), "module");
+        jdk18Builder.finalization(JavaExecutableCLIBuilder.EnabledDisabled.DISABLED);
+        List<String> arguments = CLIReflection.readField(jdk18Builder, "arguments", List.class);
+        assertTrue(arguments.contains("--finalization=disabled"));
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/java/cli/JavaExecutableCLIBuilderTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/JavaExecutableCLIBuilderTest.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests for the {@link JavaExecutableCLIBuilder} class, ensuring correct argument construction and behavior
+ * for the `java` command-line executable.
+ */
 class JavaExecutableCLIBuilderTest {
 
     @Test

--- a/src/test/java/dev/railroadide/railroad/java/cli/KeytoolCLIBuilderTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/KeytoolCLIBuilderTest.java
@@ -1,0 +1,47 @@
+package dev.railroadide.railroad.java.cli;
+
+import dev.railroadide.railroad.java.cli.impl.KeytoolCLIBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KeytoolCLIBuilderTest {
+
+    @Test
+    void commandSelectionIsExclusive() {
+        KeytoolCLIBuilder builder = KeytoolCLIBuilder.create(TestJdks.create(21));
+        builder.listEntries();
+        assertThrows(IllegalStateException.class, builder::generateKeyPair);
+    }
+
+    @Test
+    void keystorePathAddsExpectedArgument() {
+        KeytoolCLIBuilder builder = KeytoolCLIBuilder.create(TestJdks.create(21));
+        Path keystorePath = Path.of("certs", "keys.jks");
+        builder.keystore(keystorePath);
+
+        List<String> arguments = CLIReflection.readField(builder, "arguments", List.class);
+        assertTrue(arguments.contains("-keystore " + keystorePath));
+    }
+
+    @Test
+    void tlsInfoAndSslServerArgumentsAreFormatted() {
+        KeytoolCLIBuilder builder = KeytoolCLIBuilder.create(TestJdks.create(21));
+        builder.tlsInfo("TLSv1.3");
+        builder.sslServer("example.com:443");
+
+        List<String> arguments = CLIReflection.readField(builder, "arguments", List.class);
+        assertTrue(arguments.contains("-tls TLSv1.3"));
+        assertTrue(arguments.contains("-sslserver example.com:443"));
+    }
+
+    @Test
+    void timeoutCannotBeNegative() {
+        KeytoolCLIBuilder builder = KeytoolCLIBuilder.create(TestJdks.create(21));
+        assertThrows(IllegalArgumentException.class, () -> builder.setTimeout(-1, TimeUnit.SECONDS));
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/java/cli/KeytoolCLIBuilderTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/KeytoolCLIBuilderTest.java
@@ -9,6 +9,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests for the {@link KeytoolCLIBuilder} class, ensuring correct argument construction and behavior
+ * for the `keytool` command-line utility.
+ */
 class KeytoolCLIBuilderTest {
 
     @Test

--- a/src/test/java/dev/railroadide/railroad/java/cli/ProcessExecutionTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/ProcessExecutionTest.java
@@ -1,0 +1,164 @@
+package dev.railroadide.railroad.java.cli;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProcessExecutionTest {
+
+    @Test
+    void enforceTimeoutReturnsWhenProcessCompletesWithinLimit() {
+        var process = new StubProcess(true, false, true);
+        assertDoesNotThrow(() -> ProcessExecution.enforceTimeout(process, 1, TimeUnit.SECONDS, "java"));
+        assertTrue(process.isWaitForCalled(), "waitFor should be invoked when enforcing timeouts");
+        assertFalse(process.isDestroyCalled(), "completed processes should not be destroyed");
+    }
+
+    @Test
+    void enforceTimeoutDestroysHungProcess() {
+        var process = new StubProcess(false, false, false);
+        RuntimeException exception = assertThrows(RuntimeException.class,
+            () -> ProcessExecution.enforceTimeout(process, 1, TimeUnit.SECONDS, "jarsigner"));
+
+        assertTrue(exception.getMessage().contains("timed out"));
+        assertTrue(process.isDestroyCalled(), "hung process should be destroyed");
+        assertTrue(process.isDestroyForciblyCalled(), "hung process should be forcefully destroyed");
+    }
+
+    @Test
+    void enforceTimeoutHandlesInterruptions() {
+        var process = new StubProcess(true, true, true);
+        RuntimeException exception = assertThrows(RuntimeException.class,
+            () -> ProcessExecution.enforceTimeout(process, 1, TimeUnit.SECONDS, "keytool"));
+
+        assertTrue(exception.getMessage().contains("Interrupted while waiting"));
+        assertTrue(process.isDestroyCalled(), "interrupted wait should still destroy the process");
+        assertTrue(Thread.currentThread().isInterrupted(), "interrupt status should be restored");
+        Thread.interrupted(); // Clear for other tests
+    }
+
+    @Test
+    void enforceTimeoutSkipsWaitWhenDurationIsNonPositive() {
+        var process = new StubProcess(true, false, true);
+        assertDoesNotThrow(() -> ProcessExecution.enforceTimeout(process, 0, TimeUnit.SECONDS, "jar"));
+        assertFalse(process.isWaitForCalled(), "no wait should occur when timeout is disabled");
+    }
+
+    private static final class StubProcess extends Process {
+        private final boolean waitResult;
+        private final boolean interruptDuringWait;
+        private final boolean destroyStopsProcess;
+        private boolean waitForCalled;
+        private boolean destroyCalled;
+        private boolean destroyForciblyCalled;
+        private boolean alive = true;
+
+        private StubProcess(boolean waitResult, boolean interruptDuringWait, boolean destroyStopsProcess) {
+            this.waitResult = waitResult;
+            this.interruptDuringWait = interruptDuringWait;
+            this.destroyStopsProcess = destroyStopsProcess;
+        }
+
+        boolean isWaitForCalled() {
+            return waitForCalled;
+        }
+
+        boolean isDestroyCalled() {
+            return destroyCalled;
+        }
+
+        boolean isDestroyForciblyCalled() {
+            return destroyForciblyCalled;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return OutputStream.nullOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return InputStream.nullInputStream();
+        }
+
+        @Override
+        public int waitFor() {
+            waitForCalled = true;
+            alive = false;
+            return 0;
+        }
+
+        @Override
+        public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+            waitForCalled = true;
+            if (interruptDuringWait)
+                throw new InterruptedException("simulated interrupt");
+
+            if (waitResult) {
+                alive = false;
+            }
+
+            return waitResult;
+        }
+
+        @Override
+        public int exitValue() {
+            return 0;
+        }
+
+        @Override
+        public void destroy() {
+            destroyCalled = true;
+            if (destroyStopsProcess) {
+                alive = false;
+            }
+        }
+
+        @Override
+        public Process destroyForcibly() {
+            destroyForciblyCalled = true;
+            alive = false;
+            return this;
+        }
+
+        @Override
+        public boolean isAlive() {
+            return alive;
+        }
+
+        @Override
+        public long pid() {
+            return 0;
+        }
+
+        @Override
+        public ProcessHandle.Info info() {
+            return ProcessHandle.current().info();
+        }
+
+        @Override
+        public Stream<ProcessHandle> children() {
+            return Stream.empty();
+        }
+
+        @Override
+        public Stream<ProcessHandle> descendants() {
+            return Stream.empty();
+        }
+
+        @Override
+        public boolean supportsNormalTermination() {
+            return true;
+        }
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/java/cli/ProcessExecutionTest.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/ProcessExecutionTest.java
@@ -9,6 +9,10 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests for the {@link ProcessExecution} utility class, specifically focusing on its timeout
+ * and interruption handling during process execution.
+ */
 class ProcessExecutionTest {
 
     @Test

--- a/src/test/java/dev/railroadide/railroad/java/cli/TestJdks.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/TestJdks.java
@@ -7,6 +7,9 @@ import dev.railroadide.railroad.utility.JavaVersion;
 import java.nio.file.Path;
 import java.util.UUID;
 
+/**
+ * Utility class for creating and retrieving JDK instances for testing purposes.
+ */
 final class TestJdks {
     private TestJdks() {
     }

--- a/src/test/java/dev/railroadide/railroad/java/cli/TestJdks.java
+++ b/src/test/java/dev/railroadide/railroad/java/cli/TestJdks.java
@@ -1,0 +1,30 @@
+package dev.railroadide.railroad.java.cli;
+
+import dev.railroadide.railroad.java.JDK;
+import dev.railroadide.railroad.java.JDKUtils;
+import dev.railroadide.railroad.utility.JavaVersion;
+
+import java.nio.file.Path;
+import java.util.UUID;
+
+final class TestJdks {
+    private TestJdks() {
+    }
+
+    static JDK create(int release) {
+        Path home = Path.of("build", "test-jdk-" + release + "-" + UUID.randomUUID());
+        return new JDK(home, "test-jdk-" + release, JavaVersion.fromMajor(release), JDK.Brand.UNKNOWN);
+    }
+
+    static JDK currentRuntime() {
+        String javaHome = System.getProperty("java.home");
+        if (javaHome == null || javaHome.isBlank())
+            throw new IllegalStateException("java.home property is not set");
+
+        JDK jdk = JDKUtils.createJDKFromAnyPath(javaHome);
+        if (jdk == null)
+            throw new IllegalStateException("Unable to resolve the running JDK at " + javaHome);
+
+        return jdk;
+    }
+}


### PR DESCRIPTION
Closes #108

This pull request introduces a new command-line interface (CLI) abstraction for interacting with JDK tools, along with supporting utility classes and improvements to the `JDK` descriptor. The changes make it easier and safer to launch and manage JDK-related processes programmatically, add fluent builder APIs for constructing CLI commands, and improve documentation and clarity throughout the JDK management code.

### JDK CLI Abstraction & Builder Pattern

* Added the `JDKCLI` class, which provides a fluent API for accessing and executing command-line tools (such as `java`, `jar`, `javadoc`, etc.) for a specific `JDK` instance. This class acts as a factory for specialized CLI builders for each tool.
* Introduced the generic `CLIBuilder` interface, defining a fluent-style builder pattern for constructing and executing command-line processes with customizable arguments, environment, working directory, and timeout.

### JDK Descriptor Enhancements

* Updated the `JDK` class to include a reference to its associated `JDKCLI` instance, added utility methods for resolving tool executable paths, and significantly improved documentation for constructors, accessors, and the `Brand` enum.

### Process Management Utilities

* Added the `ProcessExecution` utility class for managing external processes, including enforcing execution timeouts and safe termination of processes.

### Minor Improvements & Refactoring

* Simplified platform-specific logic for resolving the Java executable name in `JDKManager` by removing the redundant helper method and using an inline constant.