### PR TITLE
Fix duplicate control key on Windows

### DIFF
--- a/src/main/java/dev/railroadide/railroad/settings/keybinds/KeyComboNode.java
+++ b/src/main/java/dev/railroadide/railroad/settings/keybinds/KeyComboNode.java
@@ -137,6 +137,7 @@ public class KeyComboNode extends RRButton {
     private String localizeModifier(KeyCombination.Modifier modifier) {
         return switch (modifier.getKey()) {
             case SHORTCUT -> OperatingSystem.isMac() ? "⌘" : "Ctrl";
+            case META -> "⌘";
             case CONTROL -> "Ctrl";
             case ALT -> OperatingSystem.isMac() ? "⌥" : "Alt";
             case SHIFT -> "Shift";

--- a/src/main/java/dev/railroadide/railroad/settings/keybinds/KeyComboNode.java
+++ b/src/main/java/dev/railroadide/railroad/settings/keybinds/KeyComboNode.java
@@ -64,6 +64,17 @@ public class KeyComboNode extends RRButton {
         if (event.isControlDown()) modifiers.add(KeyCombination.CONTROL_DOWN);
         if (event.isAltDown()) modifiers.add(KeyCombination.ALT_DOWN);
         if (event.isShiftDown()) modifiers.add(KeyCombination.SHIFT_DOWN);
+        if (event.isMetaDown()) modifiers.add(KeyCombination.META_DOWN);
+
+        if (OperatingSystem.isMac()) {
+            if (event.isMetaDown()) {
+                modifiers.remove(KeyCombination.SHORTCUT_DOWN);
+            }
+        } else {
+            if (event.isControlDown()) {
+                modifiers.remove(KeyCombination.SHORTCUT_DOWN);
+            }
+        }
 
         pendingModifiers = modifiers.isEmpty() ? null : modifiers.toArray(new KeyCombination.Modifier[0]);
     }


### PR DESCRIPTION
Fixes #103 

The control key was appearing twice because the "Shortcut" key is also the control key on Windows.

The "Shortcut" key is platform dependent. Looking at JavaFX source code we can see that it is "Meta" on Mac PCs and "Control" otherwise.
Fix this issue for all platforms.