### PR TITLE
Feat/stable document identities

### DIFF
--- a/docs/sst-document-identity.md
+++ b/docs/sst-document-identity.md
@@ -1,0 +1,71 @@
+# SST document identity contract
+
+`DocumentId` is the stable identity of one logical document. It is deliberately
+independent of filesystem path spelling, URI, content, language, and revision.
+
+## Identity rules
+
+- Renaming, moving, saving, or editing a document retains its ID.
+- A copied document receives a new ID, even when its content is identical.
+- Deleting a document ends its registry lifecycle. If a new document later uses the
+  same path, the owner must release the old association before resolving the new one.
+- Separate in-memory, generated, decompiled, archive-entry, text, and binary documents
+  receive separate IDs. None of these categories requires a filesystem path.
+- Equality and hashing use only the opaque UUID value. Paths and content never
+  participate in `DocumentId` equality.
+
+`DocumentId` does not replace the planned `DocumentUri`, `DocumentVersion`, or
+`DocumentSnapshot` contracts. An ID answers *which logical document*; those contracts
+answer *where it is addressed* and *which immutable revision is being observed*.
+
+## Ownership and lifecycle
+
+A workspace or document service owns a `DocumentIdentityRegistry`. The owner allocates
+IDs when documents enter its model and passes those IDs into syntax, semantic, indexing,
+and feature work. Consumers borrow IDs and must not derive replacements from a path or
+content hash.
+
+The registry can issue an unbound ID for any virtual, generated, in-memory, text, or
+binary document. Physical documents use `getOrCreate(Path)`. `associate` attaches an
+existing pathless identity to a physical location, while `rebind` preserves identity
+when the owner moves or renames a document. `release` forgets all path associations when
+the logical document leaves the workspace; it does not invalidate or recycle the ID.
+Old immutable snapshots and asynchronous results may therefore safely retain it.
+
+IDs are process-independent values and have a canonical UUID string representation.
+Workspaces that require identity across restarts must persist both that value and the
+workspace-specific origin association. The core registry intentionally does not choose
+a persistence policy for its owner.
+
+## Physical path resolution and failure behavior
+
+The registry retains normalized absolute and real path spellings. Existing paths are
+also compared with `Files.isSameFile`, allowing symbolic links, hard links, and other
+filesystem aliases to converge when the platform can establish equivalence. A missing
+path is represented by its normalized absolute spelling until it exists or is rebound.
+
+Invalid null or malformed IDs fail immediately. Resolving or comparing an existing path
+may throw `UncheckedIOException` when the filesystem cannot answer reliably. Associating
+one physical location with two different IDs, or rebinding an identity from a location
+it does not own, throws `IllegalStateException`; the registry never silently merges two
+logical documents.
+
+## Immutability and thread safety
+
+`DocumentId` is an immutable value type and can be shared freely between workers.
+`DocumentIdentityRegistry` serializes allocation and association operations, so concurrent
+resolution of the same physical document returns one ID. Future document snapshots must
+also be immutable, but snapshot content and versioning are outside this contract.
+
+## Compatibility with the current SST
+
+`SyntaxTree` now carries a `DocumentId`, and semantic models inherit it through their
+syntax tree. Java parser overloads accept an owner-supplied ID. Incremental parsing keeps
+the previous tree's ID for both incremental and full-reparse paths.
+
+Existing parser overloads and the original `SyntaxTree(SyntaxNode)` constructor remain
+source compatible. Because those entry points have no owning document context, they
+allocate a fresh anonymous ID for each independently created tree. Callers that correlate
+results across parses must migrate to the explicit-ID overloads. Path-keyed project index
+and raw-string feature-provider migration remains part of the later snapshot and
+compatibility roadmap items.

--- a/docs/sst-document-identity.md
+++ b/docs/sst-document-identity.md
@@ -14,8 +14,8 @@ independent of filesystem path spelling, URI, content, language, and revision.
 - Equality and hashing use only the opaque UUID value. Paths and content never
   participate in `DocumentId` equality.
 
-`DocumentId` does not replace `DocumentUri`, `DocumentVersion`, or the planned
-`DocumentSnapshot` contract. An ID answers *which logical document*, a URI answers
+`DocumentId` does not replace `DocumentUri`, `DocumentVersion`, or
+`DocumentSnapshot`. An ID answers *which logical document*, a URI answers
 *where it is addressed*, and a version identifies *which immutable revision is being
 observed*.
 
@@ -53,6 +53,30 @@ the workspace-owned registry enforces progression for each ID. `advanceVersion` 
 an atomic one-step increment, and `restoreVersion` accepts equal or later persisted state
 but rejects rollback. Reaching `Long.MAX_VALUE` fails explicitly instead of wrapping.
 
+## Snapshot rules
+
+`DocumentSnapshot` is the sealed language-neutral root for one immutable document
+revision. Its only permitted implementations are `TextDocumentSnapshot` and
+`BinaryDocumentSnapshot`, so consumers must handle text and binary content explicitly.
+Both carry a stable ID, the URI captured for that revision, a monotonic version, and a
+non-blank provider-defined language ID. Physical files, virtual/archive entries,
+generated sources, and unsaved in-memory documents use the same contracts; the URI
+scheme describes their address rather than changing snapshot semantics.
+
+`TextDocumentSnapshot` converts every `CharSequence` to an immutable `String` during
+construction and records its associated `Charset`. `BinaryDocumentSnapshot` copies
+array or buffer input during construction. It exposes either a defensive array copy or
+a fresh read-only `ByteBuffer`, preventing both byte mutation and shared buffer-position
+state. A buffer snapshot includes only the source buffer's remaining bytes and never
+advances the caller's position.
+
+The document/workspace service owns snapshot creation and publishes a new, later
+snapshot whenever observable content changes. Consumers may retain an old snapshot for
+the lifetime of analysis derived from that revision and may share it across worker
+threads without synchronization. Null metadata/content and blank language IDs fail at
+construction. Snapshot equality is deliberately not defined yet; callers correlate
+revisions with `DocumentId` and `DocumentVersion` instead of object or content equality.
+
 ## Ownership and lifecycle
 
 A workspace or document service owns a `DocumentIdentityRegistry`. The owner allocates
@@ -89,23 +113,25 @@ fails explicitly; the registry never silently merges documents or rolls versions
 
 ## Immutability and thread safety
 
-`DocumentId`, `DocumentUri`, and `DocumentVersion` are immutable value types and can be
-shared freely between workers. `DocumentIdentityRegistry` serializes allocation,
+`DocumentId`, `DocumentUri`, `DocumentVersion`, and both snapshot implementations are
+immutable and can be shared freely between workers. `DocumentIdentityRegistry` serializes allocation,
 association, and version operations, so concurrent resolution returns one ID and
-concurrent advances never allocate the same revision. Future document snapshots must
-also be immutable, but snapshot content is outside this contract.
+concurrent advances never allocate the same revision.
 
 ## Compatibility with the current SST
 
-`SyntaxTree` now carries `DocumentId`, `DocumentUri`, and `DocumentVersion`, and semantic
-models inherit them through their syntax tree. Java parser overloads accept all three
-owner-supplied values. Incremental parsing retains identity and location while advancing
-the version for both incremental and full-reparse paths. Owners may supply a later
-version explicitly; equal or earlier revisions are rejected.
+`SyntaxTree` now carries the exact `TextDocumentSnapshot` parsed into its root, and
+semantic models inherit it through their syntax tree. Java parser overloads accept a
+snapshot directly while the metadata overloads remain available. Incremental parsing
+accepts a later snapshot of the same document, allowing a URI move and encoding change
+to travel atomically with the new content. Mismatched IDs, stale versions, mismatched
+legacy previous-source arguments, and non-Java snapshots fail explicitly. Snapshot-aware
+parser entry points preserve the owner's exact input even when parser recovery affects
+the syntax representation.
 
 Existing parser overloads and the original `SyntaxTree(SyntaxNode)` constructor remain
 source compatible. Because those entry points have no owning document context, they
 allocate a fresh anonymous ID, matching in-memory URI, and initial version for each
 independently created tree. Callers that correlate results across parses must migrate to
-the explicit metadata overloads. Path-keyed project index and raw-string feature-provider
+the explicit metadata or snapshot overloads. Path-keyed project index and raw-string feature-provider
 migration remains part of the later snapshot and compatibility roadmap items.

--- a/docs/sst-document-identity.md
+++ b/docs/sst-document-identity.md
@@ -14,9 +14,29 @@ independent of filesystem path spelling, URI, content, language, and revision.
 - Equality and hashing use only the opaque UUID value. Paths and content never
   participate in `DocumentId` equality.
 
-`DocumentId` does not replace the planned `DocumentUri`, `DocumentVersion`, or
-`DocumentSnapshot` contracts. An ID answers *which logical document*; those contracts
-answer *where it is addressed* and *which immutable revision is being observed*.
+`DocumentId` does not replace `DocumentUri` or the planned `DocumentVersion` and
+`DocumentSnapshot` contracts. An ID answers *which logical document*, a URI answers
+*where it is addressed*, and a version identifies *which immutable revision is being
+observed*.
+
+## URI rules
+
+`DocumentUri` wraps an absolute `URI`. It supports physical `file` URIs, hierarchical
+provider schemes such as `memory:/scratch/Main.java` or
+`generated:/build/Generated.java`, and opaque schemes such as
+`jar:file:///library.jar!/pkg/Type.class`. Providers own the meaning and lifecycle of
+their virtual schemes.
+
+URI equality identifies the same address, not necessarily the same logical document.
+Physical aliases can have different URI spellings and still resolve to one `DocumentId`;
+conversely, a document can acquire a new URI after a rename while retaining its ID.
+Fragments, queries, archive-entry syntax, and provider-specific path structure remain
+part of the URI and are not interpreted by the neutral contract.
+
+`DocumentUri.fromPath` produces an absolute normalized file URI. `DocumentUri.virtual`
+encodes a provider scheme and virtual path without consulting the filesystem. Only file
+URIs can be converted to `Path`; callers must branch on the URI scheme instead of
+assuming all documents are physical.
 
 ## Ownership and lifecycle
 
@@ -26,11 +46,12 @@ and feature work. Consumers borrow IDs and must not derive replacements from a p
 content hash.
 
 The registry can issue an unbound ID for any virtual, generated, in-memory, text, or
-binary document. Physical documents use `getOrCreate(Path)`. `associate` attaches an
-existing pathless identity to a physical location, while `rebind` preserves identity
-when the owner moves or renames a document. `release` forgets all path associations when
-the logical document leaves the workspace; it does not invalidate or recycle the ID.
-Old immutable snapshots and asynchronous results may therefore safely retain it.
+binary document. Documents with locations use `getOrCreate(DocumentUri)`, with a `Path`
+overload retained for physical documents. `associate` attaches an existing pathless
+identity to a URI, while `rebind` preserves identity when the owner moves or renames a
+document. `release` forgets all URI and path associations when the logical document
+leaves the workspace; it does not invalidate or recycle the ID. Old immutable snapshots
+and asynchronous results may therefore safely retain it.
 
 IDs are process-independent values and have a canonical UUID string representation.
 Workspaces that require identity across restarts must persist both that value and the
@@ -44,11 +65,11 @@ also compared with `Files.isSameFile`, allowing symbolic links, hard links, and 
 filesystem aliases to converge when the platform can establish equivalence. A missing
 path is represented by its normalized absolute spelling until it exists or is rebound.
 
-Invalid null or malformed IDs fail immediately. Resolving or comparing an existing path
-may throw `UncheckedIOException` when the filesystem cannot answer reliably. Associating
-one physical location with two different IDs, or rebinding an identity from a location
-it does not own, throws `IllegalStateException`; the registry never silently merges two
-logical documents.
+Invalid null, malformed, blank, or relative document URIs fail immediately. Resolving or
+comparing an existing path may throw `UncheckedIOException` when the filesystem cannot
+answer reliably. Associating one URI with two different IDs, or rebinding an identity
+from a URI it does not own, throws `IllegalStateException`; the registry never silently
+merges two logical documents.
 
 ## Immutability and thread safety
 
@@ -59,13 +80,13 @@ also be immutable, but snapshot content and versioning are outside this contract
 
 ## Compatibility with the current SST
 
-`SyntaxTree` now carries a `DocumentId`, and semantic models inherit it through their
-syntax tree. Java parser overloads accept an owner-supplied ID. Incremental parsing keeps
-the previous tree's ID for both incremental and full-reparse paths.
+`SyntaxTree` now carries both `DocumentId` and `DocumentUri`, and semantic models inherit
+them through their syntax tree. Java parser overloads accept owner-supplied identity and
+location. Incremental parsing keeps both values for incremental and full-reparse paths.
 
 Existing parser overloads and the original `SyntaxTree(SyntaxNode)` constructor remain
 source compatible. Because those entry points have no owning document context, they
-allocate a fresh anonymous ID for each independently created tree. Callers that correlate
-results across parses must migrate to the explicit-ID overloads. Path-keyed project index
-and raw-string feature-provider migration remains part of the later snapshot and
-compatibility roadmap items.
+allocate a fresh anonymous ID and matching in-memory URI for each independently created
+tree. Callers that correlate results across parses must migrate to the explicit identity
+and URI overloads. Path-keyed project index and raw-string feature-provider migration
+remains part of the later snapshot and compatibility roadmap items.

--- a/docs/sst-document-identity.md
+++ b/docs/sst-document-identity.md
@@ -14,8 +14,8 @@ independent of filesystem path spelling, URI, content, language, and revision.
 - Equality and hashing use only the opaque UUID value. Paths and content never
   participate in `DocumentId` equality.
 
-`DocumentId` does not replace `DocumentUri` or the planned `DocumentVersion` and
-`DocumentSnapshot` contracts. An ID answers *which logical document*, a URI answers
+`DocumentId` does not replace `DocumentUri`, `DocumentVersion`, or the planned
+`DocumentSnapshot` contract. An ID answers *which logical document*, a URI answers
 *where it is addressed*, and a version identifies *which immutable revision is being
 observed*.
 
@@ -38,6 +38,21 @@ encodes a provider scheme and virtual path without consulting the filesystem. On
 URIs can be converted to `Path`; callers must branch on the URI scheme instead of
 assuming all documents are physical.
 
+## Version rules
+
+`DocumentVersion` is a non-negative ordered value scoped to one `DocumentId`. New
+documents start at version zero. Every edit, reload, save transformation, or external
+content change that produces different observable content must use a strictly later
+version. Versions need not be consecutive, allowing owners to restore persisted state or
+adopt versions from an external protocol. URI-only moves and renames retain the current
+version because they do not change document content.
+
+Version numbers from different document IDs are not comparable revisions of the same
+content, even when their numeric values match. The value type provides ordering, while
+the workspace-owned registry enforces progression for each ID. `advanceVersion` performs
+an atomic one-step increment, and `restoreVersion` accepts equal or later persisted state
+but rejects rollback. Reaching `Long.MAX_VALUE` fails explicitly instead of wrapping.
+
 ## Ownership and lifecycle
 
 A workspace or document service owns a `DocumentIdentityRegistry`. The owner allocates
@@ -45,18 +60,19 @@ IDs when documents enter its model and passes those IDs into syntax, semantic, i
 and feature work. Consumers borrow IDs and must not derive replacements from a path or
 content hash.
 
-The registry can issue an unbound ID for any virtual, generated, in-memory, text, or
-binary document. Documents with locations use `getOrCreate(DocumentUri)`, with a `Path`
-overload retained for physical documents. `associate` attaches an existing pathless
-identity to a URI, while `rebind` preserves identity when the owner moves or renames a
-document. `release` forgets all URI and path associations when the logical document
-leaves the workspace; it does not invalidate or recycle the ID. Old immutable snapshots
-and asynchronous results may therefore safely retain it.
+The registry can issue an unbound ID at its initial version for any virtual, generated,
+in-memory, text, or binary document. Documents with locations use
+`getOrCreate(DocumentUri)`, with a `Path` overload retained for physical documents.
+`associate` attaches an existing pathless identity to a URI, while `rebind` preserves
+identity and version when the owner moves or renames a document. `release` forgets all
+URI/path associations and live version allocation state when the logical document leaves
+the workspace; it does not invalidate or recycle the ID. Old immutable snapshots and
+asynchronous results may therefore safely retain their ID and version.
 
-IDs are process-independent values and have a canonical UUID string representation.
-Workspaces that require identity across restarts must persist both that value and the
-workspace-specific origin association. The core registry intentionally does not choose
-a persistence policy for its owner.
+IDs and versions are process-independent values with canonical string representations.
+Workspaces that require them across restarts must persist the ID, current version, and
+workspace-specific origin association. The core registry intentionally does not choose a
+persistence policy for its owner.
 
 ## Physical path resolution and failure behavior
 
@@ -65,28 +81,31 @@ also compared with `Files.isSameFile`, allowing symbolic links, hard links, and 
 filesystem aliases to converge when the platform can establish equivalence. A missing
 path is represented by its normalized absolute spelling until it exists or is rebound.
 
-Invalid null, malformed, blank, or relative document URIs fail immediately. Resolving or
-comparing an existing path may throw `UncheckedIOException` when the filesystem cannot
-answer reliably. Associating one URI with two different IDs, or rebinding an identity
-from a URI it does not own, throws `IllegalStateException`; the registry never silently
-merges two logical documents.
+Invalid null, malformed, blank, or relative document URIs and negative versions fail
+immediately. Resolving or comparing an existing path may throw `UncheckedIOException`
+when the filesystem cannot answer reliably. Associating one URI with two different IDs,
+rebinding an identity from a URI it does not own, or advancing an unknown/released ID
+fails explicitly; the registry never silently merges documents or rolls versions back.
 
 ## Immutability and thread safety
 
-`DocumentId` is an immutable value type and can be shared freely between workers.
-`DocumentIdentityRegistry` serializes allocation and association operations, so concurrent
-resolution of the same physical document returns one ID. Future document snapshots must
-also be immutable, but snapshot content and versioning are outside this contract.
+`DocumentId`, `DocumentUri`, and `DocumentVersion` are immutable value types and can be
+shared freely between workers. `DocumentIdentityRegistry` serializes allocation,
+association, and version operations, so concurrent resolution returns one ID and
+concurrent advances never allocate the same revision. Future document snapshots must
+also be immutable, but snapshot content is outside this contract.
 
 ## Compatibility with the current SST
 
-`SyntaxTree` now carries both `DocumentId` and `DocumentUri`, and semantic models inherit
-them through their syntax tree. Java parser overloads accept owner-supplied identity and
-location. Incremental parsing keeps both values for incremental and full-reparse paths.
+`SyntaxTree` now carries `DocumentId`, `DocumentUri`, and `DocumentVersion`, and semantic
+models inherit them through their syntax tree. Java parser overloads accept all three
+owner-supplied values. Incremental parsing retains identity and location while advancing
+the version for both incremental and full-reparse paths. Owners may supply a later
+version explicitly; equal or earlier revisions are rejected.
 
 Existing parser overloads and the original `SyntaxTree(SyntaxNode)` constructor remain
 source compatible. Because those entry points have no owning document context, they
