### PR TITLE
Update RailroadGradlePlugin to version 1.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     implementation 'org.apache.maven:maven-repository-metadata:4.0.0-rc-4'
     implementation 'org.codehaus.plexus:plexus-container-default:2.1.1'
 
-    implementation 'dev.railroadide:RailroadGradlePlugin:1.0.0'
+    implementation 'dev.railroadide:RailroadGradlePlugin:1.0.1'
 
     implementation 'io.get-coursier:interface:1.0.29-M1'
     implementation 'org.eclipse.jgit:org.eclipse.jgit:7.4.0.202509020913-r'

--- a/src/main/resources/assets/railroad/scripts/init-download-sources.gradle
+++ b/src/main/resources/assets/railroad/scripts/init-download-sources.gradle
@@ -5,7 +5,7 @@ initscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "dev.railroadide:RailroadGradlePlugin:1.0.0"
+        classpath "dev.railroadide:RailroadGradlePlugin:1.0.1"
     }
 }
 

--- a/src/main/resources/assets/railroad/scripts/init-gradle-plugin.gradle
+++ b/src/main/resources/assets/railroad/scripts/init-gradle-plugin.gradle
@@ -5,7 +5,7 @@ initscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "dev.railroadide:RailroadGradlePlugin:1.0.0"
+        classpath "dev.railroadide:RailroadGradlePlugin:1.0.1"
     }
 }
 


### PR DESCRIPTION
This change introduces a fix for the long loading times and freezes when opening the IDE that were caused by the gradle tab's gradle plugin having effectively-infinite recursion on `RailroadDependency`'s `hashCode` method. The fix here is just bumping the plugin version which introduces said fix.