### PR TITLE
Enhance Markdown preview with image insertion and layout management

### DIFF
--- a/src/main/java/dev/railroadide/railroad/ide/language/impl/MarkdownLanguageSupport.java
+++ b/src/main/java/dev/railroadide/railroad/ide/language/impl/MarkdownLanguageSupport.java
@@ -15,7 +15,7 @@ public final class MarkdownLanguageSupport extends BaseLanguageSupport {
 
     @Override
     public EditorOpenView open(Project project, Path file) {
-        var editorPane = new MarkdownPreviewPane(file);
+        var editorPane = new MarkdownPreviewPane(file, project);
         return new EditorOpenView(editorPane, null, languageId());
     }
 }

--- a/src/main/java/dev/railroadide/railroad/ide/ui/MarkdownPreviewPane.java
+++ b/src/main/java/dev/railroadide/railroad/ide/ui/MarkdownPreviewPane.java
@@ -2,21 +2,34 @@ package dev.railroadide.railroad.ide.ui;
 
 import dev.railroadide.railroad.Railroad;
 import dev.railroadide.railroad.ide.ui.codeeditor.TextEditorPane;
+import dev.railroadide.railroad.plugin.spi.dto.Project;
+import dev.railroadide.railroad.project.data.ProjectDataStore;
 import dev.railroadide.railroad.settings.Settings;
 import dev.railroadide.railroad.theme.ThemeManager;
 import dev.railroadide.railroad.ui.RRButton;
 import dev.railroadide.railroad.ui.RRHBox;
+import dev.railroadide.railroad.ui.RRTextField;
 import dev.railroadide.railroad.ui.RRVBox;
+import dev.railroadide.railroad.ui.styling.ButtonSize;
+import dev.railroadide.railroad.ui.styling.ButtonVariant;
+import dev.railroadide.railroad.window.DialogBuilder;
+import dev.railroadide.railroad.window.WindowBuilder;
 import io.github.raghultech.markdown.javafx.preview.MarkdownWebView;
 import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.geometry.Side;
 import javafx.scene.Node;
 import javafx.scene.control.*;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.web.WebView;
+import javafx.stage.Stage;
 import lombok.Getter;
 import org.kordamp.ikonli.Ikon;
 import org.kordamp.ikonli.fontawesome6.FontAwesomeBrands;