-allocate a fresh anonymous ID and matching in-memory URI for each independently created
-tree. Callers that correlate results across parses must migrate to the explicit identity
-and URI overloads. Path-keyed project index and raw-string feature-provider migration
-remains part of the later snapshot and compatibility roadmap items.
+allocate a fresh anonymous ID, matching in-memory URI, and initial version for each
+independently created tree. Callers that correlate results across parses must migrate to
+the explicit metadata overloads. Path-keyed project index and raw-string feature-provider
+migration remains part of the later snapshot and compatibility roadmap items.

--- a/docs/sst-todo-roadmap.md
+++ b/docs/sst-todo-roadmap.md
@@ -72,9 +72,9 @@ Incremental semantic sessions and broader IDE features
 - [x] **SST-P0-011** Add a stable `DocumentId` independent of filesystem path spelling. See [SST document identity contract](sst-document-identity.md).
 - [x] **SST-P0-012** Add a `DocumentUri`/URI-based identity capable of representing physical and virtual documents. See [SST document identity contract](sst-document-identity.md).
 - [x] **SST-P0-013** Add a monotonic `DocumentVersion` type. See [SST document identity contract](sst-document-identity.md).
-- [ ] **SST-P0-014** Add a sealed `DocumentSnapshot` root contract.
-- [ ] **SST-P0-015** Add `TextDocumentSnapshot` with immutable text, encoding, version, and language identity.
-- [ ] **SST-P0-016** Add `BinaryDocumentSnapshot` with immutable/read-only bytes, version, and language identity.
+- [x] **SST-P0-014** Add a sealed `DocumentSnapshot` root contract. See [SST document identity contract](sst-document-identity.md#snapshot-rules).
+- [x] **SST-P0-015** Add `TextDocumentSnapshot` with immutable text, encoding, version, and language identity. See [SST document identity contract](sst-document-identity.md#snapshot-rules).
+- [x] **SST-P0-016** Add `BinaryDocumentSnapshot` with immutable/read-only bytes, version, and language identity. See [SST document identity contract](sst-document-identity.md#snapshot-rules).
 - [ ] **SST-P0-017** Add a shared `ContentType`/content-kind model.
 - [ ] **SST-P0-018** Add a cached immutable `LineMap` for text offset/line/column conversion.
 - [ ] **SST-P0-019** Support virtual documents such as archive entries and decompiled source.

--- a/docs/sst-todo-roadmap.md
+++ b/docs/sst-todo-roadmap.md
@@ -71,7 +71,7 @@ Incremental semantic sessions and broader IDE features
 
 - [x] **SST-P0-011** Add a stable `DocumentId` independent of filesystem path spelling. See [SST document identity contract](sst-document-identity.md).
 - [x] **SST-P0-012** Add a `DocumentUri`/URI-based identity capable of representing physical and virtual documents. See [SST document identity contract](sst-document-identity.md).
-- [ ] **SST-P0-013** Add a monotonic `DocumentVersion` type.
+- [x] **SST-P0-013** Add a monotonic `DocumentVersion` type. See [SST document identity contract](sst-document-identity.md).
 - [ ] **SST-P0-014** Add a sealed `DocumentSnapshot` root contract.
 - [ ] **SST-P0-015** Add `TextDocumentSnapshot` with immutable text, encoding, version, and language identity.
 - [ ] **SST-P0-016** Add `BinaryDocumentSnapshot` with immutable/read-only bytes, version, and language identity.

--- a/docs/sst-todo-roadmap.md
+++ b/docs/sst-todo-roadmap.md
@@ -69,7 +69,7 @@ Incremental semantic sessions and broader IDE features
 
 ## P0.2 Document identity and immutable snapshots
 
-- [ ] **SST-P0-011** Add a stable `DocumentId` independent of filesystem path spelling.
+- [x] **SST-P0-011** Add a stable `DocumentId` independent of filesystem path spelling. See [SST document identity contract](sst-document-identity.md).
 - [ ] **SST-P0-012** Add a `DocumentUri`/URI-based identity capable of representing physical and virtual documents.
 - [ ] **SST-P0-013** Add a monotonic `DocumentVersion` type.
 - [ ] **SST-P0-014** Add a sealed `DocumentSnapshot` root contract.

--- a/docs/sst-todo-roadmap.md
+++ b/docs/sst-todo-roadmap.md
@@ -70,7 +70,7 @@ Incremental semantic sessions and broader IDE features
 ## P0.2 Document identity and immutable snapshots
 
 - [x] **SST-P0-011** Add a stable `DocumentId` independent of filesystem path spelling. See [SST document identity contract](sst-document-identity.md).
-- [ ] **SST-P0-012** Add a `DocumentUri`/URI-based identity capable of representing physical and virtual documents.
+- [x] **SST-P0-012** Add a `DocumentUri`/URI-based identity capable of representing physical and virtual documents. See [SST document identity contract](sst-document-identity.md).
 - [ ] **SST-P0-013** Add a monotonic `DocumentVersion` type.
 - [ ] **SST-P0-014** Add a sealed `DocumentSnapshot` root contract.
 - [ ] **SST-P0-015** Add `TextDocumentSnapshot` with immutable text, encoding, version, and language identity.

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/BinaryDocumentSnapshot.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/BinaryDocumentSnapshot.java
@@ -1,0 +1,125 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Immutable snapshot of binary document content.
+ * <p>
+ * Input bytes are copied during construction. {@link #bytes()} returns a fresh read-only
+ * buffer on every call, so neither content nor shared buffer position can be mutated by
+ * consumers.
+ */
+public final class BinaryDocumentSnapshot implements DocumentSnapshot {
+    private final DocumentId id;
+    private final DocumentUri uri;
+    private final DocumentVersion version;
+    private final String languageId;
+    private final byte[] content;
+
+    /**
+     * Creates an immutable binary document revision from a byte array.
+     *
+     * @param id stable logical document identity
+     * @param uri physical or virtual document location
+     * @param version content revision
+     * @param languageId provider-defined non-blank language identity
+     * @param content complete binary content; copied during construction
+     */
+    public BinaryDocumentSnapshot(
+        DocumentId id,
+        DocumentUri uri,
+        DocumentVersion version,
+        String languageId,
+        byte[] content
+    ) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.uri = Objects.requireNonNull(uri, "uri");
+        this.version = Objects.requireNonNull(version, "version");
+        this.languageId = requireLanguageId(languageId);
+        content = Objects.requireNonNull(content, "content");
+        this.content = Arrays.copyOf(content, content.length);
+    }
+
+    /**
+     * Creates an immutable binary document revision from the remaining bytes of a buffer.
+     * The source buffer's position is not modified.
+     *
+     * @param id stable logical document identity
+     * @param uri physical or virtual document location
+     * @param version content revision
+     * @param languageId provider-defined non-blank language identity
+     * @param content buffer whose remaining bytes are copied
+     */
+    public BinaryDocumentSnapshot(
+        DocumentId id,
+        DocumentUri uri,
+        DocumentVersion version,
+        String languageId,
+        ByteBuffer content
+    ) {
+        this(id, uri, version, languageId, copyRemaining(content));
+    }
+
+    @Override
+    public DocumentId id() {
+        return id;
+    }
+
+    @Override
+    public DocumentUri uri() {
+        return uri;
+    }
+
+    @Override
+    public DocumentVersion version() {
+        return version;
+    }
+
+    @Override
+    public String languageId() {
+        return languageId;
+    }
+
+    /**
+     * Returns a fresh read-only view of the complete binary content.
+     *
+     * @return read-only buffer positioned at zero
+     */
+    public ByteBuffer bytes() {
+        return ByteBuffer.wrap(content).asReadOnlyBuffer();
+    }
+
+    /**
+     * Returns an independent copy of the complete binary content.
+     *
+     * @return copied byte array
+     */
+    public byte[] copyBytes() {
+        return Arrays.copyOf(content, content.length);
+    }
+
+    /**
+     * Returns the content size in bytes.
+     *
+     * @return byte count
+     */
+    public int size() {
+        return content.length;
+    }
+
+    private static byte[] copyRemaining(ByteBuffer content) {
+        ByteBuffer source = Objects.requireNonNull(content, "content").duplicate();
+        byte[] copy = new byte[source.remaining()];
+        source.get(copy);
+        return copy;
+    }
+
+    private static String requireLanguageId(String languageId) {
+        languageId = Objects.requireNonNull(languageId, "languageId");
+        if (languageId.isBlank())
+            throw new IllegalArgumentException("languageId cannot be blank");
+        return languageId;
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentId.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentId.java
@@ -1,0 +1,56 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Stable, opaque identity of a logical document.
+ * <p>
+ * A document ID is independent of the document's location, content, language, and
+ * revision. Moving or editing a document therefore does not change its ID. Copies and
+ * newly created documents receive new IDs even when their contents are identical.
+ * <p>
+ * Instances are immutable, thread-safe value objects. The canonical external form is
+ * the lowercase UUID returned by {@link #toString()} and accepted by {@link #parse(String)}.
+ * Allocation and lifecycle are owned by the workspace or document service; consumers
+ * should carry IDs supplied by that owner rather than manufacture replacements.
+ *
+ * @param value opaque UUID value
+ */
+public record DocumentId(UUID value) {
+    public DocumentId {
+        Objects.requireNonNull(value, "value");
+    }
+
+    /**
+     * Allocates a fresh identity for a new logical document.
+     *
+     * @return a new document identity
+     */
+    public static DocumentId create() {
+        return new DocumentId(UUID.randomUUID());
+    }
+
+    /**
+     * Parses the canonical external representation of a document identity.
+     *
+     * @param value UUID text previously returned by {@link #toString()}
+     * @return parsed document identity
+     * @throws NullPointerException     if {@code value} is {@code null}
+     * @throws IllegalArgumentException if {@code value} is blank or not a UUID
+     */
+    public static DocumentId parse(String value) {
+        value = Objects.requireNonNull(value, "value").trim();
+        if (value.isEmpty())
+            throw new IllegalArgumentException("value cannot be blank");
+
+        return new DocumentId(UUID.fromString(value));
+    }
+
+    @Override
+    public @NonNull String toString() {
+        return value.toString();
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistry.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistry.java
@@ -1,0 +1,199 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Workspace-owned allocator and physical-location registry for document identities.
+ * <p>
+ * The registry separates logical identity from path spelling. Existing physical files
+ * are resolved through their real path, and already registered files are compared with
+ * {@link Files#isSameFile(Path, Path)} so aliases such as symbolic or hard links converge
+ * on one ID. Missing paths use an absolute normalized spelling until a physical file is
+ * available or the owner explicitly rebinds the document.
+ * <p>
+ * Virtual, generated, in-memory, text, and binary documents use {@link #create()} and do
+ * not need a filesystem association. Their owner may associate a physical path later.
+ * <p>
+ * All operations are thread-safe. IDs are never recycled. {@link #release(DocumentId)}
+ * only forgets registry associations; existing snapshots and analysis results may safely
+ * retain the immutable ID. Registry persistence, when required by a workspace, should
+ * store the canonical {@link DocumentId#toString()} value and restore associations with
+ * {@link #associate(DocumentId, Path)}.
+ */
+public final class DocumentIdentityRegistry {
+    private final Map<Path, DocumentId> idsByPath = new HashMap<>();
+
+    /**
+     * Allocates an unbound identity for a new logical document.
+     *
+     * @return a fresh identity
+     */
+    public DocumentId create() {
+        return DocumentId.create();
+    }
+
+    /**
+     * Returns the identity associated with {@code path}, allocating one when necessary.
+     * Equivalent spellings of the same existing physical file return the same identity.
+     *
+     * @param path physical document path
+     * @return stable identity associated with the path
+     * @throws NullPointerException if {@code path} is {@code null}
+     * @throws UncheckedIOException if an existing path cannot be resolved or compared
+     */
+    public synchronized DocumentId getOrCreate(Path path) {
+        Path normalized = normalize(path);
+        Path resolved = resolve(normalized);
+        DocumentId existing = findRegistered(normalized, resolved);
+        if (existing != null)
+            return existing;
+
+        existing = findEquivalentPhysicalFile(resolved);
+        if (existing != null) {
+            registerSpellings(existing, normalized, resolved);
+            return existing;
+        }
+
+        DocumentId created = create();
+        registerSpellings(created, normalized, resolved);
+        return created;
+    }
+
+    /**
+     * Finds an existing association without allocating an identity.
+     *
+     * @param path physical document path
+     * @return associated identity, or empty when the path is unknown
+     */
+    public synchronized Optional<DocumentId> find(Path path) {
+        Path normalized = normalize(path);
+        Path resolved = resolve(normalized);
+        DocumentId existing = findRegistered(normalized, resolved);
+        if (existing != null)
+            return Optional.of(existing);
+
+        existing = findEquivalentPhysicalFile(resolved);
+        if (existing != null)
+            registerSpellings(existing, normalized, resolved);
+
+        return Optional.ofNullable(existing);
+    }
+
+    /**
+     * Associates an existing identity with a physical path.
+     *
+     * @param documentId identity owned by this workspace
+     * @param path       physical document path
+     * @throws IllegalStateException if the path is already associated with another ID
+     */
+    public synchronized void associate(DocumentId documentId, Path path) {
+        documentId = Objects.requireNonNull(documentId, "documentId");
+        Path normalized = normalize(path);
+        Path resolved = resolve(normalized);
+        DocumentId existing = findRegistered(normalized, resolved);
+        if (existing == null)
+            existing = findEquivalentPhysicalFile(resolved);
+
+        if (existing != null && !existing.equals(documentId))
+            throw new IllegalStateException("Document path is already associated with another identity: " + path);
+
+        registerSpellings(documentId, normalized, resolved);
+    }
+
+    /**
+     * Moves the physical association for a document while preserving its identity.
+     * The filesystem move itself remains the caller's responsibility.
+     *
+     * @param documentId   identity being moved
+     * @param previousPath previous physical path
+     * @param newPath      new physical path
+     * @throws IllegalStateException if the old association is missing or belongs to a
+     *                               different document, or the new path belongs to another document
+     */
+    public synchronized void rebind(DocumentId documentId, Path previousPath, Path newPath) {
+        documentId = Objects.requireNonNull(documentId, "documentId");
+        Path previousNormalized = normalize(previousPath);
+        Path previousResolved = resolve(previousNormalized);
+        DocumentId previous = findRegistered(previousNormalized, previousResolved);
+        if (!documentId.equals(previous))
+            throw new IllegalStateException("Previous path is not associated with the supplied identity: " + previousPath);
+
+        Path newNormalized = normalize(newPath);
+        Path newResolved = resolve(newNormalized);
+        DocumentId existing = findRegistered(newNormalized, newResolved);
+        if (existing == null)
+            existing = findEquivalentPhysicalFile(newResolved);
+
+        if (existing != null && !documentId.equals(existing))
+            throw new IllegalStateException(
+                "New path is already associated with another identity: " + newPath);
+
+        idsByPath.values().removeIf(documentId::equals);
+        registerSpellings(documentId, newNormalized, newResolved);
+    }
+
+    /**
+     * Forgets every physical association for an identity. The ID remains valid for any
+     * immutable snapshots or results that already reference it and is never reused.
+     *
+     * @param documentId identity whose associations should be removed
+     */
+    public synchronized void release(DocumentId documentId) {
+        documentId = Objects.requireNonNull(documentId, "documentId");
+        idsByPath.values().removeIf(documentId::equals);
+    }
+
+    private DocumentId findEquivalentPhysicalFile(Path path) {
+        if (Files.notExists(path))
+            return null;
+
+        for (Map.Entry<Path, DocumentId> entry : idsByPath.entrySet()) {
+            Path registered = entry.getKey();
+            if (Files.notExists(registered))
+                continue;
+
+            try {
+                if (Files.isSameFile(path, registered))
+                    return entry.getValue();
+            } catch (IOException exception) {
+                throw new UncheckedIOException(
+                    "Failed to compare document paths " + path + " and " + registered,
+                    exception);
+            }
+        }
+
+        return null;
+    }
+
+    private DocumentId findRegistered(Path normalized, Path resolved) {
+        DocumentId existing = idsByPath.get(normalized);
+        return existing != null ? existing : idsByPath.get(resolved);
+    }
+
+    private void registerSpellings(DocumentId documentId, Path normalized, Path resolved) {
+        idsByPath.put(normalized, documentId);
+        idsByPath.put(resolved, documentId);
+    }
+
+    private static Path normalize(Path path) {
+        return Objects.requireNonNull(path, "path").toAbsolutePath().normalize();
+    }
+
+    private static Path resolve(Path path) {
+        try {
+            return path.toRealPath();
+        } catch (NoSuchFileException exception) {
+            return path;
+        } catch (IOException exception) {
+            throw new UncheckedIOException("Failed to resolve document path " + path, exception);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistry.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistry.java
@@ -6,9 +6,11 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Workspace-owned allocator and location registry for document identities.
@@ -23,23 +25,78 @@ import java.util.Optional;
  * {@link DocumentUri} or use {@link #create()} before they have a location. Their owner
  * may associate a URI or physical path later.
  * <p>
- * All operations are thread-safe. IDs are never recycled. {@link #release(DocumentId)}
- * only forgets registry associations; existing snapshots and analysis results may safely
- * retain the immutable ID. Registry persistence, when required by a workspace, should
- * store the canonical {@link DocumentId#toString()} value and restore associations with
- * {@link #associate(DocumentId, DocumentUri)}.
+ * All operations are thread-safe. IDs are never recycled, and content versions advance
+ * atomically per ID. {@link #release(DocumentId)} forgets registry associations and live
+ * version state; existing snapshots and analysis results may safely retain their
+ * immutable ID and version. Registry persistence, when required by a workspace, should
+ * store both canonical values and restore them with {@link #restoreVersion(DocumentId,
+ * DocumentVersion)} and {@link #associate(DocumentId, DocumentUri)}.
  */
 public final class DocumentIdentityRegistry {
     private final Map<Path, DocumentId> idsByPath = new HashMap<>();
     private final Map<DocumentUri, DocumentId> idsByUri = new HashMap<>();
+    private final Map<DocumentId, DocumentVersion> versionsById = new HashMap<>();
+    private final Set<DocumentId> releasedIds = new HashSet<>();
 
     /**
      * Allocates an unbound identity for a new logical document.
      *
      * @return a fresh identity
      */
-    public DocumentId create() {
-        return DocumentId.create();
+    public synchronized DocumentId create() {
+        DocumentId documentId = DocumentId.create();
+        versionsById.put(documentId, DocumentVersion.initial());
+        return documentId;
+    }
+
+    /**
+     * Returns the current content version of an identity owned by this registry.
+     *
+     * @param documentId logical document identity
+     * @return current document version
+     * @throws IllegalStateException if the identity is not owned by this registry or has
+     *                               been released
+     */
+    public synchronized DocumentVersion currentVersion(DocumentId documentId) {
+        documentId = Objects.requireNonNull(documentId, "documentId");
+        DocumentVersion version = versionsById.get(documentId);
+        if (version == null)
+            throw new IllegalStateException("Document identity is not owned by this registry: " + documentId);
+        return version;
+    }
+
+    /**
+     * Atomically advances and returns the content version of an owned document.
+     *
+     * @param documentId logical document identity
+     * @return newly allocated version
+     * @throws IllegalStateException if the identity is unknown, released, or its version
+     *                               is exhausted
+     */
+    public synchronized DocumentVersion advanceVersion(DocumentId documentId) {
+        DocumentVersion next = currentVersion(documentId).next();
+        versionsById.put(documentId, next);
+        return next;
+    }
+
+    /**
+     * Restores or advances persisted version state. Existing state may stay equal or move
+     * forward but can never move backward.
+     *
+     * @param documentId logical document identity
+     * @param version    persisted or externally allocated version
+     * @throws IllegalArgumentException if {@code version} is earlier than existing state
+     */
+    public synchronized void restoreVersion(DocumentId documentId, DocumentVersion version) {
+        documentId = Objects.requireNonNull(documentId, "documentId");
+        version = Objects.requireNonNull(version, "version");
+        rejectReleased(documentId);
+        DocumentVersion current = versionsById.get(documentId);
+        if (current != null && version.isBefore(current)) {
+            throw new IllegalArgumentException(
+                "Document version cannot move backward from " + current + " to " + version);
+        }
+        versionsById.put(documentId, version);
     }
 
     /**
@@ -55,7 +112,9 @@ public final class DocumentIdentityRegistry {
         if (filePath.isPresent())
             return getOrCreate(filePath.get());
 
-        return idsByUri.computeIfAbsent(uri, ignored -> create());
+        DocumentId documentId = idsByUri.computeIfAbsent(uri, ignored -> create());
+        ensureVersion(documentId);
+        return documentId;
     }
 
     /**
@@ -71,12 +130,15 @@ public final class DocumentIdentityRegistry {
         Path normalized = normalize(path);
         Path resolved = resolve(normalized);
         DocumentId existing = findRegistered(normalized, resolved);
-        if (existing != null)
+        if (existing != null) {
+            ensureVersion(existing);
             return existing;
+        }
 
         existing = findEquivalentPhysicalFile(resolved);
         if (existing != null) {
             registerSpellings(existing, normalized, resolved);
+            ensureVersion(existing);
             return existing;
         }
 
@@ -135,6 +197,7 @@ public final class DocumentIdentityRegistry {
         if (existing != null && !existing.equals(documentId))
             throw new IllegalStateException("Document path is already associated with another identity: " + path);
 
+        ensureVersion(documentId);
         registerSpellings(documentId, normalized, resolved);
     }
 
@@ -142,7 +205,7 @@ public final class DocumentIdentityRegistry {
      * Associates an existing identity with a physical or virtual URI.
      *
      * @param documentId identity owned by this workspace
-     * @param uri current document URI
+     * @param uri        current document URI
      * @throws IllegalStateException if the URI is already associated with another ID
      */
     public synchronized void associate(DocumentId documentId, DocumentUri uri) {
@@ -158,6 +221,7 @@ public final class DocumentIdentityRegistry {
         if (existing != null && !existing.equals(documentId))
             throw new IllegalStateException("Document URI is already associated with another identity: " + uri);
 
+        ensureVersion(documentId);
         idsByUri.put(uri, documentId);
     }
 
@@ -184,27 +248,23 @@ public final class DocumentIdentityRegistry {
      * aliases registered for the previous location are forgotten. Moving filesystem
      * content remains the caller's responsibility.
      *
-     * @param documentId identity being moved
+     * @param documentId  identity being moved
      * @param previousUri previous document URI
-     * @param newUri new document URI
+     * @param newUri      new document URI
      * @throws IllegalStateException if the previous URI is not owned by the supplied ID,
-     * or the new URI belongs to another document
+     *                               or the new URI belongs to another document
      */
     public synchronized void rebind(DocumentId documentId, DocumentUri previousUri, DocumentUri newUri) {
         documentId = Objects.requireNonNull(documentId, "documentId");
         previousUri = Objects.requireNonNull(previousUri, "previousUri");
         newUri = Objects.requireNonNull(newUri, "newUri");
         DocumentId previous = find(previousUri).orElse(null);
-        if (!documentId.equals(previous)) {
-            throw new IllegalStateException(
-                "Previous URI is not associated with the supplied identity: " + previousUri);
-        }
+        if (!documentId.equals(previous))
+            throw new IllegalStateException("Previous URI is not associated with the supplied identity: " + previousUri);
 
         DocumentId existing = find(newUri).orElse(null);
-        if (existing != null && !documentId.equals(existing)) {
-            throw new IllegalStateException(
-                "New URI is already associated with another identity: " + newUri);
-        }
+        if (existing != null && !documentId.equals(existing))
+            throw new IllegalStateException("New URI is already associated with another identity: " + newUri);
 
         removeAssociations(documentId);
         associate(documentId, newUri);
@@ -218,12 +278,25 @@ public final class DocumentIdentityRegistry {
      */
     public synchronized void release(DocumentId documentId) {
         documentId = Objects.requireNonNull(documentId, "documentId");
+        currentVersion(documentId);
         removeAssociations(documentId);
+        versionsById.remove(documentId);
+        releasedIds.add(documentId);
     }
 
     private void removeAssociations(DocumentId documentId) {
         idsByPath.values().removeIf(documentId::equals);
         idsByUri.values().removeIf(documentId::equals);
+    }
+
+    private void ensureVersion(DocumentId documentId) {
+        rejectReleased(documentId);
+        versionsById.putIfAbsent(documentId, DocumentVersion.initial());
+    }
+
+    private void rejectReleased(DocumentId documentId) {
+        if (releasedIds.contains(documentId))
+            throw new IllegalStateException("Document identity has been released and cannot be reused: " + documentId);
     }
 
     private DocumentId findEquivalentPhysicalFile(Path path) {

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistry.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistry.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Workspace-owned allocator and physical-location registry for document identities.
+ * Workspace-owned allocator and location registry for document identities.
  * <p>
  * The registry separates logical identity from path spelling. Existing physical files
  * are resolved through their real path, and already registered files are compared with
@@ -19,17 +19,19 @@ import java.util.Optional;
  * on one ID. Missing paths use an absolute normalized spelling until a physical file is
  * available or the owner explicitly rebinds the document.
  * <p>
- * Virtual, generated, in-memory, text, and binary documents use {@link #create()} and do
- * not need a filesystem association. Their owner may associate a physical path later.
+ * Virtual, generated, in-memory, text, and binary documents may be resolved directly by
+ * {@link DocumentUri} or use {@link #create()} before they have a location. Their owner
+ * may associate a URI or physical path later.
  * <p>
  * All operations are thread-safe. IDs are never recycled. {@link #release(DocumentId)}
  * only forgets registry associations; existing snapshots and analysis results may safely
  * retain the immutable ID. Registry persistence, when required by a workspace, should
  * store the canonical {@link DocumentId#toString()} value and restore associations with
- * {@link #associate(DocumentId, Path)}.
+ * {@link #associate(DocumentId, DocumentUri)}.
  */
 public final class DocumentIdentityRegistry {
     private final Map<Path, DocumentId> idsByPath = new HashMap<>();
+    private final Map<DocumentUri, DocumentId> idsByUri = new HashMap<>();
 
     /**
      * Allocates an unbound identity for a new logical document.
@@ -38,6 +40,22 @@ public final class DocumentIdentityRegistry {
      */
     public DocumentId create() {
         return DocumentId.create();
+    }
+
+    /**
+     * Returns the identity associated with {@code uri}, allocating one when necessary.
+     * File URIs receive the same physical-alias handling as {@link #getOrCreate(Path)}.
+     *
+     * @param uri physical or virtual document URI
+     * @return stable identity associated with the URI
+     */
+    public synchronized DocumentId getOrCreate(DocumentUri uri) {
+        uri = Objects.requireNonNull(uri, "uri");
+        Optional<Path> filePath = uri.filePath();
+        if (filePath.isPresent())
+            return getOrCreate(filePath.get());
+
+        return idsByUri.computeIfAbsent(uri, ignored -> create());
     }
 
     /**
@@ -88,6 +106,18 @@ public final class DocumentIdentityRegistry {
     }
 
     /**
+     * Finds an existing physical or virtual URI association without allocating an ID.
+     *
+     * @param uri document URI
+     * @return associated identity, or empty when the URI is unknown
+     */
+    public synchronized Optional<DocumentId> find(DocumentUri uri) {
+        uri = Objects.requireNonNull(uri, "uri");
+        Optional<Path> filePath = uri.filePath();
+        return filePath.isPresent() ? find(filePath.get()) : Optional.ofNullable(idsByUri.get(uri));
+    }
+
+    /**
      * Associates an existing identity with a physical path.
      *
      * @param documentId identity owned by this workspace
@@ -109,6 +139,29 @@ public final class DocumentIdentityRegistry {
     }
 
     /**
+     * Associates an existing identity with a physical or virtual URI.
+     *
+     * @param documentId identity owned by this workspace
+     * @param uri current document URI
+     * @throws IllegalStateException if the URI is already associated with another ID
+     */
+    public synchronized void associate(DocumentId documentId, DocumentUri uri) {
+        documentId = Objects.requireNonNull(documentId, "documentId");
+        uri = Objects.requireNonNull(uri, "uri");
+        Optional<Path> filePath = uri.filePath();
+        if (filePath.isPresent()) {
+            associate(documentId, filePath.get());
+            return;
+        }
+
+        DocumentId existing = idsByUri.get(uri);
+        if (existing != null && !existing.equals(documentId))
+            throw new IllegalStateException("Document URI is already associated with another identity: " + uri);
+
+        idsByUri.put(uri, documentId);
+    }
+
+    /**
      * Moves the physical association for a document while preserving its identity.
      * The filesystem move itself remains the caller's responsibility.
      *
@@ -119,36 +172,58 @@ public final class DocumentIdentityRegistry {
      *                               different document, or the new path belongs to another document
      */
     public synchronized void rebind(DocumentId documentId, Path previousPath, Path newPath) {
-        documentId = Objects.requireNonNull(documentId, "documentId");
-        Path previousNormalized = normalize(previousPath);
-        Path previousResolved = resolve(previousNormalized);
-        DocumentId previous = findRegistered(previousNormalized, previousResolved);
-        if (!documentId.equals(previous))
-            throw new IllegalStateException("Previous path is not associated with the supplied identity: " + previousPath);
-
-        Path newNormalized = normalize(newPath);
-        Path newResolved = resolve(newNormalized);
-        DocumentId existing = findRegistered(newNormalized, newResolved);
-        if (existing == null)
-            existing = findEquivalentPhysicalFile(newResolved);
-
-        if (existing != null && !documentId.equals(existing))
-            throw new IllegalStateException(
-                "New path is already associated with another identity: " + newPath);
-
-        idsByPath.values().removeIf(documentId::equals);
-        registerSpellings(documentId, newNormalized, newResolved);
+        rebind(
+            documentId,
+            DocumentUri.fromPath(previousPath),
+            DocumentUri.fromPath(newPath)
+        );
     }
 
     /**
-     * Forgets every physical association for an identity. The ID remains valid for any
+     * Changes a document's physical or virtual URI while preserving its identity. Any
+     * aliases registered for the previous location are forgotten. Moving filesystem
+     * content remains the caller's responsibility.
+     *
+     * @param documentId identity being moved
+     * @param previousUri previous document URI
+     * @param newUri new document URI
+     * @throws IllegalStateException if the previous URI is not owned by the supplied ID,
+     * or the new URI belongs to another document
+     */
+    public synchronized void rebind(DocumentId documentId, DocumentUri previousUri, DocumentUri newUri) {
+        documentId = Objects.requireNonNull(documentId, "documentId");
+        previousUri = Objects.requireNonNull(previousUri, "previousUri");
+        newUri = Objects.requireNonNull(newUri, "newUri");
+        DocumentId previous = find(previousUri).orElse(null);
+        if (!documentId.equals(previous)) {
+            throw new IllegalStateException(
+                "Previous URI is not associated with the supplied identity: " + previousUri);
+        }
+
+        DocumentId existing = find(newUri).orElse(null);
+        if (existing != null && !documentId.equals(existing)) {
+            throw new IllegalStateException(
+                "New URI is already associated with another identity: " + newUri);
+        }
+
+        removeAssociations(documentId);
+        associate(documentId, newUri);
+    }
+
+    /**
+     * Forgets every path and URI association for an identity. The ID remains valid for any
      * immutable snapshots or results that already reference it and is never reused.
      *
      * @param documentId identity whose associations should be removed
      */
     public synchronized void release(DocumentId documentId) {
         documentId = Objects.requireNonNull(documentId, "documentId");
+        removeAssociations(documentId);
+    }
+
+    private void removeAssociations(DocumentId documentId) {
         idsByPath.values().removeIf(documentId::equals);
+        idsByUri.values().removeIf(documentId::equals);
     }
 
     private DocumentId findEquivalentPhysicalFile(Path path) {
@@ -181,6 +256,8 @@ public final class DocumentIdentityRegistry {
     private void registerSpellings(DocumentId documentId, Path normalized, Path resolved) {
         idsByPath.put(normalized, documentId);
         idsByPath.put(resolved, documentId);
+        idsByUri.put(DocumentUri.fromPath(normalized), documentId);
+        idsByUri.put(DocumentUri.fromPath(resolved), documentId);
     }
 
     private static Path normalize(Path path) {

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentSnapshot.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentSnapshot.java
@@ -1,0 +1,41 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+/**
+ * Immutable view of one version of a physical or virtual document.
+ * <p>
+ * A snapshot permanently binds logical identity, current location, content revision,
+ * language identity, and either text or binary content. Owners create a new snapshot
+ * when content changes; consumers may safely retain and share older snapshots across
+ * worker threads.
+ * <p>
+ * Snapshot equality semantics are intentionally not defined by this root contract.
+ */
+public sealed interface DocumentSnapshot permits TextDocumentSnapshot, BinaryDocumentSnapshot {
+    /**
+     * Returns the stable identity shared by every revision of this logical document.
+     *
+     * @return logical document identity
+     */
+    DocumentId id();
+
+    /**
+     * Returns the physical or virtual location captured by this snapshot.
+     *
+     * @return document URI
+     */
+    DocumentUri uri();
+
+    /**
+     * Returns the immutable content revision captured by this snapshot.
+     *
+     * @return document version
+     */
+    DocumentVersion version();
+
+    /**
+     * Returns the provider-defined language identity for this content.
+     *
+     * @return non-blank language ID
+     */
+    String languageId();
+}

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentUri.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentUri.java
@@ -1,0 +1,124 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable address of a physical or virtual document.
+ * <p>
+ * A URI describes where a document is currently addressed; it is not the document's
+ * stable logical identity. Moving or renaming a document can therefore change its URI
+ * while retaining the same {@link DocumentId}.
+ * <p>
+ * Both hierarchical URIs such as {@code file:///workspace/Main.java} and opaque URIs
+ * such as {@code jar:file:///library.jar!/pkg/Type.class} are supported. Application and
+ * language providers may define schemes for generated, decompiled, archive-entry, or
+ * other virtual documents. Instances are immutable and thread-safe.
+ *
+ * @param value absolute URI value
+ */
+public record DocumentUri(URI value) {
+    public DocumentUri {
+        value = Objects.requireNonNull(value, "value");
+        if (!value.isAbsolute() || value.getScheme() == null || value.getScheme().isBlank())
+            throw new IllegalArgumentException("Document URI must be absolute: " + value);
+        if (value.getRawSchemeSpecificPart() == null || value.getRawSchemeSpecificPart().isBlank())
+            throw new IllegalArgumentException("Document URI must identify a resource: " + value);
+    }
+
+    /**
+     * Parses an absolute physical or virtual document URI.
+     *
+     * @param value URI text
+     * @return parsed document URI
+     * @throws NullPointerException if {@code value} is {@code null}
+     * @throws IllegalArgumentException if it is blank, malformed, or relative
+     */
+    public static DocumentUri parse(String value) {
+        value = Objects.requireNonNull(value, "value").trim();
+        if (value.isEmpty())
+            throw new IllegalArgumentException("value cannot be blank");
+
+        return new DocumentUri(URI.create(value));
+    }
+
+    /**
+     * Creates a file URI from an absolute normalized spelling of {@code path}. Physical
+     * alias resolution remains the responsibility of the document identity owner.
+     *
+     * @param path physical document path
+     * @return absolute file document URI
+     */
+    public static DocumentUri fromPath(Path path) {
+        path = Objects.requireNonNull(path, "path").toAbsolutePath().normalize();
+        return new DocumentUri(path.toUri());
+    }
+
+    /**
+     * Creates a hierarchical URI for a virtual document. The supplied path is encoded as
+     * a URI path and need not refer to the local filesystem.
+     *
+     * @param scheme provider-owned URI scheme
+     * @param path non-empty virtual path
+     * @return virtual document URI
+     */
+    public static DocumentUri virtual(String scheme, String path) {
+        scheme = requireComponent(scheme, "scheme").toLowerCase(Locale.ROOT);
+        path = requireComponent(path, "path");
+        if (!path.startsWith("/"))
+            path = "/" + path;
+
+        try {
+            return new DocumentUri(new URI(scheme, null, path, null));
+        } catch (URISyntaxException exception) {
+            throw new IllegalArgumentException("Invalid virtual document URI", exception);
+        }
+    }
+
+    /**
+     * Creates the anonymous in-memory location used by compatibility entry points that
+     * have a document identity but no owner-supplied URI.
+     *
+     * @param documentId logical document identity
+     * @return unique in-memory document URI
+     */
+    public static DocumentUri inMemory(DocumentId documentId) {
+        return virtual("memory", Objects.requireNonNull(documentId, "documentId").toString());
+    }
+
+    /**
+     * Returns whether this URI uses the {@code file} scheme.
+     *
+     * @return {@code true} for physical file URIs
+     */
+    public boolean isFile() {
+        return "file".equalsIgnoreCase(value.getScheme());
+    }
+
+    /**
+     * Converts a physical file URI back to a path.
+     *
+     * @return physical path, or empty for non-file document schemes
+     * @throws IllegalArgumentException if a malformed file URI cannot be represented by
+     * the current filesystem provider
+     */
+    public Optional<Path> filePath() {
+        return isFile() ? Optional.of(Path.of(value)) : Optional.empty();
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    private static String requireComponent(String value, String name) {
+        value = Objects.requireNonNull(value, name).trim();
+        if (value.isEmpty())
+            throw new IllegalArgumentException(name + " cannot be blank");
+        return value;
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentVersion.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/DocumentVersion.java
@@ -1,0 +1,92 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import java.util.Objects;
+
+/**
+ * Immutable, monotonically ordered revision of one logical document.
+ * <p>
+ * Versions are scoped to a {@link DocumentId}; equal numeric values belonging to
+ * different documents do not imply related content. Every content change must produce
+ * a strictly later version for that document. Gaps are valid, while moving or renaming a
+ * document without changing its content retains the current version.
+ * <p>
+ * Instances are immutable, thread-safe value objects. Allocation and progression are
+ * owned by the workspace or document service rather than by analysis consumers.
+ *
+ * @param value non-negative revision value
+ */
+public record DocumentVersion(long value) implements Comparable<DocumentVersion> {
+    private static final DocumentVersion INITIAL = new DocumentVersion(0);
+
+    public DocumentVersion {
+        if (value < 0)
+            throw new IllegalArgumentException("Document version cannot be negative: " + value);
+    }
+
+    /**
+     * Returns the initial version assigned to a newly owned document.
+     *
+     * @return version zero
+     */
+    public static DocumentVersion initial() {
+        return INITIAL;
+    }
+
+    /**
+     * Parses the canonical decimal representation of a document version.
+     *
+     * @param value non-negative decimal version
+     * @return parsed document version
+     * @throws NullPointerException if {@code value} is {@code null}
+     * @throws IllegalArgumentException if it is blank, malformed, or negative
+     */
+    public static DocumentVersion parse(String value) {
+        value = Objects.requireNonNull(value, "value").trim();
+        if (value.isEmpty())
+            throw new IllegalArgumentException("value cannot be blank");
+
+        return new DocumentVersion(Long.parseLong(value));
+    }
+
+    /**
+     * Returns the immediately following version.
+     *
+     * @return next document version
+     * @throws IllegalStateException if this version is {@link Long#MAX_VALUE}
+     */
+    public DocumentVersion next() {
+        if (value == Long.MAX_VALUE)
+            throw new IllegalStateException("Document version is exhausted");
+        return new DocumentVersion(value + 1);
+    }
+
+    /**
+     * Returns whether this version is strictly later than {@code other}.
+     *
+     * @param other version from the same logical document
+     * @return {@code true} when this version is later
+     */
+    public boolean isAfter(DocumentVersion other) {
+        return compareTo(other) > 0;
+    }
+
+    /**
+     * Returns whether this version is strictly earlier than {@code other}.
+     *
+     * @param other version from the same logical document
+     * @return {@code true} when this version is earlier
+     */
+    public boolean isBefore(DocumentVersion other) {
+        return compareTo(other) < 0;
+    }
+
+    @Override
+    public int compareTo(DocumentVersion other) {
+        return Long.compare(value, Objects.requireNonNull(other, "other").value);
+    }
+
+    @Override
+    public String toString() {
+        return Long.toString(value);
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/TextDocumentSnapshot.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/TextDocumentSnapshot.java
@@ -1,0 +1,93 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import java.nio.charset.Charset;
+import java.util.Objects;
+
+/**
+ * Immutable snapshot of text document content.
+ * <p>
+ * Mutable {@link CharSequence} inputs are converted to a {@link String} during
+ * construction. The snapshot therefore never observes later caller mutations and is
+ * safe to share across analysis threads.
+ */
+public final class TextDocumentSnapshot implements DocumentSnapshot {
+    private final DocumentId id;
+    private final DocumentUri uri;
+    private final DocumentVersion version;
+    private final String languageId;
+    private final String text;
+    private final Charset encoding;
+
+    /**
+     * Creates an immutable text document revision.
+     *
+     * @param id stable logical document identity
+     * @param uri physical or virtual document location
+     * @param version content revision
+     * @param languageId provider-defined non-blank language identity
+     * @param text complete document text; mutable inputs are copied
+     * @param encoding character encoding associated with the text origin
+     * @throws NullPointerException if any argument is {@code null}
+     * @throws IllegalArgumentException if {@code languageId} is blank
+     */
+    public TextDocumentSnapshot(
+        DocumentId id,
+        DocumentUri uri,
+        DocumentVersion version,
+        String languageId,
+        CharSequence text,
+        Charset encoding
+    ) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.uri = Objects.requireNonNull(uri, "uri");
+        this.version = Objects.requireNonNull(version, "version");
+        this.languageId = requireLanguageId(languageId);
+        this.text = Objects.requireNonNull(text, "text").toString();
+        this.encoding = Objects.requireNonNull(encoding, "encoding");
+    }
+
+    @Override
+    public DocumentId id() {
+        return id;
+    }
+
+    @Override
+    public DocumentUri uri() {
+        return uri;
+    }
+
+    @Override
+    public DocumentVersion version() {
+        return version;
+    }
+
+    @Override
+    public String languageId() {
+        return languageId;
+    }
+
+    /**
+     * Returns the immutable complete document text.
+     *
+     * @return document text
+     */
+    public String text() {
+        return text;
+    }
+
+    /**
+     * Returns the character encoding associated with the document origin.
+     *
+     * @return text encoding
+     */
+    public Charset encoding() {
+        return encoding;
+    }
+
+    private static String requireLanguageId(String languageId) {
+        languageId = Objects.requireNonNull(languageId, "languageId");
+        if (languageId.isBlank())
+            throw new IllegalArgumentException("languageId cannot be blank");
+        return languageId;
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/package-info.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/package-info.java
@@ -7,14 +7,17 @@
  * feature results borrow that identity and must not reinterpret its value.
  * {@link dev.railroadide.railroad.ide.sst.document.api.DocumentUri} is the immutable
  * physical or virtual address currently associated with that document.
+ * {@link dev.railroadide.railroad.ide.sst.document.api.DocumentVersion} identifies the
+ * immutable content revision observed by a snapshot or analysis result.
  * <p>
  * Identity does not imply location or snapshot equality. A rename retains the same ID
- * while changing its URI, an edit produces a later snapshot with the same ID and URI,
- * and a copy receives a different ID. Version, text/binary snapshot, and source-origin
- * contracts are intentionally separate platform concepts.
+ * while changing its URI, an edit advances the version while retaining the ID, and a
+ * copy receives a different ID. Text/binary snapshot and source-origin contracts are
+ * intentionally separate platform concepts.
  * <p>
- * Legacy syntax construction and parser entry points without an owner-supplied ID remain
- * source compatible by allocating a fresh anonymous identity. Callers that correlate
- * work across parses must use the explicit-ID overloads.
+ * Legacy syntax construction and parser entry points without owner-supplied metadata
+ * remain source compatible by allocating a fresh anonymous identity, in-memory URI, and
+ * initial version. Callers that correlate work across parses must use the explicit
+ * metadata overloads.
  */
 package dev.railroadide.railroad.ide.sst.document.api;

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/package-info.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/package-info.java
@@ -9,10 +9,14 @@
  * physical or virtual address currently associated with that document.
  * {@link dev.railroadide.railroad.ide.sst.document.api.DocumentVersion} identifies the
  * immutable content revision observed by a snapshot or analysis result.
+ * {@link dev.railroadide.railroad.ide.sst.document.api.DocumentSnapshot} is the sealed
+ * root for immutable text and binary revisions. Text inputs are copied into strings;
+ * binary inputs are copied and exposed only through defensive copies or read-only
+ * buffers.
  * <p>
  * Identity does not imply location or snapshot equality. A rename retains the same ID
  * while changing its URI, an edit advances the version while retaining the ID, and a
- * copy receives a different ID. Text/binary snapshot and source-origin contracts are
+ * copy receives a different ID. Snapshot equality and source-origin contracts remain
  * intentionally separate platform concepts.
  * <p>
  * Legacy syntax construction and parser entry points without owner-supplied metadata

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/package-info.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Language-neutral document identity contracts for the SST platform.
+ * <p>
+ * {@link dev.railroadide.railroad.ide.sst.document.api.DocumentId} identifies a logical
+ * document independently of its path, URI, content, language, or revision. A workspace
+ * or document service owns allocation and association; syntax, semantic, indexing, and
+ * feature results borrow that identity and must not reinterpret its value.
+ * <p>
+ * Identity does not imply location or snapshot equality. A rename retains the same ID,
+ * an edit produces a later snapshot with the same ID, and a copy receives a different ID.
+ * URI, version, text/binary snapshot, and source-origin contracts are intentionally
+ * separate platform concepts.
+ * <p>
+ * Legacy syntax construction and parser entry points without an owner-supplied ID remain
+ * source compatible by allocating a fresh anonymous identity. Callers that correlate
+ * work across parses must use the explicit-ID overloads.
+ */
+package dev.railroadide.railroad.ide.sst.document.api;

--- a/src/main/java/dev/railroadide/railroad/ide/sst/document/api/package-info.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/document/api/package-info.java
@@ -5,11 +5,13 @@
  * document independently of its path, URI, content, language, or revision. A workspace
  * or document service owns allocation and association; syntax, semantic, indexing, and
  * feature results borrow that identity and must not reinterpret its value.
+ * {@link dev.railroadide.railroad.ide.sst.document.api.DocumentUri} is the immutable
+ * physical or virtual address currently associated with that document.
  * <p>
- * Identity does not imply location or snapshot equality. A rename retains the same ID,
- * an edit produces a later snapshot with the same ID, and a copy receives a different ID.
- * URI, version, text/binary snapshot, and source-origin contracts are intentionally
- * separate platform concepts.
+ * Identity does not imply location or snapshot equality. A rename retains the same ID
+ * while changing its URI, an edit produces a later snapshot with the same ID and URI,
+ * and a copy receives a different ID. Version, text/binary snapshot, and source-origin
+ * contracts are intentionally separate platform concepts.
  * <p>
  * Legacy syntax construction and parser entry points without an owner-supplied ID remain
  * source compatible by allocating a fresh anonymous identity. Callers that correlate

--- a/src/main/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParser.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParser.java
@@ -3,12 +3,14 @@ package dev.railroadide.railroad.ide.sst.impl.java;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentVersion;
+import dev.railroadide.railroad.ide.sst.document.api.TextDocumentSnapshot;
 import dev.railroadide.railroad.ide.sst.lexer.Lexer;
 import dev.railroadide.railroad.ide.sst.syntax.api.*;
 import dev.railroadide.railroad.ide.sst.syntax.internal.GreenElement;
 import dev.railroadide.railroad.ide.sst.syntax.internal.GreenNode;
 import dev.railroadide.railroad.ide.sst.syntax.internal.SyntaxInternalFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public final class JavaSyntaxParser {
@@ -47,12 +49,20 @@ public final class JavaSyntaxParser {
         DocumentVersion documentVersion,
         CharSequence source
     ) {
-        Objects.requireNonNull(documentId, "documentId");
-        Objects.requireNonNull(documentUri, "documentUri");
-        Objects.requireNonNull(documentVersion, "documentVersion");
-        Objects.requireNonNull(source, "source");
-        try (var lexer = new JavaLexer(source)) {
-            return parse(documentId, documentUri, documentVersion, lexer);
+        return parse(new TextDocumentSnapshot(
+            documentId,
+            documentUri,
+            documentVersion,
+            "java",
+            source,
+            StandardCharsets.UTF_8
+        ));
+    }
+
+    public static SyntaxTree parse(TextDocumentSnapshot documentSnapshot) {
+        documentSnapshot = requireJavaSnapshot(documentSnapshot);
+        try (var lexer = new JavaLexer(documentSnapshot.text())) {
+            return parse(documentSnapshot, lexer);
         }
     }
 
@@ -82,7 +92,24 @@ public final class JavaSyntaxParser {
         Objects.requireNonNull(documentUri, "documentUri");
         Objects.requireNonNull(documentVersion, "documentVersion");
         GreenNode root = new JavaGreenParser(Objects.requireNonNull(lexer, "lexer")).parseGreenTree();
-        return SyntaxInternalFactory.treeFromGreenRoot(documentId, documentUri, documentVersion, root);
+        var documentSnapshot = new TextDocumentSnapshot(
+            documentId,
+            documentUri,
+            documentVersion,
+            "java",
+            SyntaxInternalFactory.sourceText(root),
+            StandardCharsets.UTF_8
+        );
+        return SyntaxInternalFactory.treeFromGreenRoot(documentSnapshot, root);
+    }
+
+    public static SyntaxTree parse(
+        TextDocumentSnapshot documentSnapshot,
+        Lexer<JavaTokenType> lexer
+    ) {
+        documentSnapshot = requireJavaSnapshot(documentSnapshot);
+        GreenNode root = new JavaGreenParser(Objects.requireNonNull(lexer, "lexer")).parseGreenTree();
+        return SyntaxInternalFactory.treeFromGreenRoot(documentSnapshot, root);
     }
 
     public static ParseResult parseWithDiagnostics(CharSequence source) {
@@ -107,13 +134,19 @@ public final class JavaSyntaxParser {
         DocumentVersion documentVersion,
         CharSequence source
     ) {
-        Objects.requireNonNull(documentId, "documentId");
-        Objects.requireNonNull(documentUri, "documentUri");
-        Objects.requireNonNull(documentVersion, "documentVersion");
-        Objects.requireNonNull(source, "source");
-        try (var lexer = new JavaLexer(source)) {
-            return parseWithDiagnostics(documentId, documentUri, documentVersion, lexer);
-        }
+        return parseWithDiagnostics(new TextDocumentSnapshot(
+            documentId,
+            documentUri,
+            documentVersion,
+            "java",
+            source,
+            StandardCharsets.UTF_8
+        ));
+    }
+
+    public static ParseResult parseWithDiagnostics(TextDocumentSnapshot documentSnapshot) {
+        SyntaxTree tree = parse(documentSnapshot);
+        return new ParseResult(tree, collectSyntaxDiagnostics(tree.root()));
     }
 
     public static ParseResult parseWithDiagnostics(Lexer<JavaTokenType> lexer) {
@@ -142,6 +175,14 @@ public final class JavaSyntaxParser {
         return new ParseResult(tree, collectSyntaxDiagnostics(tree.root()));
     }
 
+    public static ParseResult parseWithDiagnostics(
+        TextDocumentSnapshot documentSnapshot,
+        Lexer<JavaTokenType> lexer
+    ) {
+        SyntaxTree tree = parse(documentSnapshot, lexer);
+        return new ParseResult(tree, collectSyntaxDiagnostics(tree.root()));
+    }
+
     public static IncrementalParseResult parseIncremental(
         SyntaxTree previousTree,
         CharSequence previousSource,
@@ -149,13 +190,16 @@ public final class JavaSyntaxParser {
         TextEdit edit
     ) {
         Objects.requireNonNull(previousTree, "previousTree");
-        return parseIncremental(
-            previousTree,
-            previousTree.documentVersion().next(),
-            previousSource,
+        verifyPreviousSource(previousTree, previousSource);
+        TextDocumentSnapshot previousSnapshot = previousTree.documentSnapshot();
+        return parseIncremental(previousTree, new TextDocumentSnapshot(
+            previousSnapshot.id(),
+            previousSnapshot.uri(),
+            previousSnapshot.version().next(),
+            previousSnapshot.languageId(),
             newSource,
-            edit
-        );
+            previousSnapshot.encoding()
+        ), edit);
     }
 
     public static IncrementalParseResult parseIncremental(
@@ -166,13 +210,47 @@ public final class JavaSyntaxParser {
         TextEdit edit
     ) {
         Objects.requireNonNull(previousTree, "previousTree");
-        newVersion = Objects.requireNonNull(newVersion, "newVersion");
-        if (!newVersion.isAfter(previousTree.documentVersion()))
-            throw new IllegalArgumentException("newVersion must be later than previous tree version " + previousTree.documentVersion());
+        verifyPreviousSource(previousTree, previousSource);
+        TextDocumentSnapshot previousSnapshot = previousTree.documentSnapshot();
+        return parseIncremental(previousTree, new TextDocumentSnapshot(
+            previousSnapshot.id(),
+            previousSnapshot.uri(),
+            Objects.requireNonNull(newVersion, "newVersion"),
+            previousSnapshot.languageId(),
+            newSource,
+            previousSnapshot.encoding()
+        ), edit);
+    }
 
-        Objects.requireNonNull(previousSource, "previousSource");
-        Objects.requireNonNull(newSource, "newSource");
-        Objects.requireNonNull(edit, "edit");
+    /**
+     * Incrementally parses a later immutable snapshot of the same logical document.
+     *
+     * @param previousTree syntax tree for the preceding snapshot
+     * @param newSnapshot complete later snapshot to parse
+     * @param edit change transforming the previous snapshot text into the new text
+     * @return incremental parse result carrying {@code newSnapshot}
+     * @throws IllegalArgumentException if identity or version continuity is invalid
+     */
+    public static IncrementalParseResult parseIncremental(
+        SyntaxTree previousTree,
+        TextDocumentSnapshot newSnapshot,
+        TextEdit edit
+    ) {
+        Objects.requireNonNull(previousTree, "previousTree");
+        newSnapshot = requireJavaSnapshot(newSnapshot);
+        edit = Objects.requireNonNull(edit, "edit");
+
+        TextDocumentSnapshot previousSnapshot = previousTree.documentSnapshot();
+        if (!newSnapshot.id().equals(previousSnapshot.id()))
+            throw new IllegalArgumentException("newSnapshot must have the same document identity as previousTree");
+        if (!newSnapshot.version().isAfter(previousSnapshot.version())) {
+            throw new IllegalArgumentException(
+                "newSnapshot version must be later than previous tree version " + previousSnapshot.version()
+            );
+        }
+
+        String previousSource = previousSnapshot.text();
+        String newSource = newSnapshot.text();
 
         int oldLength = previousSource.length();
         int newLength = newSource.length();
@@ -181,18 +259,13 @@ public final class JavaSyntaxParser {
         ReusePlan fallbackPlan = planReuse(previousTree, previousSource, newSource, edit);
         Optional<TopLevelReparseWindow> incrementalWindow = selectTopLevelWindow(previousTree.root(), edit, oldLength, newLength);
         if (incrementalWindow.isEmpty()) {
-            SyntaxTree reparsed = parse(
-                previousTree.documentId(),
-                previousTree.documentUri(),
-                newVersion,
-                newSource
-            );
+            SyntaxTree reparsed = parse(newSnapshot);
             return new IncrementalParseResult(reparsed, fallbackPlan, true);
         }
 
         try {
             TopLevelReparseWindow window = incrementalWindow.get();
-            SyntaxTree incrementalTree = reparseTopLevelTail(previousTree, newVersion, newSource, window);
+            SyntaxTree incrementalTree = reparseTopLevelTail(previousTree, newSnapshot, window);
             ReusePlan incrementalPlan = buildReusePlan(
                 previousTree.root(),
                 window.oldReparseStart(),
@@ -203,12 +276,7 @@ public final class JavaSyntaxParser {
             );
             return new IncrementalParseResult(incrementalTree, incrementalPlan, false);
         } catch (RuntimeException ignored) {
-            SyntaxTree reparsed = parse(
-                previousTree.documentId(),
-                previousTree.documentUri(),
-                newVersion,
-                newSource
-            );
+            SyntaxTree reparsed = parse(newSnapshot);
             return new IncrementalParseResult(reparsed, fallbackPlan, true);
         }
     }
@@ -319,8 +387,7 @@ public final class JavaSyntaxParser {
 
     private static SyntaxTree reparseTopLevelTail(
         SyntaxTree previousTree,
-        DocumentVersion newVersion,
-        CharSequence newSource,
+        TextDocumentSnapshot newSnapshot,
         TopLevelReparseWindow window
     ) {
         List<SyntaxNode> previousChildren = previousTree.root().children();
@@ -329,23 +396,29 @@ public final class JavaSyntaxParser {
             mergedChildren.add(SyntaxInternalFactory.greenElement(previousChildren.get(index)));
         }
 
-        CharSequence tailSource = newSource.subSequence(window.newReparseStart(), window.newReparseEnd());
-        SyntaxTree reparsedTail = parse(
-            previousTree.documentId(),
-            previousTree.documentUri(),
-            newVersion,
-            tailSource
-        );
+        CharSequence tailSource = newSnapshot.text().subSequence(window.newReparseStart(), window.newReparseEnd());
+        SyntaxTree reparsedTail = parse(tailSource);
         GreenNode reparsedTailRoot = SyntaxInternalFactory.greenRoot(reparsedTail);
         mergedChildren.addAll(reparsedTailRoot.children());
 
         GreenNode mergedRoot = SyntaxInternalFactory.greenNode(JavaSyntaxKinds.COMPILATION_UNIT, mergedChildren);
-        return SyntaxInternalFactory.treeFromGreenRoot(
-            previousTree.documentId(),
-            previousTree.documentUri(),
-            newVersion,
-            mergedRoot
-        );
+        return SyntaxInternalFactory.treeFromGreenRoot(newSnapshot, mergedRoot);
+    }
+
+    private static TextDocumentSnapshot requireJavaSnapshot(TextDocumentSnapshot documentSnapshot) {
+        documentSnapshot = Objects.requireNonNull(documentSnapshot, "documentSnapshot");
+        if (!"java".equalsIgnoreCase(documentSnapshot.languageId()))
+            throw new IllegalArgumentException("Java parser requires a snapshot with languageId 'java'");
+        return documentSnapshot;
+    }
+
+    private static void verifyPreviousSource(SyntaxTree previousTree, CharSequence previousSource) {
+        previousSource = Objects.requireNonNull(previousSource, "previousSource");
+        if (!previousTree.documentSnapshot().text().contentEquals(previousSource)) {
+            throw new IllegalArgumentException(
+                "previousSource must match the immutable snapshot carried by previousTree"
+            );
+        }
     }
 
     private static int findAffectedTopLevelChild(

--- a/src/main/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParser.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParser.java
@@ -1,5 +1,6 @@
 package dev.railroadide.railroad.ide.sst.impl.java;
 
+import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.lexer.Lexer;
 import dev.railroadide.railroad.ide.sst.syntax.api.*;
 import dev.railroadide.railroad.ide.sst.syntax.internal.GreenElement;
@@ -27,25 +28,45 @@ public final class JavaSyntaxParser {
     }
 
     public static SyntaxTree parse(CharSequence source) {
+        return parse(DocumentId.create(), source);
+    }
+
+    public static SyntaxTree parse(DocumentId documentId, CharSequence source) {
+        Objects.requireNonNull(documentId, "documentId");
         Objects.requireNonNull(source, "source");
         try (var lexer = new JavaLexer(source)) {
-            return parse(lexer);
+            return parse(documentId, lexer);
         }
     }
 
     public static SyntaxTree parse(Lexer<JavaTokenType> lexer) {
-        return new JavaGreenParser(Objects.requireNonNull(lexer, "lexer")).parseSyntaxTree();
+        return parse(DocumentId.create(), lexer);
+    }
+
+    public static SyntaxTree parse(DocumentId documentId, Lexer<JavaTokenType> lexer) {
+        Objects.requireNonNull(documentId, "documentId");
+        GreenNode root = new JavaGreenParser(Objects.requireNonNull(lexer, "lexer")).parseGreenTree();
+        return SyntaxInternalFactory.treeFromGreenRoot(documentId, root);
     }
 
     public static ParseResult parseWithDiagnostics(CharSequence source) {
+        return parseWithDiagnostics(DocumentId.create(), source);
+    }
+
+    public static ParseResult parseWithDiagnostics(DocumentId documentId, CharSequence source) {
+        Objects.requireNonNull(documentId, "documentId");
         Objects.requireNonNull(source, "source");
         try (var lexer = new JavaLexer(source)) {
-            return parseWithDiagnostics(lexer);
+            return parseWithDiagnostics(documentId, lexer);
         }
     }
 
     public static ParseResult parseWithDiagnostics(Lexer<JavaTokenType> lexer) {
-        SyntaxTree tree = parse(lexer);
+        return parseWithDiagnostics(DocumentId.create(), lexer);
+    }
+
+    public static ParseResult parseWithDiagnostics(DocumentId documentId, Lexer<JavaTokenType> lexer) {
+        SyntaxTree tree = parse(documentId, lexer);
         return new ParseResult(tree, collectSyntaxDiagnostics(tree.root()));
     }
 
@@ -67,7 +88,7 @@ public final class JavaSyntaxParser {
         ReusePlan fallbackPlan = planReuse(previousTree, previousSource, newSource, edit);
         Optional<TopLevelReparseWindow> incrementalWindow = selectTopLevelWindow(previousTree.root(), edit, oldLength, newLength);
         if (incrementalWindow.isEmpty()) {
-            SyntaxTree reparsed = parse(newSource);
+            SyntaxTree reparsed = parse(previousTree.documentId(), newSource);
             return new IncrementalParseResult(reparsed, fallbackPlan, true);
         }
 
@@ -84,7 +105,7 @@ public final class JavaSyntaxParser {
             );
             return new IncrementalParseResult(incrementalTree, incrementalPlan, false);
         } catch (RuntimeException ignored) {
-            SyntaxTree reparsed = parse(newSource);
+            SyntaxTree reparsed = parse(previousTree.documentId(), newSource);
             return new IncrementalParseResult(reparsed, fallbackPlan, true);
         }
     }
@@ -205,12 +226,12 @@ public final class JavaSyntaxParser {
         }
 
         CharSequence tailSource = newSource.subSequence(window.newReparseStart(), window.newReparseEnd());
-        SyntaxTree reparsedTail = parse(tailSource);
+        SyntaxTree reparsedTail = parse(previousTree.documentId(), tailSource);
         GreenNode reparsedTailRoot = SyntaxInternalFactory.greenRoot(reparsedTail);
         mergedChildren.addAll(reparsedTailRoot.children());
 
         GreenNode mergedRoot = SyntaxInternalFactory.greenNode(JavaSyntaxKinds.COMPILATION_UNIT, mergedChildren);
-        return SyntaxInternalFactory.treeFromGreenRoot(mergedRoot);
+        return SyntaxInternalFactory.treeFromGreenRoot(previousTree.documentId(), mergedRoot);
     }
 
     private static int findAffectedTopLevelChild(

--- a/src/main/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParser.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParser.java
@@ -1,6 +1,7 @@
 package dev.railroadide.railroad.ide.sst.impl.java;
 
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
+import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
 import dev.railroadide.railroad.ide.sst.lexer.Lexer;
 import dev.railroadide.railroad.ide.sst.syntax.api.*;
 import dev.railroadide.railroad.ide.sst.syntax.internal.GreenElement;
@@ -32,10 +33,15 @@ public final class JavaSyntaxParser {
     }
 
     public static SyntaxTree parse(DocumentId documentId, CharSequence source) {
+        return parse(documentId, DocumentUri.inMemory(documentId), source);
+    }
+
+    public static SyntaxTree parse(DocumentId documentId, DocumentUri documentUri, CharSequence source) {
         Objects.requireNonNull(documentId, "documentId");
+        Objects.requireNonNull(documentUri, "documentUri");
         Objects.requireNonNull(source, "source");
         try (var lexer = new JavaLexer(source)) {
-            return parse(documentId, lexer);
+            return parse(documentId, documentUri, lexer);
         }
     }
 
@@ -44,9 +50,18 @@ public final class JavaSyntaxParser {
     }
 
     public static SyntaxTree parse(DocumentId documentId, Lexer<JavaTokenType> lexer) {
+        return parse(documentId, DocumentUri.inMemory(documentId), lexer);
+    }
+
+    public static SyntaxTree parse(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        Lexer<JavaTokenType> lexer
+    ) {
         Objects.requireNonNull(documentId, "documentId");
+        Objects.requireNonNull(documentUri, "documentUri");
         GreenNode root = new JavaGreenParser(Objects.requireNonNull(lexer, "lexer")).parseGreenTree();
-        return SyntaxInternalFactory.treeFromGreenRoot(documentId, root);
+        return SyntaxInternalFactory.treeFromGreenRoot(documentId, documentUri, root);
     }
 
     public static ParseResult parseWithDiagnostics(CharSequence source) {
@@ -54,10 +69,19 @@ public final class JavaSyntaxParser {
     }
 
     public static ParseResult parseWithDiagnostics(DocumentId documentId, CharSequence source) {
+        return parseWithDiagnostics(documentId, DocumentUri.inMemory(documentId), source);
+    }
+
+    public static ParseResult parseWithDiagnostics(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        CharSequence source
+    ) {
         Objects.requireNonNull(documentId, "documentId");
+        Objects.requireNonNull(documentUri, "documentUri");
         Objects.requireNonNull(source, "source");
         try (var lexer = new JavaLexer(source)) {
-            return parseWithDiagnostics(documentId, lexer);
+            return parseWithDiagnostics(documentId, documentUri, lexer);
         }
     }
 
@@ -66,7 +90,15 @@ public final class JavaSyntaxParser {
     }
 
     public static ParseResult parseWithDiagnostics(DocumentId documentId, Lexer<JavaTokenType> lexer) {
-        SyntaxTree tree = parse(documentId, lexer);
+        return parseWithDiagnostics(documentId, DocumentUri.inMemory(documentId), lexer);
+    }
+
+    public static ParseResult parseWithDiagnostics(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        Lexer<JavaTokenType> lexer
+    ) {
+        SyntaxTree tree = parse(documentId, documentUri, lexer);
         return new ParseResult(tree, collectSyntaxDiagnostics(tree.root()));
     }
 
@@ -88,7 +120,7 @@ public final class JavaSyntaxParser {
         ReusePlan fallbackPlan = planReuse(previousTree, previousSource, newSource, edit);
         Optional<TopLevelReparseWindow> incrementalWindow = selectTopLevelWindow(previousTree.root(), edit, oldLength, newLength);
         if (incrementalWindow.isEmpty()) {
-            SyntaxTree reparsed = parse(previousTree.documentId(), newSource);
+            SyntaxTree reparsed = parse(previousTree.documentId(), previousTree.documentUri(), newSource);
             return new IncrementalParseResult(reparsed, fallbackPlan, true);
         }
 
@@ -105,7 +137,7 @@ public final class JavaSyntaxParser {
             );
             return new IncrementalParseResult(incrementalTree, incrementalPlan, false);
         } catch (RuntimeException ignored) {
-            SyntaxTree reparsed = parse(previousTree.documentId(), newSource);
+            SyntaxTree reparsed = parse(previousTree.documentId(), previousTree.documentUri(), newSource);
             return new IncrementalParseResult(reparsed, fallbackPlan, true);
         }
     }
@@ -226,12 +258,16 @@ public final class JavaSyntaxParser {
         }
 
         CharSequence tailSource = newSource.subSequence(window.newReparseStart(), window.newReparseEnd());
-        SyntaxTree reparsedTail = parse(previousTree.documentId(), tailSource);
+        SyntaxTree reparsedTail = parse(previousTree.documentId(), previousTree.documentUri(), tailSource);
         GreenNode reparsedTailRoot = SyntaxInternalFactory.greenRoot(reparsedTail);
         mergedChildren.addAll(reparsedTailRoot.children());
 
         GreenNode mergedRoot = SyntaxInternalFactory.greenNode(JavaSyntaxKinds.COMPILATION_UNIT, mergedChildren);
-        return SyntaxInternalFactory.treeFromGreenRoot(previousTree.documentId(), mergedRoot);
+        return SyntaxInternalFactory.treeFromGreenRoot(
+            previousTree.documentId(),
+            previousTree.documentUri(),
+            mergedRoot
+        );
     }
 
     private static int findAffectedTopLevelChild(

--- a/src/main/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParser.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParser.java
@@ -2,6 +2,7 @@ package dev.railroadide.railroad.ide.sst.impl.java;
 
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
+import dev.railroadide.railroad.ide.sst.document.api.DocumentVersion;
 import dev.railroadide.railroad.ide.sst.lexer.Lexer;
 import dev.railroadide.railroad.ide.sst.syntax.api.*;
 import dev.railroadide.railroad.ide.sst.syntax.internal.GreenElement;
@@ -12,13 +13,13 @@ import java.util.*;
 
 public final class JavaSyntaxParser {
     private static final Set<String> INCREMENTAL_ANCHOR_KIND_IDS = Set.of(
-            JavaSyntaxKinds.TYPE_DECLARATION.id(),
-            JavaSyntaxKinds.CLASS_DECLARATION.id(),
-            JavaSyntaxKinds.INTERFACE_DECLARATION.id(),
-            JavaSyntaxKinds.ENUM_DECLARATION.id(),
-            JavaSyntaxKinds.ANNOTATION_TYPE_DECLARATION.id(),
-            JavaSyntaxKinds.RECORD_DECLARATION.id(),
-            JavaSyntaxKinds.EMPTY_TYPE_DECLARATION.id()
+        JavaSyntaxKinds.TYPE_DECLARATION.id(),
+        JavaSyntaxKinds.CLASS_DECLARATION.id(),
+        JavaSyntaxKinds.INTERFACE_DECLARATION.id(),
+        JavaSyntaxKinds.ENUM_DECLARATION.id(),
+        JavaSyntaxKinds.ANNOTATION_TYPE_DECLARATION.id(),
+        JavaSyntaxKinds.RECORD_DECLARATION.id(),
+        JavaSyntaxKinds.EMPTY_TYPE_DECLARATION.id()
     );
     private static final String EOF_KIND_ID = JavaSyntaxKinds.tokenKind(JavaTokenType.EOF).id();
     private static final String MISSING_TOKEN_KIND_ID = SyntaxKind.MISSING_TOKEN.id();
@@ -37,11 +38,21 @@ public final class JavaSyntaxParser {
     }
 
     public static SyntaxTree parse(DocumentId documentId, DocumentUri documentUri, CharSequence source) {
+        return parse(documentId, documentUri, DocumentVersion.initial(), source);
+    }
+
+    public static SyntaxTree parse(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        DocumentVersion documentVersion,
+        CharSequence source
+    ) {
         Objects.requireNonNull(documentId, "documentId");
         Objects.requireNonNull(documentUri, "documentUri");
+        Objects.requireNonNull(documentVersion, "documentVersion");
         Objects.requireNonNull(source, "source");
         try (var lexer = new JavaLexer(source)) {
-            return parse(documentId, documentUri, lexer);
+            return parse(documentId, documentUri, documentVersion, lexer);
         }
     }
 
@@ -58,10 +69,20 @@ public final class JavaSyntaxParser {
         DocumentUri documentUri,
         Lexer<JavaTokenType> lexer
     ) {
+        return parse(documentId, documentUri, DocumentVersion.initial(), lexer);
+    }
+
+    public static SyntaxTree parse(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        DocumentVersion documentVersion,
+        Lexer<JavaTokenType> lexer
+    ) {
         Objects.requireNonNull(documentId, "documentId");
         Objects.requireNonNull(documentUri, "documentUri");
+        Objects.requireNonNull(documentVersion, "documentVersion");
         GreenNode root = new JavaGreenParser(Objects.requireNonNull(lexer, "lexer")).parseGreenTree();
-        return SyntaxInternalFactory.treeFromGreenRoot(documentId, documentUri, root);
+        return SyntaxInternalFactory.treeFromGreenRoot(documentId, documentUri, documentVersion, root);
     }
 
     public static ParseResult parseWithDiagnostics(CharSequence source) {
@@ -77,11 +98,21 @@ public final class JavaSyntaxParser {
         DocumentUri documentUri,
         CharSequence source
     ) {
+        return parseWithDiagnostics(documentId, documentUri, DocumentVersion.initial(), source);
+    }
+
+    public static ParseResult parseWithDiagnostics(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        DocumentVersion documentVersion,
+        CharSequence source
+    ) {
         Objects.requireNonNull(documentId, "documentId");
         Objects.requireNonNull(documentUri, "documentUri");
+        Objects.requireNonNull(documentVersion, "documentVersion");
         Objects.requireNonNull(source, "source");
         try (var lexer = new JavaLexer(source)) {
-            return parseWithDiagnostics(documentId, documentUri, lexer);
+            return parseWithDiagnostics(documentId, documentUri, documentVersion, lexer);
         }
     }
 
@@ -98,17 +129,47 @@ public final class JavaSyntaxParser {
         DocumentUri documentUri,
         Lexer<JavaTokenType> lexer
     ) {
-        SyntaxTree tree = parse(documentId, documentUri, lexer);
+        return parseWithDiagnostics(documentId, documentUri, DocumentVersion.initial(), lexer);
+    }
+
+    public static ParseResult parseWithDiagnostics(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        DocumentVersion documentVersion,
+        Lexer<JavaTokenType> lexer
+    ) {
+        SyntaxTree tree = parse(documentId, documentUri, documentVersion, lexer);
         return new ParseResult(tree, collectSyntaxDiagnostics(tree.root()));
     }
 
     public static IncrementalParseResult parseIncremental(
-            SyntaxTree previousTree,
-            CharSequence previousSource,
-            CharSequence newSource,
-            TextEdit edit
+        SyntaxTree previousTree,
+        CharSequence previousSource,
+        CharSequence newSource,
+        TextEdit edit
     ) {
         Objects.requireNonNull(previousTree, "previousTree");
+        return parseIncremental(
+            previousTree,
+            previousTree.documentVersion().next(),
+            previousSource,
+            newSource,
+            edit
+        );
+    }
+
+    public static IncrementalParseResult parseIncremental(
+        SyntaxTree previousTree,
+        DocumentVersion newVersion,
+        CharSequence previousSource,
+        CharSequence newSource,
+        TextEdit edit
+    ) {
+        Objects.requireNonNull(previousTree, "previousTree");
+        newVersion = Objects.requireNonNull(newVersion, "newVersion");
+        if (!newVersion.isAfter(previousTree.documentVersion()))
+            throw new IllegalArgumentException("newVersion must be later than previous tree version " + previousTree.documentVersion());
+
         Objects.requireNonNull(previousSource, "previousSource");
         Objects.requireNonNull(newSource, "newSource");
         Objects.requireNonNull(edit, "edit");
@@ -120,33 +181,43 @@ public final class JavaSyntaxParser {
         ReusePlan fallbackPlan = planReuse(previousTree, previousSource, newSource, edit);
         Optional<TopLevelReparseWindow> incrementalWindow = selectTopLevelWindow(previousTree.root(), edit, oldLength, newLength);
         if (incrementalWindow.isEmpty()) {
-            SyntaxTree reparsed = parse(previousTree.documentId(), previousTree.documentUri(), newSource);
+            SyntaxTree reparsed = parse(
+                previousTree.documentId(),
+                previousTree.documentUri(),
+                newVersion,
+                newSource
+            );
             return new IncrementalParseResult(reparsed, fallbackPlan, true);
         }
 
         try {
             TopLevelReparseWindow window = incrementalWindow.get();
-            SyntaxTree incrementalTree = reparseTopLevelTail(previousTree, newSource, window);
+            SyntaxTree incrementalTree = reparseTopLevelTail(previousTree, newVersion, newSource, window);
             ReusePlan incrementalPlan = buildReusePlan(
-                    previousTree.root(),
-                    window.oldReparseStart(),
-                    window.oldReparseEnd(),
-                    edit,
-                    oldLength,
-                    newLength
+                previousTree.root(),
+                window.oldReparseStart(),
+                window.oldReparseEnd(),
+                edit,
+                oldLength,
+                newLength
             );
             return new IncrementalParseResult(incrementalTree, incrementalPlan, false);
         } catch (RuntimeException ignored) {
-            SyntaxTree reparsed = parse(previousTree.documentId(), previousTree.documentUri(), newSource);
+            SyntaxTree reparsed = parse(
+                previousTree.documentId(),
+                previousTree.documentUri(),
+                newVersion,
+                newSource
+            );
             return new IncrementalParseResult(reparsed, fallbackPlan, true);
         }
     }
 
     public static ReusePlan planReuse(
-            SyntaxTree previousTree,
-            CharSequence previousSource,
-            CharSequence newSource,
-            TextEdit edit
+        SyntaxTree previousTree,
+        CharSequence previousSource,
+        CharSequence newSource,
+        TextEdit edit
     ) {
         Objects.requireNonNull(previousTree, "previousTree");
         Objects.requireNonNull(previousSource, "previousSource");
@@ -177,12 +248,12 @@ public final class JavaSyntaxParser {
     }
 
     private static ReusePlan buildReusePlan(
-            SyntaxNode root,
-            int oldReparseStart,
-            int oldReparseEnd,
-            TextEdit edit,
-            int oldLength,
-            int newLength
+        SyntaxNode root,
+        int oldReparseStart,
+        int oldReparseEnd,
+        TextEdit edit,
+        int oldLength,
+        int newLength
     ) {
         int clampedOldStart = clamp(oldReparseStart, 0, oldLength);
         int clampedOldEnd = clamp(oldReparseEnd, clampedOldStart, oldLength);
@@ -206,15 +277,15 @@ public final class JavaSyntaxParser {
         int expectedNewLength = oldLength - removedLength + edit.insertedText().length();
         if (expectedNewLength != newLength) {
             throw new IllegalArgumentException("new source length does not match edit delta: expected " +
-                    expectedNewLength + ", got " + newLength);
+                expectedNewLength + ", got " + newLength);
         }
     }
 
     private static Optional<TopLevelReparseWindow> selectTopLevelWindow(
-            SyntaxNode root,
-            TextEdit edit,
-            int oldLength,
-            int newLength
+        SyntaxNode root,
+        TextEdit edit,
+        int oldLength,
+        int newLength
     ) {
         List<SyntaxNode> topLevelChildren = root.children();
         if (topLevelChildren.isEmpty())
@@ -247,9 +318,10 @@ public final class JavaSyntaxParser {
     }
 
     private static SyntaxTree reparseTopLevelTail(
-            SyntaxTree previousTree,
-            CharSequence newSource,
-            TopLevelReparseWindow window
+        SyntaxTree previousTree,
+        DocumentVersion newVersion,
+        CharSequence newSource,
+        TopLevelReparseWindow window
     ) {
         List<SyntaxNode> previousChildren = previousTree.root().children();
         List<GreenElement> mergedChildren = new ArrayList<>(previousChildren.size());
@@ -258,7 +330,12 @@ public final class JavaSyntaxParser {
         }
 
         CharSequence tailSource = newSource.subSequence(window.newReparseStart(), window.newReparseEnd());
-        SyntaxTree reparsedTail = parse(previousTree.documentId(), previousTree.documentUri(), tailSource);
+        SyntaxTree reparsedTail = parse(
+            previousTree.documentId(),
+            previousTree.documentUri(),
+            newVersion,
+            tailSource
+        );
         GreenNode reparsedTailRoot = SyntaxInternalFactory.greenRoot(reparsedTail);
         mergedChildren.addAll(reparsedTailRoot.children());
 
@@ -266,15 +343,16 @@ public final class JavaSyntaxParser {
         return SyntaxInternalFactory.treeFromGreenRoot(
             previousTree.documentId(),
             previousTree.documentUri(),
+            newVersion,
             mergedRoot
         );
     }
 
     private static int findAffectedTopLevelChild(
-            List<SyntaxNode> topLevelChildren,
-            int oldEditStart,
-            int oldEditEnd,
-            int oldLength
+        List<SyntaxNode> topLevelChildren,
+        int oldEditStart,
+        int oldEditEnd,
+        int oldLength
     ) {
         int probeStart = oldEditStart;
         int probeEnd = oldEditEnd;
@@ -337,11 +415,11 @@ public final class JavaSyntaxParser {
     }
 
     private static void collectReuseCandidates(
-            SyntaxNode node,
-            int oldReparseStart,
-            int oldReparseEnd,
-            int delta,
-            List<ReuseCandidate> candidates
+        SyntaxNode node,
+        int oldReparseStart,
+        int oldReparseEnd,
+        int delta,
+        List<ReuseCandidate> candidates
     ) {
         if (node instanceof SyntaxToken || node.width() == 0) {
             for (SyntaxNode child : node.children()) {
@@ -377,19 +455,19 @@ public final class JavaSyntaxParser {
             String kindId = node.kind().id();
             if (ERROR_NODE_KIND_ID.equals(kindId)) {
                 diagnostics.add(new SyntaxDiagnostic(
-                        SyntaxDiagnostic.Severity.ERROR,
-                        "JAVA_ERROR_NODE",
-                        "Recovered syntax error node",
-                        node.start(),
-                        node.end()
+                    SyntaxDiagnostic.Severity.ERROR,
+                    "JAVA_ERROR_NODE",
+                    "Recovered syntax error node",
+                    node.start(),
+                    node.end()
                 ));
             } else if (node instanceof SyntaxToken && isMissingTokenKind(kindId)) {
                 diagnostics.add(new SyntaxDiagnostic(
-                        SyntaxDiagnostic.Severity.ERROR,
-                        "JAVA_MISSING_TOKEN",
-                        "Inserted missing token",
-                        node.start(),
-                        node.end()
+                    SyntaxDiagnostic.Severity.ERROR,
+                    "JAVA_MISSING_TOKEN",
+                    "Inserted missing token",
+                    node.start(),
+                    node.end()
                 ));
             }
 
@@ -406,18 +484,18 @@ public final class JavaSyntaxParser {
     }
 
     private record TopLevelReparseWindow(
-            int startChildIndex,
-            int oldReparseStart,
-            int oldReparseEnd,
-            int newReparseStart,
-            int newReparseEnd
+        int startChildIndex,
+        int oldReparseStart,
+        int oldReparseEnd,
+        int newReparseStart,
+        int newReparseEnd
     ) {
     }
 
     public record TextEdit(
-            int startOffset,
-            int removedLength,
-            String insertedText
+        int startOffset,
+        int removedLength,
+        String insertedText
     ) {
         public TextEdit {
             if (startOffset < 0)
@@ -437,34 +515,34 @@ public final class JavaSyntaxParser {
     }
 
     public record ReuseCandidate(
-            String kindId,
-            int oldStartOffset,
-            int oldEndOffset,
-            int newStartOffset,
-            int newEndOffset
+        String kindId,
+        int oldStartOffset,
+        int oldEndOffset,
+        int newStartOffset,
+        int newEndOffset
     ) {
     }
 
     public record ReusePlan(
-            int oldReparseStart,
-            int oldReparseEnd,
-            int newReparseStart,
-            int newReparseEnd,
-            int lengthDelta,
-            List<ReuseCandidate> candidates
+        int oldReparseStart,
+        int oldReparseEnd,
+        int newReparseStart,
+        int newReparseEnd,
+        int lengthDelta,
+        List<ReuseCandidate> candidates
     ) {
     }
 
     public record IncrementalParseResult(
-            SyntaxTree tree,
-            ReusePlan reusePlan,
-            boolean fullReparse
+        SyntaxTree tree,
+        ReusePlan reusePlan,
+        boolean fullReparse
     ) {
     }
 
     public record ParseResult(
-            SyntaxTree tree,
-            List<SyntaxDiagnostic> diagnostics
+        SyntaxTree tree,
+        List<SyntaxDiagnostic> diagnostics
     ) {
         public ParseResult {
             tree = Objects.requireNonNull(tree, "tree");

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/SyntaxTree.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/SyntaxTree.java
@@ -1,5 +1,7 @@
 package dev.railroadide.railroad.ide.sst.syntax.api;
 
+import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
+
 import java.util.Objects;
 
 /**
@@ -10,16 +12,40 @@ import java.util.Objects;
  * {@link dev.railroadide.railroad.plugin.spi.inspection.JavaRuleContext#traverse}.
  */
 public final class SyntaxTree {
+    private final DocumentId documentId;
     private final SyntaxNode root;
 
     /**
-     * Creates a syntax tree with the supplied root node.
+     * Creates a syntax tree with the supplied root node and a fresh anonymous document
+     * identity. Prefer {@link #SyntaxTree(DocumentId, SyntaxNode)} when the caller owns a
+     * stable identity for the parsed document.
      *
-     * @param root root node covering the full file
+     * @param root root node covering the full document
      * @throws NullPointerException if {@code root} is {@code null}
      */
     public SyntaxTree(SyntaxNode root) {
+        this(DocumentId.create(), root);
+    }
+
+    /**
+     * Creates a syntax tree for a known logical document.
+     *
+     * @param documentId stable identity of the parsed document
+     * @param root root node covering the full document
+     * @throws NullPointerException if any argument is {@code null}
+     */
+    public SyntaxTree(DocumentId documentId, SyntaxNode root) {
+        this.documentId = Objects.requireNonNull(documentId, "documentId");
         this.root = Objects.requireNonNull(root, "root");
+    }
+
+    /**
+     * Returns the stable identity of the logical document represented by this tree.
+     *
+     * @return document identity
+     */
+    public DocumentId documentId() {
+        return documentId;
     }
 
     /**

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/SyntaxTree.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/SyntaxTree.java
@@ -1,6 +1,7 @@
 package dev.railroadide.railroad.ide.sst.syntax.api;
 
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
+import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
 
 import java.util.Objects;
 
@@ -13,6 +14,7 @@ import java.util.Objects;
  */
 public final class SyntaxTree {
     private final DocumentId documentId;
+    private final DocumentUri documentUri;
     private final SyntaxNode root;
 
     /**
@@ -35,7 +37,20 @@ public final class SyntaxTree {
      * @throws NullPointerException if any argument is {@code null}
      */
     public SyntaxTree(DocumentId documentId, SyntaxNode root) {
+        this(documentId, DocumentUri.inMemory(documentId), root);
+    }
+
+    /**
+     * Creates a syntax tree for a known logical document and current location.
+     *
+     * @param documentId stable identity of the parsed document
+     * @param documentUri location of the parsed document
+     * @param root root node covering the full document
+     * @throws NullPointerException if any argument is {@code null}
+     */
+    public SyntaxTree(DocumentId documentId, DocumentUri documentUri, SyntaxNode root) {
         this.documentId = Objects.requireNonNull(documentId, "documentId");
+        this.documentUri = Objects.requireNonNull(documentUri, "documentUri");
         this.root = Objects.requireNonNull(root, "root");
     }
 
@@ -46,6 +61,15 @@ public final class SyntaxTree {
      */
     public DocumentId documentId() {
         return documentId;
+    }
+
+    /**
+     * Returns the physical or virtual location parsed into this tree.
+     *
+     * @return document URI
+     */
+    public DocumentUri documentUri() {
+        return documentUri;
     }
 
     /**

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/SyntaxTree.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/SyntaxTree.java
@@ -2,6 +2,7 @@ package dev.railroadide.railroad.ide.sst.syntax.api;
 
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
+import dev.railroadide.railroad.ide.sst.document.api.DocumentVersion;
 
 import java.util.Objects;
 
@@ -15,6 +16,7 @@ import java.util.Objects;
 public final class SyntaxTree {
     private final DocumentId documentId;
     private final DocumentUri documentUri;
+    private final DocumentVersion documentVersion;
     private final SyntaxNode root;
 
     /**
@@ -49,8 +51,27 @@ public final class SyntaxTree {
      * @throws NullPointerException if any argument is {@code null}
      */
     public SyntaxTree(DocumentId documentId, DocumentUri documentUri, SyntaxNode root) {
+        this(documentId, documentUri, DocumentVersion.initial(), root);
+    }
+
+    /**
+     * Creates a syntax tree for a specific immutable document revision.
+     *
+     * @param documentId stable identity of the parsed document
+     * @param documentUri location of the parsed document
+     * @param documentVersion content revision parsed into this tree
+     * @param root root node covering the full document
+     * @throws NullPointerException if any argument is {@code null}
+     */
+    public SyntaxTree(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        DocumentVersion documentVersion,
+        SyntaxNode root
+    ) {
         this.documentId = Objects.requireNonNull(documentId, "documentId");
         this.documentUri = Objects.requireNonNull(documentUri, "documentUri");
+        this.documentVersion = Objects.requireNonNull(documentVersion, "documentVersion");
         this.root = Objects.requireNonNull(root, "root");
     }
 
@@ -70,6 +91,15 @@ public final class SyntaxTree {
      */
     public DocumentUri documentUri() {
         return documentUri;
+    }
+
+    /**
+     * Returns the immutable content revision parsed into this tree.
+     *
+     * @return document version
+     */
+    public DocumentVersion documentVersion() {
+        return documentVersion;
     }
 
     /**

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/SyntaxTree.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/SyntaxTree.java
@@ -3,7 +3,9 @@ package dev.railroadide.railroad.ide.sst.syntax.api;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentVersion;
+import dev.railroadide.railroad.ide.sst.document.api.TextDocumentSnapshot;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
@@ -14,9 +16,7 @@ import java.util.Objects;
  * {@link dev.railroadide.railroad.plugin.spi.inspection.JavaRuleContext#traverse}.
  */
 public final class SyntaxTree {
-    private final DocumentId documentId;
-    private final DocumentUri documentUri;
-    private final DocumentVersion documentVersion;
+    private final TextDocumentSnapshot documentSnapshot;
     private final SyntaxNode root;
 
     /**
@@ -69,10 +69,28 @@ public final class SyntaxTree {
         DocumentVersion documentVersion,
         SyntaxNode root
     ) {
-        this.documentId = Objects.requireNonNull(documentId, "documentId");
-        this.documentUri = Objects.requireNonNull(documentUri, "documentUri");
-        this.documentVersion = Objects.requireNonNull(documentVersion, "documentVersion");
+        this(compatibilitySnapshot(documentId, documentUri, documentVersion, root), root);
+    }
+
+    /**
+     * Creates a syntax tree for an immutable text snapshot.
+     *
+     * @param documentSnapshot exact source snapshot parsed into the tree
+     * @param root root node covering the complete snapshot text
+     * @throws NullPointerException if any argument is {@code null}
+     */
+    public SyntaxTree(TextDocumentSnapshot documentSnapshot, SyntaxNode root) {
+        this.documentSnapshot = Objects.requireNonNull(documentSnapshot, "documentSnapshot");
         this.root = Objects.requireNonNull(root, "root");
+    }
+
+    /**
+     * Returns the immutable source snapshot parsed into this tree.
+     *
+     * @return text document snapshot
+     */
+    public TextDocumentSnapshot documentSnapshot() {
+        return documentSnapshot;
     }
 
     /**
@@ -81,7 +99,7 @@ public final class SyntaxTree {
      * @return document identity
      */
     public DocumentId documentId() {
-        return documentId;
+        return documentSnapshot.id();
     }
 
     /**
@@ -90,7 +108,7 @@ public final class SyntaxTree {
      * @return document URI
      */
     public DocumentUri documentUri() {
-        return documentUri;
+        return documentSnapshot.uri();
     }
 
     /**
@@ -99,7 +117,7 @@ public final class SyntaxTree {
      * @return document version
      */
     public DocumentVersion documentVersion() {
-        return documentVersion;
+        return documentSnapshot.version();
     }
 
     /**
@@ -109,5 +127,36 @@ public final class SyntaxTree {
      */
     public SyntaxNode root() {
         return root;
+    }
+
+    private static TextDocumentSnapshot compatibilitySnapshot(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        DocumentVersion documentVersion,
+        SyntaxNode root
+    ) {
+        return new TextDocumentSnapshot(
+            Objects.requireNonNull(documentId, "documentId"),
+            Objects.requireNonNull(documentUri, "documentUri"),
+            Objects.requireNonNull(documentVersion, "documentVersion"),
+            "unknown",
+            sourceText(Objects.requireNonNull(root, "root")),
+            StandardCharsets.UTF_8
+        );
+    }
+
+    private static String sourceText(SyntaxNode root) {
+        StringBuilder text = new StringBuilder(Math.max(0, root.width()));
+        appendSourceText(root, text);
+        return text.toString();
+    }
+
+    private static void appendSourceText(SyntaxNode node, StringBuilder text) {
+        if (node instanceof SyntaxToken token) {
+            text.append(token.text());
+            return;
+        }
+        for (SyntaxNode child : node.children())
+            appendSourceText(child, text);
     }
 }

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/package-info.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/package-info.java
@@ -8,7 +8,8 @@
  * preserve token boundaries, offsets, parent/child links, and parser recovery details.
  * Every tree also carries the stable {@link
  * dev.railroadide.railroad.ide.sst.document.api.DocumentId} of the logical document it
- * represents.
+ * represents and its current {@link
+ * dev.railroadide.railroad.ide.sst.document.api.DocumentUri}.
  * <p>
  * Prefer this package when writing inspections. It gives you:
  * <ul>

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/package-info.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/package-info.java
@@ -6,6 +6,9 @@
  * dev.railroadide.railroad.ide.sst.syntax.api.SyntaxToken} instances. Kind identifiers are
  * stable strings such as {@code JAVA_CLASS_DECLARATION} and {@code JAVA_IDENTIFIER}. Nodes
  * preserve token boundaries, offsets, parent/child links, and parser recovery details.
+ * Every tree also carries the stable {@link
+ * dev.railroadide.railroad.ide.sst.document.api.DocumentId} of the logical document it
+ * represents.
  * <p>
  * Prefer this package when writing inspections. It gives you:
  * <ul>

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/package-info.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/package-info.java
@@ -9,7 +9,8 @@
  * Every tree also carries the stable {@link
  * dev.railroadide.railroad.ide.sst.document.api.DocumentId} of the logical document it
  * represents and its current {@link
- * dev.railroadide.railroad.ide.sst.document.api.DocumentUri}.
+ * dev.railroadide.railroad.ide.sst.document.api.DocumentUri}, plus the immutable {@link
+ * dev.railroadide.railroad.ide.sst.document.api.DocumentVersion} parsed into the tree.
  * <p>
  * Prefer this package when writing inspections. It gives you:
  * <ul>

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/package-info.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/api/package-info.java
@@ -6,11 +6,9 @@
  * dev.railroadide.railroad.ide.sst.syntax.api.SyntaxToken} instances. Kind identifiers are
  * stable strings such as {@code JAVA_CLASS_DECLARATION} and {@code JAVA_IDENTIFIER}. Nodes
  * preserve token boundaries, offsets, parent/child links, and parser recovery details.
- * Every tree also carries the stable {@link
- * dev.railroadide.railroad.ide.sst.document.api.DocumentId} of the logical document it
- * represents and its current {@link
- * dev.railroadide.railroad.ide.sst.document.api.DocumentUri}, plus the immutable {@link
- * dev.railroadide.railroad.ide.sst.document.api.DocumentVersion} parsed into the tree.
+ * Every tree also carries the exact immutable {@link
+ * dev.railroadide.railroad.ide.sst.document.api.TextDocumentSnapshot} parsed into its
+ * root, including logical identity, current URI, version, language, encoding, and text.
  * <p>
  * Prefer this package when writing inspections. It gives you:
  * <ul>

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/internal/SyntaxInternalFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/internal/SyntaxInternalFactory.java
@@ -2,6 +2,7 @@ package dev.railroadide.railroad.ide.sst.syntax.internal;
 
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
+import dev.railroadide.railroad.ide.sst.document.api.DocumentVersion;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxKind;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxNode;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxTree;
@@ -41,11 +42,21 @@ public final class SyntaxInternalFactory {
         DocumentUri documentUri,
         List<? extends GreenElement> children
     ) {
+        return treeFromRootChildren(documentId, documentUri, DocumentVersion.initial(), children);
+    }
+
+    public static SyntaxTree treeFromRootChildren(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        DocumentVersion documentVersion,
+        List<? extends GreenElement> children
+    ) {
         Objects.requireNonNull(documentId, "documentId");
         Objects.requireNonNull(documentUri, "documentUri");
+        Objects.requireNonNull(documentVersion, "documentVersion");
         Objects.requireNonNull(children, "children");
         GreenNode rootGreen = GreenNode.root(children);
-        var tree = new SyntaxTree(documentId, documentUri, RedFactory.root(rootGreen));
+        var tree = new SyntaxTree(documentId, documentUri, documentVersion, RedFactory.root(rootGreen));
         SyntaxTreeValidator.validate(tree.root());
         return tree;
     }
@@ -59,9 +70,24 @@ public final class SyntaxInternalFactory {
     }
 
     public static SyntaxTree treeFromGreenRoot(DocumentId documentId, DocumentUri documentUri, GreenNode root) {
+        return treeFromGreenRoot(documentId, documentUri, DocumentVersion.initial(), root);
+    }
+
+    public static SyntaxTree treeFromGreenRoot(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        DocumentVersion documentVersion,
+        GreenNode root
+    ) {
         Objects.requireNonNull(documentId, "documentId");
         Objects.requireNonNull(documentUri, "documentUri");
-        var tree = new SyntaxTree(documentId, documentUri, RedFactory.root(Objects.requireNonNull(root, "root")));
+        Objects.requireNonNull(documentVersion, "documentVersion");
+        var tree = new SyntaxTree(
+            documentId,
+            documentUri,
+            documentVersion,
+            RedFactory.root(Objects.requireNonNull(root, "root"))
+        );
         SyntaxTreeValidator.validate(tree.root());
         return tree;
     }

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/internal/SyntaxInternalFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/internal/SyntaxInternalFactory.java
@@ -3,6 +3,7 @@ package dev.railroadide.railroad.ide.sst.syntax.internal;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentVersion;
+import dev.railroadide.railroad.ide.sst.document.api.TextDocumentSnapshot;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxKind;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxNode;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxTree;
@@ -61,6 +62,18 @@ public final class SyntaxInternalFactory {
         return tree;
     }
 
+    public static SyntaxTree treeFromRootChildren(
+        TextDocumentSnapshot documentSnapshot,
+        List<? extends GreenElement> children
+    ) {
+        Objects.requireNonNull(documentSnapshot, "documentSnapshot");
+        Objects.requireNonNull(children, "children");
+        GreenNode rootGreen = GreenNode.root(children);
+        var tree = new SyntaxTree(documentSnapshot, RedFactory.root(rootGreen));
+        SyntaxTreeValidator.validate(tree.root());
+        return tree;
+    }
+
     public static SyntaxTree treeFromGreenRoot(GreenNode root) {
         return treeFromGreenRoot(DocumentId.create(), root);
     }
@@ -92,6 +105,16 @@ public final class SyntaxInternalFactory {
         return tree;
     }
 
+    public static SyntaxTree treeFromGreenRoot(TextDocumentSnapshot documentSnapshot, GreenNode root) {
+        Objects.requireNonNull(documentSnapshot, "documentSnapshot");
+        var tree = new SyntaxTree(
+            documentSnapshot,
+            RedFactory.root(Objects.requireNonNull(root, "root"))
+        );
+        SyntaxTreeValidator.validate(tree.root());
+        return tree;
+    }
+
     public static GreenNode greenRoot(SyntaxTree tree) {
         Objects.requireNonNull(tree, "tree");
         return greenNode(tree.root());
@@ -111,5 +134,24 @@ public final class SyntaxInternalFactory {
             return redElement.green();
 
         throw new IllegalArgumentException("syntax node is not backed by internal red element: " + node.getClass().getName());
+    }
+
+    public static String sourceText(GreenElement element) {
+        Objects.requireNonNull(element, "element");
+        var text = new StringBuilder(element.width());
+        appendSourceText(element, text);
+        return text.toString();
+    }
+
+    private static void appendSourceText(GreenElement element, StringBuilder text) {
+        if (element instanceof GreenToken token) {
+            text.append(token.text());
+            return;
+        }
+
+        GreenNode node = (GreenNode) element;
+        for (GreenElement child : node.children()) {
+            appendSourceText(child, text);
+        }
     }
 }

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/internal/SyntaxInternalFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/internal/SyntaxInternalFactory.java
@@ -1,6 +1,7 @@
 package dev.railroadide.railroad.ide.sst.syntax.internal;
 
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
+import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxKind;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxNode;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxTree;
@@ -32,10 +33,19 @@ public final class SyntaxInternalFactory {
     }
 
     public static SyntaxTree treeFromRootChildren(DocumentId documentId, List<? extends GreenElement> children) {
+        return treeFromRootChildren(documentId, DocumentUri.inMemory(documentId), children);
+    }
+
+    public static SyntaxTree treeFromRootChildren(
+        DocumentId documentId,
+        DocumentUri documentUri,
+        List<? extends GreenElement> children
+    ) {
         Objects.requireNonNull(documentId, "documentId");
+        Objects.requireNonNull(documentUri, "documentUri");
         Objects.requireNonNull(children, "children");
         GreenNode rootGreen = GreenNode.root(children);
-        var tree = new SyntaxTree(documentId, RedFactory.root(rootGreen));
+        var tree = new SyntaxTree(documentId, documentUri, RedFactory.root(rootGreen));
         SyntaxTreeValidator.validate(tree.root());
         return tree;
     }
@@ -45,8 +55,13 @@ public final class SyntaxInternalFactory {
     }
 
     public static SyntaxTree treeFromGreenRoot(DocumentId documentId, GreenNode root) {
+        return treeFromGreenRoot(documentId, DocumentUri.inMemory(documentId), root);
+    }
+
+    public static SyntaxTree treeFromGreenRoot(DocumentId documentId, DocumentUri documentUri, GreenNode root) {
         Objects.requireNonNull(documentId, "documentId");
-        var tree = new SyntaxTree(documentId, RedFactory.root(Objects.requireNonNull(root, "root")));
+        Objects.requireNonNull(documentUri, "documentUri");
+        var tree = new SyntaxTree(documentId, documentUri, RedFactory.root(Objects.requireNonNull(root, "root")));
         SyntaxTreeValidator.validate(tree.root());
         return tree;
     }

--- a/src/main/java/dev/railroadide/railroad/ide/sst/syntax/internal/SyntaxInternalFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/sst/syntax/internal/SyntaxInternalFactory.java
@@ -1,5 +1,6 @@
 package dev.railroadide.railroad.ide.sst.syntax.internal;
 
+import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxKind;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxNode;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxTree;
@@ -27,15 +28,25 @@ public final class SyntaxInternalFactory {
     }
 
     public static SyntaxTree treeFromRootChildren(List<? extends GreenElement> children) {
+        return treeFromRootChildren(DocumentId.create(), children);
+    }
+
+    public static SyntaxTree treeFromRootChildren(DocumentId documentId, List<? extends GreenElement> children) {
+        Objects.requireNonNull(documentId, "documentId");
         Objects.requireNonNull(children, "children");
         GreenNode rootGreen = GreenNode.root(children);
-        SyntaxTree tree = new SyntaxTree(RedFactory.root(rootGreen));
+        var tree = new SyntaxTree(documentId, RedFactory.root(rootGreen));
         SyntaxTreeValidator.validate(tree.root());
         return tree;
     }
 
     public static SyntaxTree treeFromGreenRoot(GreenNode root) {
-        SyntaxTree tree = new SyntaxTree(RedFactory.root(Objects.requireNonNull(root, "root")));
+        return treeFromGreenRoot(DocumentId.create(), root);
+    }
+
+    public static SyntaxTree treeFromGreenRoot(DocumentId documentId, GreenNode root) {
+        Objects.requireNonNull(documentId, "documentId");
+        var tree = new SyntaxTree(documentId, RedFactory.root(Objects.requireNonNull(root, "root")));
         SyntaxTreeValidator.validate(tree.root());
         return tree;
     }

--- a/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdTest.java
@@ -1,0 +1,37 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DocumentIdTest {
+    @Test
+    void freshlyAllocatedIdsAreDistinct() {
+        assertNotEquals(DocumentId.create(), DocumentId.create());
+    }
+
+    @Test
+    void externalFormRoundTrips() {
+        DocumentId original = new DocumentId(UUID.fromString("12345678-1234-5678-9abc-def012345678"));
+
+        assertEquals("12345678-1234-5678-9abc-def012345678", original.toString());
+        assertEquals(original, DocumentId.parse(original.toString()));
+        assertEquals(original, DocumentId.parse("  " + original + "  "));
+    }
+
+    @Test
+    void rejectsInvalidExternalForms() {
+        assertThrows(NullPointerException.class, () -> DocumentId.parse(null));
+        assertThrows(IllegalArgumentException.class, () -> DocumentId.parse("  "));
+        assertThrows(IllegalArgumentException.class, () -> DocumentId.parse("not-a-document-id"));
+    }
+
+    @Test
+    void rejectsNullUuid() {
+        assertThrows(NullPointerException.class, () -> new DocumentId(null));
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistryTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistryTest.java
@@ -56,6 +56,37 @@ class DocumentIdentityRegistryTest {
         DocumentId inMemoryBinary = registry.create();
 
         assertNotEquals(generatedText, inMemoryBinary);
+        assertEquals(DocumentVersion.initial(), registry.currentVersion(generatedText));
+        assertEquals(DocumentVersion.initial(), registry.currentVersion(inMemoryBinary));
+    }
+
+    @Test
+    void versionsAdvanceAtomicallyForOneDocument() {
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+        DocumentId documentId = registry.create();
+
+        Set<DocumentVersion> allocated = IntStream.range(0, 100)
+            .parallel()
+            .mapToObj(index -> registry.advanceVersion(documentId))
+            .collect(Collectors.toSet());
+
+        assertEquals(100, allocated.size());
+        assertEquals(new DocumentVersion(100), registry.currentVersion(documentId));
+    }
+
+    @Test
+    void persistedVersionsCanOnlyBeRestoredForward() {
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+        DocumentId documentId = DocumentId.create();
+
+        registry.restoreVersion(documentId, new DocumentVersion(10));
+        registry.restoreVersion(documentId, new DocumentVersion(12));
+
+        assertEquals(new DocumentVersion(12), registry.currentVersion(documentId));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> registry.restoreVersion(documentId, new DocumentVersion(11))
+        );
     }
 
     @Test
@@ -98,11 +129,13 @@ class DocumentIdentityRegistryTest {
         DocumentUri current = DocumentUri.virtual("generated", "second/Generated.java");
         DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
         DocumentId documentId = registry.getOrCreate(previous);
+        DocumentVersion version = registry.advanceVersion(documentId);
 
         registry.rebind(documentId, previous, current);
 
         assertTrue(registry.find(previous).isEmpty());
         assertEquals(documentId, registry.find(current).orElseThrow());
+        assertEquals(version, registry.currentVersion(documentId));
     }
 
     @Test
@@ -151,5 +184,14 @@ class DocumentIdentityRegistryTest {
         DocumentId replacement = registry.getOrCreate(file);
 
         assertNotEquals(released, replacement);
+        assertThrows(IllegalStateException.class, () -> registry.currentVersion(released));
+        assertThrows(
+            IllegalStateException.class,
+            () -> registry.associate(released, DocumentUri.virtual("memory", "released"))
+        );
+        assertThrows(
+            IllegalStateException.class,
+            () -> registry.restoreVersion(released, new DocumentVersion(100))
+        );
     }
 }

--- a/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistryTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistryTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DocumentIdentityRegistryTest {
     @TempDir
@@ -66,6 +67,42 @@ class DocumentIdentityRegistryTest {
         registry.associate(documentId, generatedOutput);
 
         assertEquals(documentId, registry.getOrCreate(generatedOutput));
+    }
+
+    @Test
+    void fileUriAndPathResolveToTheSameIdentity() throws IOException {
+        Path file = Files.writeString(tempDirectory.resolve("Physical.java"), "class Physical {}");
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+
+        DocumentId fromPath = registry.getOrCreate(file);
+        DocumentId fromUri = registry.getOrCreate(DocumentUri.fromPath(file));
+
+        assertEquals(fromPath, fromUri);
+    }
+
+    @Test
+    void virtualUriResolutionIsStableAndIndependent() {
+        DocumentUri generated = DocumentUri.virtual("generated", "demo/Generated.java");
+        DocumentUri inMemory = DocumentUri.virtual("memory", "demo/Generated.java");
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+
+        DocumentId generatedId = registry.getOrCreate(generated);
+
+        assertEquals(generatedId, registry.getOrCreate(generated));
+        assertNotEquals(generatedId, registry.getOrCreate(inMemory));
+    }
+
+    @Test
+    void rebindPreservesIdentityAcrossVirtualUriChanges() {
+        DocumentUri previous = DocumentUri.virtual("generated", "first/Generated.java");
+        DocumentUri current = DocumentUri.virtual("generated", "second/Generated.java");
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+        DocumentId documentId = registry.getOrCreate(previous);
+
+        registry.rebind(documentId, previous, current);
+
+        assertTrue(registry.find(previous).isEmpty());
+        assertEquals(documentId, registry.find(current).orElseThrow());
     }
 
     @Test

--- a/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistryTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentIdentityRegistryTest.java
@@ -1,0 +1,118 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DocumentIdentityRegistryTest {
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void normalizedAndAbsoluteSpellingsShareOneIdentity() throws IOException {
+        Path nested = Files.createDirectories(tempDirectory.resolve("nested"));
+        Path file = Files.writeString(tempDirectory.resolve("Example.java"), "class Example {}");
+        Path alternateSpelling = nested.resolve("..").resolve(file.getFileName());
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+
+        DocumentId first = registry.getOrCreate(file);
+        DocumentId second = registry.getOrCreate(alternateSpelling);
+
+        assertEquals(first, second);
+        assertEquals(first, registry.find(file.toAbsolutePath()).orElseThrow());
+    }
+
+    @Test
+    void physicalAliasesShareOneIdentity() throws IOException {
+        Path file = Files.writeString(tempDirectory.resolve("source.bin"), "content");
+        Path hardLink = tempDirectory.resolve("alias.bin");
+        try {
+            Files.createLink(hardLink, file);
+        } catch (UnsupportedOperationException | SecurityException | IOException ignored) {
+            org.junit.jupiter.api.Assumptions.abort("Hard links are unavailable on this filesystem");
+        }
+
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+        assertEquals(registry.getOrCreate(file), registry.getOrCreate(hardLink));
+    }
+
+    @Test
+    void pathlessDocumentsReceiveIndependentIdentities() {
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+
+        DocumentId generatedText = registry.create();
+        DocumentId inMemoryBinary = registry.create();
+
+        assertNotEquals(generatedText, inMemoryBinary);
+    }
+
+    @Test
+    void explicitAssociationSupportsPathlessDocumentsThatGainALocation() throws IOException {
+        Path generatedOutput = Files.writeString(tempDirectory.resolve("Generated.java"), "class Generated {}");
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+        DocumentId documentId = registry.create();
+
+        registry.associate(documentId, generatedOutput);
+
+        assertEquals(documentId, registry.getOrCreate(generatedOutput));
+    }
+
+    @Test
+    void rebindPreservesIdentityAcrossRename() throws IOException {
+        Path previous = Files.writeString(tempDirectory.resolve("Before.java"), "class Before {}");
+        Path renamed = tempDirectory.resolve("After.java");
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+        DocumentId documentId = registry.getOrCreate(previous);
+
+        Files.move(previous, renamed);
+        registry.rebind(documentId, previous, renamed);
+
+        assertFalse(registry.find(previous).isPresent());
+        assertEquals(documentId, registry.find(renamed).orElseThrow());
+    }
+
+    @Test
+    void conflictingAssociationIsRejected() throws IOException {
+        Path file = Files.writeString(tempDirectory.resolve("Owned.java"), "class Owned {}");
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+        registry.getOrCreate(file);
+
+        assertThrows(IllegalStateException.class, () -> registry.associate(registry.create(), file));
+    }
+
+    @Test
+    void concurrentResolutionReturnsOneIdentity() throws IOException {
+        Path file = Files.writeString(tempDirectory.resolve("Concurrent.java"), "class Concurrent {}");
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+
+        Set<DocumentId> identities = IntStream.range(0, 100)
+            .parallel()
+            .mapToObj(index -> registry.getOrCreate(file))
+            .collect(Collectors.toSet());
+
+        assertEquals(1, identities.size());
+    }
+
+    @Test
+    void releaseForgetsAssociationsWithoutReusingTheIdentity() throws IOException {
+        Path file = Files.writeString(tempDirectory.resolve("Released.java"), "class Released {}");
+        DocumentIdentityRegistry registry = new DocumentIdentityRegistry();
+        DocumentId released = registry.getOrCreate(file);
+
+        registry.release(released);
+        DocumentId replacement = registry.getOrCreate(file);
+
+        assertNotEquals(released, replacement);
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentSnapshotTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentSnapshotTest.java
@@ -1,0 +1,128 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocumentSnapshotTest {
+
+    @Test
+    void rootIsSealedToTextAndBinarySnapshots() {
+        assertTrue(DocumentSnapshot.class.isSealed());
+        assertEquals(
+            Set.of(TextDocumentSnapshot.class, BinaryDocumentSnapshot.class),
+            Set.of(DocumentSnapshot.class.getPermittedSubclasses())
+        );
+    }
+
+    @Test
+    void textSnapshotCopiesMutableInputAndCarriesMetadata() {
+        DocumentId id = DocumentId.create();
+        DocumentUri uri = DocumentUri.virtual("generated", "sources/Example.java");
+        DocumentVersion version = new DocumentVersion(8);
+        StringBuilder source = new StringBuilder("class Example {}");
+
+        TextDocumentSnapshot snapshot = new TextDocumentSnapshot(
+            id,
+            uri,
+            version,
+            "java",
+            source,
+            StandardCharsets.UTF_16
+        );
+        source.replace(0, source.length(), "changed");
+
+        assertEquals(id, snapshot.id());
+        assertEquals(uri, snapshot.uri());
+        assertEquals(version, snapshot.version());
+        assertEquals("java", snapshot.languageId());
+        assertEquals("class Example {}", snapshot.text());
+        assertEquals(StandardCharsets.UTF_16, snapshot.encoding());
+    }
+
+    @Test
+    void textSnapshotAlsoAcceptsPhysicalDocumentLocations() {
+        DocumentUri physicalUri = DocumentUri.fromPath(Path.of("Example.java").toAbsolutePath());
+
+        TextDocumentSnapshot snapshot = new TextDocumentSnapshot(
+            DocumentId.create(),
+            physicalUri,
+            DocumentVersion.initial(),
+            "java",
+            "class Example {}",
+            StandardCharsets.UTF_8
+        );
+
+        assertTrue(snapshot.uri().isFile());
+    }
+
+    @Test
+    void binarySnapshotCopiesInputsAndExposesIndependentReadOnlyViews() {
+        byte[] content = {1, 2, 3, 4};
+        BinaryDocumentSnapshot snapshot = new BinaryDocumentSnapshot(
+            DocumentId.create(),
+            DocumentUri.virtual("memory", "images/icon.bin"),
+            DocumentVersion.initial(),
+            "application/octet-stream",
+            content
+        );
+        content[0] = (byte) 99;
+
+        ByteBuffer first = snapshot.bytes();
+        ByteBuffer second = snapshot.bytes();
+        assertTrue(first.isReadOnly());
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, snapshot.copyBytes());
+        assertEquals(4, snapshot.size());
+        assertEquals(1, first.get());
+        assertEquals(0, second.position());
+        assertThrows(ReadOnlyBufferException.class, () -> second.put((byte) 9));
+
+        byte[] copy = snapshot.copyBytes();
+        copy[1] = (byte) 88;
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, snapshot.copyBytes());
+    }
+
+    @Test
+    void binarySnapshotCopiesOnlyRemainingBytesWithoutMovingSourcePosition() {
+        ByteBuffer source = ByteBuffer.wrap(new byte[]{10, 20, 30, 40});
+        source.position(1);
+        source.limit(3);
+
+        BinaryDocumentSnapshot snapshot = new BinaryDocumentSnapshot(
+            DocumentId.create(),
+            DocumentUri.virtual("archive", "library.jar!/asset.dat"),
+            new DocumentVersion(2),
+            "binary",
+            source
+        );
+
+        assertEquals(1, source.position());
+        assertArrayEquals(new byte[]{20, 30}, snapshot.copyBytes());
+    }
+
+    @Test
+    void snapshotsRejectMissingMetadataAndBlankLanguages() {
+        DocumentId id = DocumentId.create();
+        DocumentUri uri = DocumentUri.inMemory(id);
+        DocumentVersion version = DocumentVersion.initial();
+
+        assertThrows(IllegalArgumentException.class, () -> new TextDocumentSnapshot(
+            id, uri, version, "  ", "", StandardCharsets.UTF_8
+        ));
+        assertThrows(NullPointerException.class, () -> new TextDocumentSnapshot(
+            id, uri, version, "java", null, StandardCharsets.UTF_8
+        ));
+        assertThrows(IllegalArgumentException.class, () -> new BinaryDocumentSnapshot(
+            id, uri, version, "\t", new byte[0]
+        ));
+        assertThrows(NullPointerException.class, () -> new BinaryDocumentSnapshot(
+            id, uri, version, "binary", (byte[]) null
+        ));
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentUriTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentUriTest.java
@@ -1,0 +1,66 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DocumentUriTest {
+    @TempDir
+    Path tempDirectory;
+
+    @Test
+    void physicalPathRoundTripsThroughFileUri() {
+        Path path = tempDirectory.resolve("folder").resolve("..").resolve("Document.java");
+
+        DocumentUri uri = DocumentUri.fromPath(path);
+
+        assertTrue(uri.isFile());
+        assertEquals(path.toAbsolutePath().normalize(), uri.filePath().orElseThrow());
+        assertEquals(uri, DocumentUri.parse(uri.toString()));
+    }
+
+    @Test
+    void supportsHierarchicalVirtualDocumentSchemes() {
+        DocumentUri uri = DocumentUri.virtual("GENERATED", "sources/My File.java");
+
+        assertEquals("generated", uri.value().getScheme());
+        assertEquals("/sources/My File.java", uri.value().getPath());
+        assertEquals("generated:/sources/My%20File.java", uri.toString());
+        assertFalse(uri.isFile());
+        assertTrue(uri.filePath().isEmpty());
+    }
+
+    @Test
+    void supportsOpaqueArchiveEntryUris() {
+        DocumentUri uri = DocumentUri.parse("jar:file:///libraries/example.jar!/demo/Example.class");
+
+        assertEquals("jar", uri.value().getScheme());
+        assertTrue(uri.value().isOpaque());
+        assertTrue(uri.filePath().isEmpty());
+    }
+
+    @Test
+    void inMemoryLocationIsStableForTheSuppliedDocumentId() {
+        DocumentId documentId = DocumentId.create();
+
+        assertEquals(DocumentUri.inMemory(documentId), DocumentUri.inMemory(documentId));
+        assertEquals("memory", DocumentUri.inMemory(documentId).value().getScheme());
+    }
+
+    @Test
+    void rejectsNullBlankMalformedAndRelativeUris() {
+        assertThrows(NullPointerException.class, () -> DocumentUri.parse(null));
+        assertThrows(IllegalArgumentException.class, () -> DocumentUri.parse("  "));
+        assertThrows(IllegalArgumentException.class, () -> DocumentUri.parse("not a URI"));
+        assertThrows(IllegalArgumentException.class, () -> DocumentUri.parse("relative/document.java"));
+        assertThrows(IllegalArgumentException.class, () -> new DocumentUri(URI.create("relative")));
+        assertThrows(IllegalArgumentException.class, () -> DocumentUri.virtual("bad scheme", "document"));
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentVersionTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/document/api/DocumentVersionTest.java
@@ -1,0 +1,49 @@
+package dev.railroadide.railroad.ide.sst.document.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DocumentVersionTest {
+    @Test
+    void initialVersionStartsAtZero() {
+        assertEquals(0, DocumentVersion.initial().value());
+    }
+
+    @Test
+    void nextProducesAStrictlyLaterVersion() {
+        DocumentVersion current = new DocumentVersion(41);
+        DocumentVersion next = current.next();
+
+        assertEquals(new DocumentVersion(42), next);
+        assertTrue(next.isAfter(current));
+        assertTrue(current.isBefore(next));
+        assertFalse(current.isAfter(next));
+    }
+
+    @Test
+    void decimalExternalFormRoundTrips() {
+        DocumentVersion version = new DocumentVersion(123456789);
+
+        assertEquals("123456789", version.toString());
+        assertEquals(version, DocumentVersion.parse(version.toString()));
+        assertEquals(version, DocumentVersion.parse("  123456789  "));
+    }
+
+    @Test
+    void rejectsInvalidVersions() {
+        assertThrows(IllegalArgumentException.class, () -> new DocumentVersion(-1));
+        assertThrows(NullPointerException.class, () -> DocumentVersion.parse(null));
+        assertThrows(IllegalArgumentException.class, () -> DocumentVersion.parse("  "));
+        assertThrows(IllegalArgumentException.class, () -> DocumentVersion.parse("1.5"));
+        assertThrows(IllegalArgumentException.class, () -> DocumentVersion.parse("-1"));
+    }
+
+    @Test
+    void failsExplicitlyAtVersionExhaustion() {
+        assertThrows(IllegalStateException.class, () -> new DocumentVersion(Long.MAX_VALUE).next());
+    }
+}

--- a/src/test/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParserTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParserTest.java
@@ -3,9 +3,11 @@ package dev.railroadide.railroad.ide.sst.impl.java;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentVersion;
+import dev.railroadide.railroad.ide.sst.document.api.TextDocumentSnapshot;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxTree;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,6 +30,33 @@ class JavaSyntaxParserTest {
         assertEquals(documentId, tree.documentId());
         assertEquals(documentUri, tree.documentUri());
         assertEquals(documentVersion, tree.documentVersion());
+    }
+
+    @Test
+    void parsesAndRetainsTheExactTextSnapshot() {
+        TextDocumentSnapshot snapshot = new TextDocumentSnapshot(
+            DocumentId.create(),
+            DocumentUri.virtual("memory", "tests/Snapshot.java"),
+            new DocumentVersion(4),
+            "java",
+            "class Snapshot {}",
+            StandardCharsets.UTF_16LE
+        );
+
+        SyntaxTree tree = JavaSyntaxParser.parse(snapshot);
+
+        assertSame(snapshot, tree.documentSnapshot());
+        assertEquals(snapshot.text(), JavaParserTestSupport.syntaxText(tree));
+        assertThrows(IllegalArgumentException.class, () -> JavaSyntaxParser.parse(
+            new TextDocumentSnapshot(
+                snapshot.id(),
+                snapshot.uri(),
+                snapshot.version(),
+                "kotlin",
+                "class Snapshot",
+                StandardCharsets.UTF_8
+            )
+        ));
     }
 
     @Test
@@ -180,6 +209,65 @@ class JavaSyntaxParserTest {
                 newSource,
                 edit
             )
+        );
+    }
+
+    @Test
+    void incrementalParseUsesSnapshotContentIdentityAndVersionAtomically() {
+        String oldSource = "class A { int value = 1; }";
+        String newSource = "class A { int value = 20; }";
+        TextDocumentSnapshot previousSnapshot = new TextDocumentSnapshot(
+            DocumentId.create(),
+            DocumentUri.virtual("memory", "tests/A.java"),
+            new DocumentVersion(5),
+            "java",
+            oldSource,
+            StandardCharsets.UTF_8
+        );
+        SyntaxTree previousTree = JavaSyntaxParser.parse(previousSnapshot);
+        TextDocumentSnapshot newSnapshot = new TextDocumentSnapshot(
+            previousSnapshot.id(),
+            DocumentUri.virtual("memory", "renamed/A.java"),
+            new DocumentVersion(9),
+            "java",
+            newSource,
+            StandardCharsets.UTF_16
+        );
+        JavaSyntaxParser.TextEdit edit = new JavaSyntaxParser.TextEdit(oldSource.indexOf("1"), 1, "20");
+
+        JavaSyntaxParser.IncrementalParseResult result =
+            JavaSyntaxParser.parseIncremental(previousTree, newSnapshot, edit);
+
+        assertSame(newSnapshot, result.tree().documentSnapshot());
+        assertEquals(newSource, JavaParserTestSupport.syntaxText(result.tree()));
+
+        TextDocumentSnapshot wrongIdentity = new TextDocumentSnapshot(
+            DocumentId.create(),
+            newSnapshot.uri(),
+            newSnapshot.version(),
+            "java",
+            newSource,
+            StandardCharsets.UTF_8
+        );
+        TextDocumentSnapshot staleVersion = new TextDocumentSnapshot(
+            previousSnapshot.id(),
+            newSnapshot.uri(),
+            previousSnapshot.version(),
+            "java",
+            newSource,
+            StandardCharsets.UTF_8
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JavaSyntaxParser.parseIncremental(previousTree, wrongIdentity, edit)
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JavaSyntaxParser.parseIncremental(previousTree, staleVersion, edit)
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JavaSyntaxParser.parseIncremental(previousTree, "not the old source", newSource, edit)
         );
     }
 

--- a/src/test/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParserTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParserTest.java
@@ -1,5 +1,6 @@
 package dev.railroadide.railroad.ide.sst.impl.java;
 
+import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxTree;
 import org.junit.jupiter.api.Test;
 
@@ -8,6 +9,15 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 class JavaSyntaxParserTest {
+
+    @Test
+    void carriesCallerSuppliedDocumentIdentity() {
+        DocumentId documentId = DocumentId.create();
+
+        SyntaxTree tree = JavaSyntaxParser.parse(documentId, "class Identified {}");
+
+        assertEquals(documentId, tree.documentId());
+    }
 
     @Test
     void roundTripsSourceTextFromSyntaxTree() {
@@ -94,6 +104,7 @@ class JavaSyntaxParserTest {
                 JavaSyntaxParser.parseIncremental(previousTree, oldSource, newSource, edit);
 
         assertFalse(result.fullReparse());
+        assertEquals(previousTree.documentId(), result.tree().documentId());
         assertTrue(result.reusePlan().candidates().size() > 0);
         assertEquals(newSource, JavaParserTestSupport.syntaxText(result.tree()));
     }
@@ -119,6 +130,7 @@ class JavaSyntaxParserTest {
                 JavaSyntaxParser.parseIncremental(previousTree, oldSource, newSource, edit);
 
         assertTrue(result.fullReparse());
+        assertEquals(previousTree.documentId(), result.tree().documentId());
         assertEquals(newSource, JavaParserTestSupport.syntaxText(result.tree()));
     }
 

--- a/src/test/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParserTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParserTest.java
@@ -2,6 +2,7 @@ package dev.railroadide.railroad.ide.sst.impl.java;
 
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
 import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
+import dev.railroadide.railroad.ide.sst.document.api.DocumentVersion;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxTree;
 import org.junit.jupiter.api.Test;
 
@@ -15,11 +16,18 @@ class JavaSyntaxParserTest {
     void carriesCallerSuppliedDocumentIdentity() {
         DocumentId documentId = DocumentId.create();
         DocumentUri documentUri = DocumentUri.virtual("memory", "tests/Identified.java");
+        DocumentVersion documentVersion = new DocumentVersion(7);
 
-        SyntaxTree tree = JavaSyntaxParser.parse(documentId, documentUri, "class Identified {}");
+        SyntaxTree tree = JavaSyntaxParser.parse(
+            documentId,
+            documentUri,
+            documentVersion,
+            "class Identified {}"
+        );
 
         assertEquals(documentId, tree.documentId());
         assertEquals(documentUri, tree.documentUri());
+        assertEquals(documentVersion, tree.documentVersion());
     }
 
     @Test
@@ -109,6 +117,7 @@ class JavaSyntaxParserTest {
         assertFalse(result.fullReparse());
         assertEquals(previousTree.documentId(), result.tree().documentId());
         assertEquals(previousTree.documentUri(), result.tree().documentUri());
+        assertEquals(previousTree.documentVersion().next(), result.tree().documentVersion());
         assertTrue(result.reusePlan().candidates().size() > 0);
         assertEquals(newSource, JavaParserTestSupport.syntaxText(result.tree()));
     }
@@ -136,7 +145,42 @@ class JavaSyntaxParserTest {
         assertTrue(result.fullReparse());
         assertEquals(previousTree.documentId(), result.tree().documentId());
         assertEquals(previousTree.documentUri(), result.tree().documentUri());
+        assertEquals(previousTree.documentVersion().next(), result.tree().documentVersion());
         assertEquals(newSource, JavaParserTestSupport.syntaxText(result.tree()));
+    }
+
+    @Test
+    void incrementalParseAcceptsOnlyALaterCallerSuppliedVersion() {
+        String oldSource = "class A { int value = 1; }";
+        String newSource = "class A { int value = 2; }";
+        DocumentVersion previousVersion = new DocumentVersion(10);
+        SyntaxTree previousTree = JavaSyntaxParser.parse(
+            DocumentId.create(),
+            DocumentUri.virtual("memory", "tests/A.java"),
+            previousVersion,
+            oldSource
+        );
+        JavaSyntaxParser.TextEdit edit = new JavaSyntaxParser.TextEdit(oldSource.indexOf("1"), 1, "2");
+
+        JavaSyntaxParser.IncrementalParseResult result = JavaSyntaxParser.parseIncremental(
+            previousTree,
+            new DocumentVersion(15),
+            oldSource,
+            newSource,
+            edit
+        );
+
+        assertEquals(new DocumentVersion(15), result.tree().documentVersion());
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JavaSyntaxParser.parseIncremental(
+                previousTree,
+                previousVersion,
+                oldSource,
+                newSource,
+                edit
+            )
+        );
     }
 
     private static long countKind(List<String> kinds, String kindId) {

--- a/src/test/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParserTest.java
+++ b/src/test/java/dev/railroadide/railroad/ide/sst/impl/java/JavaSyntaxParserTest.java
@@ -1,6 +1,7 @@
 package dev.railroadide.railroad.ide.sst.impl.java;
 
 import dev.railroadide.railroad.ide.sst.document.api.DocumentId;
+import dev.railroadide.railroad.ide.sst.document.api.DocumentUri;
 import dev.railroadide.railroad.ide.sst.syntax.api.SyntaxTree;
 import org.junit.jupiter.api.Test;
 
@@ -13,10 +14,12 @@ class JavaSyntaxParserTest {
     @Test
     void carriesCallerSuppliedDocumentIdentity() {
         DocumentId documentId = DocumentId.create();
+        DocumentUri documentUri = DocumentUri.virtual("memory", "tests/Identified.java");
 
-        SyntaxTree tree = JavaSyntaxParser.parse(documentId, "class Identified {}");
+        SyntaxTree tree = JavaSyntaxParser.parse(documentId, documentUri, "class Identified {}");
 
         assertEquals(documentId, tree.documentId());
+        assertEquals(documentUri, tree.documentUri());
     }
 
     @Test
@@ -105,6 +108,7 @@ class JavaSyntaxParserTest {
 
         assertFalse(result.fullReparse());
         assertEquals(previousTree.documentId(), result.tree().documentId());
+        assertEquals(previousTree.documentUri(), result.tree().documentUri());
         assertTrue(result.reusePlan().candidates().size() > 0);
         assertEquals(newSource, JavaParserTestSupport.syntaxText(result.tree()));
     }
@@ -131,6 +135,7 @@ class JavaSyntaxParserTest {
 
         assertTrue(result.fullReparse());
         assertEquals(previousTree.documentId(), result.tree().documentId());
+        assertEquals(previousTree.documentUri(), result.tree().documentUri());
         assertEquals(newSource, JavaParserTestSupport.syntaxText(result.tree()));
     }
 


### PR DESCRIPTION
## Summary

  Introduces the document identity and immutable snapshot foundations for the SST platform.

  - Adds stable `DocumentId` values and workspace-owned identity lifecycle management.
  - Adds `DocumentUri` support for physical files, in-memory documents, generated sources, archive entries, and other virtual documents.
  - Adds monotonic `DocumentVersion` tracking with atomic advancement and rollback protection.
  - Adds the sealed `DocumentSnapshot` contract.
  - Adds immutable `TextDocumentSnapshot` and `BinaryDocumentSnapshot` implementations.
  - Propagates document snapshots through syntax trees, Java parsing, diagnostics, semantic analysis, and incremental parsing.
  - Preserves existing parser and `SyntaxTree` entry points through compatibility defaults.
  - Documents ownership, lifecycle, failure behaviour, thread safety, and compatibility expectations.

  ## Follow-up work

  Snapshot equality, content-type modelling, line maps, and feature-provider migration remain separate roadmap items.

  Closes #158
  Closes #159
  Closes #160
  Closes #161
  Closes #162
  Closes #163