@@ -25,11 +38,20 @@ import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 public class MarkdownPreviewPane extends RRVBox {
+    public static final Pattern NUMBERED_LIST_PATTERN = Pattern.compile("\\d+\\. \\w+");
+    public static final Pattern BULLET_LIST_PATTERN = Pattern.compile("\\* .+");
+    public static final Pattern DASH_LIST_PATTERN = Pattern.compile("- .+");
+    private static final Pattern HTML_LIST_ITEM_PATTERN = Pattern.compile("\\s*<li>.*</li>\\s*");
+
+    private static final MarkdownLayoutType DEFAULT_MARKDOWN_LAYOUT = MarkdownLayoutType.SPLIT;
+    private static final String MARKDOWN_LAYOUT_LOCATION = "markdown.json";
+
     private final MarkdownWebView preview;
-    @Getter
-    private final Path markdownFile;
+    @Getter private final Path markdownFile;
 
     private TextEditorPane textEditorPane;
     private WebView webViewPane;
@@ -38,8 +60,13 @@ public class MarkdownPreviewPane extends RRVBox {
     private final HBox markdownButtons;
     private final HBox switchButtons;
 
-    public MarkdownPreviewPane(Path markdownFile) {
+    private final Project project;
+
+    private int scrollAmount;
+
+    public MarkdownPreviewPane(Path markdownFile, Project project) {
         this.markdownFile = markdownFile;
+        this.project = project;
 
         try {
             preview = new MarkdownWebView(Files.readString(markdownFile), Railroad.getHostServicess());
@@ -59,20 +86,72 @@ public class MarkdownPreviewPane extends RRVBox {
         Settings.THEME.addListener((ignored, newThemeName) ->
             preview.setDarkMode(newThemeName.contains("dark")));
 
-        showContent(splitView(), topRow);
-    }
+        ProjectDataStore dataStore = project.getDataStore();
 
-    public Path getMarkdownFile() {
-        return markdownFile;
+        Optional<MarkdownLayout> markdownLayout = dataStore.readJson(MARKDOWN_LAYOUT_LOCATION, MarkdownLayout.class);
+
+        MarkdownLayout layout = markdownLayout.orElseGet(() -> new MarkdownLayout(DEFAULT_MARKDOWN_LAYOUT));
+        markdownButtons.setVisible(layout.layoutType() != MarkdownLayoutType.PREVIEW);
+
+        Node pane = switch (layout.layoutType()) {
+            case MarkdownLayoutType.CODE -> codeView();
+            case MarkdownLayoutType.PREVIEW -> previewView();
+            default -> splitView();
+        };
+
+        showContent(pane, topRow);
     }
 
     private TextEditorPane codeView() {
-        if (textEditorPane != null)
+        if (textEditorPane != null) {
+            restoreEditorScroll();
             return textEditorPane;
+        }
+
 
         textEditorPane = new TextEditorPane(markdownFile, "markdown");
         textEditorPane.textProperty().addListener(
             (observable, oldValue, newValue) -> preview.setContent(newValue));
+
+        textEditorPane.addEventFilter(KeyEvent.KEY_PRESSED,event -> {
+            if (event.getCode().equals(KeyCode.ENTER)) {
+                int caret = textEditorPane.getCaretPosition();
+                String upToCaret = textEditorPane.getText(0, caret);
+                String lastLine = upToCaret.substring(upToCaret.lastIndexOf("\n") + 1);
+
+                if (NUMBERED_LIST_PATTERN.matcher(lastLine).matches()) {
+                    event.consume();
+
+                    int previousLineNumber = Integer.parseInt(lastLine.split("\\.")[0]);
+                    textEditorPane.insertText(caret, "\n" + (previousLineNumber + 1) + ". ");
+                }
+
+                if (BULLET_LIST_PATTERN.matcher(lastLine).matches()){
+                    event.consume();
+
+                    textEditorPane.insertText(caret, "\n* ");
+                }
+
+                if (DASH_LIST_PATTERN.matcher(lastLine).matches()) {
+                    event.consume();
+
+                    textEditorPane.insertText(caret, "\n- ");
+                }
+
+                if (HTML_LIST_ITEM_PATTERN.matcher(lastLine).matches()) {
+                    event.consume();
+
+                    String item = "\n<li></li>";
+                    textEditorPane.insertText(caret, item);
+                    textEditorPane.moveTo(caret + "\n<li>".length());
+                }
+            }
+        });
+
+        textEditorPane.addEventFilter(ScrollEvent.SCROLL, event ->
+            scrollAmount = (int) textEditorPane.getEstimatedScrollY());
+
+        restoreEditorScroll();
 
         return textEditorPane;
     }
@@ -80,7 +159,10 @@ public class MarkdownPreviewPane extends RRVBox {
     private SplitPane splitView() {
         var splitPane = new SplitPane(codeView(), previewView());
         // ensure divider is applied after layout to avoid a 0 width child
-        Platform.runLater(() -> splitPane.setDividerPosition(0, 0.5));
+        Platform.runLater(() -> {
+            splitPane.setDividerPosition(0, 0.5);
+            restoreEditorScroll();
+        });
         return splitPane;
     }
 
@@ -92,12 +174,29 @@ public class MarkdownPreviewPane extends RRVBox {
         return webViewPane;
     }
 
+    private void switchLayout(MarkdownLayoutType layoutType) {
+        getChildren().clear();
+
+        Node pane = switch (layoutType) {
+            case CODE -> codeView();
+            case PREVIEW -> previewView();
+            case SPLIT -> splitView();
+        };
+
+        markdownButtons.setVisible(layoutType != MarkdownLayoutType.PREVIEW);
+        getChildren().addAll(topRow, pane);
+        VBox.setVgrow(pane, Priority.ALWAYS);
+    }
+
     private void showContent(Node content, HBox topRow) {
         getChildren().clear();
         getChildren().addAll(topRow, content);
         VBox.setVgrow(content, Priority.ALWAYS);
+    }
+
+    private void restoreEditorScroll() {
         if (textEditorPane != null)
-            textEditorPane.scrollToPixel(0, 0);
+            Platform.runLater(() -> textEditorPane.scrollToPixel(0, scrollAmount));
     }
 
     private HBox createViewButtons() {
@@ -109,19 +208,22 @@ public class MarkdownPreviewPane extends RRVBox {
         switchButtons.setAlignment(Pos.TOP_RIGHT);
 
         codeView.setOnAction($ -> {
-            markdownButtons.setVisible(true);
+            switchLayout(MarkdownLayoutType.CODE);
             showContent(codeView(), topRow);
+            project.getDataStore().writeJson(MARKDOWN_LAYOUT_LOCATION, new MarkdownLayout(MarkdownLayoutType.CODE));
         });
 
         splitView.setOnAction($ -> {
-            markdownButtons.setVisible(true);
+            switchLayout(MarkdownLayoutType.SPLIT);
             showContent(splitView(), topRow);
+            project.getDataStore().writeJson(MARKDOWN_LAYOUT_LOCATION, new MarkdownLayout(MarkdownLayoutType.SPLIT));
         });
 
         previewView.setOnAction($ -> {
             // hide markdown buttons in preview-only mode
-            markdownButtons.setVisible(false);
+            switchLayout(MarkdownLayoutType.PREVIEW);
             showContent(previewView(), topRow);
+            project.getDataStore().writeJson(MARKDOWN_LAYOUT_LOCATION, new MarkdownLayout(MarkdownLayoutType.PREVIEW));
         });
 
         return switchButtons;
@@ -165,13 +267,23 @@ public class MarkdownPreviewPane extends RRVBox {
         Button orderedListButton = createButton(FontAwesomeSolid.LIST_OL);
         setButtonOnAction(orderedListButton, "1. ");
 
-        //TODO implement task list in markdown
-        //Button taskListButton = createButton(FontAwesomeSolid.TASKS);
-        //setButtonOnAction(taskListButton, "- [ ]");
+        Button taskListButton = createButton(FontAwesomeSolid.TASKS);
+        setButtonOnAction(taskListButton, "- [ ]");
 
+        Button horizontalRuleButton = createButton(FontAwesomeSolid.MINUS);
+        setButtonOnAction(horizontalRuleButton, "---");
+
+        Button strikethroughButton = createButton(FontAwesomeSolid.STRIKETHROUGH);
+        setButtonOnAction(strikethroughButton, "~~", "~~");
+
+        Button codeBlockButton = createButton(FontAwesomeSolid.CODE);
+        setButtonOnAction(codeBlockButton, "```", "```");
+
+        Button imageButton = createButton(FontAwesomeSolid.IMAGE);
+        imageButton.setOnAction(event -> imageDialog());
 
         return new RRHBox(headingButton, boldButton, italicButton, quoteButton, codeButton, linkButton,
-            unorderedListButton, orderedListButton);
+            unorderedListButton, orderedListButton, taskListButton, horizontalRuleButton, strikethroughButton, codeBlockButton, imageButton);
     }
 
     private CustomMenuItem createMenuItem(int level, int[] headingFontSizes, ContextMenu headingMenu) {
@@ -185,8 +297,9 @@ public class MarkdownPreviewPane extends RRVBox {
 
         item.setOnAction($ -> {
             headingMenu.hide();
-            textEditorPane.insertText(textEditorPane.getCaretPosition(), "#".repeat(level) + " ");
-            textEditorPane.requestFocus();
+            TextEditorPane editor = editorForInsertion();
+            editor.insertText(editor.getCaretPosition(), "#".repeat(level) + " ");
+            editor.requestFocus();
         });
 
         return item;
@@ -201,21 +314,135 @@ public class MarkdownPreviewPane extends RRVBox {
 
     private void setButtonOnAction(Button button, String prefix) {
         button.setOnAction($ -> {
-            if (textEditorPane != null) {
-                textEditorPane.insertText(textEditorPane.getCaretPosition(), prefix + " ");
-                textEditorPane.requestFocus();
-            }
+            TextEditorPane editor = editorForInsertion();
+            editor.insertText(editor.getCaretPosition(), prefix + " ");
+            editor.requestFocus();
         });
     }
 
     private void setButtonOnAction(Button button, String prefix, String postfix) {
         button.setOnAction($ -> {
-            if (textEditorPane != null) {
-                int caretPosition = textEditorPane.getCaretPosition();
-                textEditorPane.insertText(caretPosition, prefix + postfix);
-                textEditorPane.moveTo(caretPosition + prefix.length());
-                textEditorPane.requestFocus();
+            TextEditorPane editor = editorForInsertion();
+            int caretPosition = editor.getCaretPosition();
+            editor.insertText(caretPosition, prefix + postfix);
+            editor.moveTo(caretPosition + prefix.length());
+            editor.requestFocus();
+        });
+    }
+
+    private TextEditorPane editorForInsertion() {
+        return textEditorPane == null ? codeView() : textEditorPane;
+    }
+
+    private void imageDialog() {
+        var altTextField = new RRTextField("railroad.markdown.image_dialog.image_alt_text", FontAwesomeSolid.IMAGE);
+        var uriTextField = new RRTextField("railroad.markdown.image_dialog.image_uri_prompt", FontAwesomeSolid.LINK);
+
+        altTextField.setPrefColumnCount(42);
+        uriTextField.setPrefColumnCount(42);
+        altTextField.getStyleClass().add("markdown-image-dialog-field");
+        uriTextField.getStyleClass().add("markdown-image-dialog-field");
+
+        if (textEditorPane != null && !textEditorPane.getSelectedText().isBlank()) {
+            altTextField.setText(textEditorPane.getSelectedText());
+        }
+
+        var form = new RRVBox(22, altTextField, uriTextField);
+        form.getStyleClass().add("markdown-image-dialog-form");
+        form.setPadding(new Insets(22, 32, 22, 32));
+
+        var cancelButton = new RRButton("railroad.generic.cancel");
+        var insertButton = new RRButton("railroad.markdown.image_dialog.insert", FontAwesomeSolid.IMAGE);
+
+        createDialogButtons(cancelButton, insertButton, uriTextField, altTextField);
+
+        var dialog = WindowBuilder.createDialog(
+            "railroad.markdown.image_dialog.heading",
+            DialogBuilder.create()
+                .title("railroad.markdown.image_dialog.heading")
+                .contentNode(form)
+                .buttons(cancelButton, insertButton)
+                .submitOnEnter(false)
+        );
+        Platform.runLater(() -> {
+            addNodeStyles(dialog);
+            dialog.getScene().getRoot().applyCss();
+            dialog.getScene().getRoot().layout();
+            dialog.sizeToScene();
+        });
+    }
+
+    private static void addNodeStyles(Stage dialog) {
+        var title = dialog.getScene().lookup(".alert-title");
+        if (title != null) {
+            title.getStyleClass().add("markdown-image-dialog-title");
+        }
+
+        var header = dialog.getScene().lookup(".alert-header");
+        if (header != null) {
+            header.getStyleClass().add("markdown-image-dialog-header");
+        }
+
+        var buttons = dialog.getScene().lookup(".alert-buttons");
+        if (buttons != null) {
+            buttons.getStyleClass().add("markdown-image-dialog-buttons");
+        }
+    }
+
+    private void createDialogButtons(RRButton cancelButton, RRButton insertButton, RRTextField uriTextField, RRTextField altTextField){
+        insertButton.setVariant(ButtonVariant.PRIMARY);
+        insertButton.setButtonSize(ButtonSize.LARGE);
+        insertButton.getStyleClass().add("markdown-image-dialog-button");
+        insertButton.setDefaultButton(true);
+        insertButton.disableProperty().bind(Bindings.createBooleanBinding(
+            () -> uriTextField.getText().trim().isEmpty(),
+            uriTextField.textProperty()
+        ));
+
+        cancelButton.setVariant(ButtonVariant.SECONDARY);
+        cancelButton.setButtonSize(ButtonSize.LARGE);
+        cancelButton.getStyleClass().add("markdown-image-dialog-button");
+
+        cancelButton.setOnAction(event -> {
+            if (insertButton.getScene().getWindow() instanceof Stage stage) {
+                stage.close();
             }
         });
+
+        insertButton.setOnAction(event -> {
+            insertMarkdownImage(altTextField.getText(), uriTextField.getText());
+            if (insertButton.getScene().getWindow() instanceof Stage stage) {
+                stage.close();
+            }
+        });
+    }
+
+    private void insertMarkdownImage(String altText, String uri) {
+        if (uri == null || uri.trim().isEmpty()) {
+            return;
+        }
+
+        uri = uri.trim()
+            .replace("\\", "\\\\")
+            .replace(")", "\\)");
+
+        altText = altText.trim()
+            .replace("\\", "\\\\")
+            .replace("[", "\\[")
+            .replace("]", "\\]");
+
+        TextEditorPane editor = editorForInsertion();
+        String markdown = "![" + altText + "](" + uri + ")";
+        IndexRange selection = editor.getSelection();
+        editor.replaceText(selection.getStart(), selection.getEnd(), markdown);
+        editor.requestFocus();
+    }
+
+    public record MarkdownLayout(MarkdownLayoutType layoutType) { }
+
+    public enum MarkdownLayoutType {
+        SPLIT,
+        PREVIEW,
+        CODE
     }
 }

--- a/src/main/resources/assets/railroad/lang/en_us.lang
+++ b/src/main/resources/assets/railroad/lang/en_us.lang
@@ -1019,3 +1019,11 @@ railroad.git.push.strategy.matching=Matching
 railroad.git.push.strategy.nothing=Nothing
 railroad.git.sync.controls.remote.none=No remotes
 railroad.git.commit.details.unknown=Unknown
+
+# =============================================================================
+# Markdown
+# =============================================================================
+railroad.markdown.image_dialog.heading=Insert Image
+railroad.markdown.image_dialog.image_alt_text=Alt Text
+railroad.markdown.image_dialog.image_uri_prompt=Image URI
+railroad.markdown.image_dialog.insert=Insert

--- a/src/main/resources/assets/railroad/styles/components/markdown-preview.css
+++ b/src/main/resources/assets/railroad/styles/components/markdown-preview.css
@@ -1,4 +1,41 @@
 .markdown-preview-heading-label {
     -fx-font-family: 'monospace';
-    -fx-padding: 6 12;
+    -fx-padding: 6px 12px;
+}
+
+.markdown-image-dialog-form {
+    -fx-spacing: 22px;
+    -fx-min-width: 560px;
+    -fx-padding: 22px 32px 28px 32px;
+}
+
+.markdown-image-dialog-title {
+    -fx-font-size: 24px;
+    -fx-font-weight: 700;
+    -fx-min-height: 44px;
+    -fx-pref-height: 44px;
+    -fx-padding: 0 0 8px 0;
+}
+
+.markdown-image-dialog-header {
+    -fx-min-height: 72px;
+    -fx-pref-height: 72px;
+    -fx-padding: 24px 0 10px 0;
+}
+
+.markdown-image-dialog-field {
+    -fx-font-size: 17px;
+    -fx-min-height: 50px;
+    -fx-pref-height: 50px;
+    -fx-padding: 12px 16px;
+}
+
+.markdown-image-dialog-button {
+    -fx-font-size: 16px;
+    -fx-min-width: 150px;
+    -fx-min-height: 46px;
+}
+
+.markdown-image-dialog-buttons {
+    -fx-padding: 14px 32px 32px 32px;
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the Markdown editing experience in the IDE. The main improvements include a new image insertion dialog for Markdown, persistent layout selection for the Markdown editor, smarter list handling in the editor, and additional formatting buttons. The changes also include UI styling updates and localization strings for the new features.

**Markdown Editing and UI Improvements**

* Added a comprehensive image insertion dialog (`imageDialog`) to the Markdown editor, allowing users to insert images with alt text and URI through a user-friendly form. This includes full keyboard and button support, form validation, and proper Markdown syntax insertion. [[1]](diffhunk://#diff-c6ed0f0e6e01c7ebc69e48e55901687b50ef8eb50fa2a1d7663436fdd36769e6L204-R447) [[2]](diffhunk://#diff-b4fae1f8d68fe3a0011f2d23e3998d01949a770d42ca70fcefb9c70b95ea6bd1R1022-R1029) [[3]](diffhunk://#diff-180cf7211d621920b6d3f51f4674174fd5b3ac5c4a985f4a57e40e312559b1d4L3-R40)
* Added new formatting buttons to the Markdown toolbar: task list, horizontal rule, strikethrough, code block, and image insertion, expanding the range of Markdown elements users can quickly insert.

**Editor Behavior and Layout Persistence**

* Implemented persistent layout selection (split/code/preview) for the Markdown editor, storing the user's last choice in the project data store and restoring it on reopen. [[1]](diffhunk://#diff-c6ed0f0e6e01c7ebc69e48e55901687b50ef8eb50fa2a1d7663436fdd36769e6R41-R54) [[2]](diffhunk://#diff-c6ed0f0e6e01c7ebc69e48e55901687b50ef8eb50fa2a1d7663436fdd36769e6L62-R165) [[3]](diffhunk://#diff-c6ed0f0e6e01c7ebc69e48e55901687b50ef8eb50fa2a1d7663436fdd36769e6L112-R226)
* Improved editor behavior for lists: when pressing Enter after a list item, the editor automatically continues the list with the correct syntax for numbered, bullet, dash, and HTML lists.

**Code Quality and UI Styling**

* Refactored button insertion logic to ensure it always operates on the correct editor instance, and added CSS styles for the new image dialog and its components for a consistent look and feel. [[1]](diffhunk://#diff-c6ed0f0e6e01c7ebc69e48e55901687b50ef8eb50fa2a1d7663436fdd36769e6L188-R302) [[2]](diffhunk://#diff-180cf7211d621920b6d3f51f4674174fd5b3ac5c4a985f4a57e40e312559b1d4L3-R40)

These changes collectively make Markdown editing more powerful, efficient, and user-friendly.