### PR TITLE
Implemented open last project feature including settings to enable or disable it

### DIFF
--- a/src/main/java/dev/railroadide/railroad/Railroad.java
+++ b/src/main/java/dev/railroadide/railroad/Railroad.java
@@ -174,10 +174,12 @@ public class Railroad extends Application {
 
             List<Project> projects = Railroad.PROJECT_MANAGER.getProjects();
 
-            Optional<Project> project = projects.stream().max(Comparator.comparingLong(Project::getLastOpened))
+            Optional<Project> optProject = projects.stream().max(Comparator.comparingLong(Project::getLastOpened))
                 .filter($ -> Boolean.TRUE.equals(Settings.OPEN_LAST_PROJECT_ON_START.getValue()));
 
-            project.ifPresentOrElse(project1 -> project1.open(primaryStage), () -> WINDOW_MANAGER.showPrimary(
+            optProject.ifPresentOrElse(
+                project -> project.open(primaryStage), 
+                () -> WINDOW_MANAGER.showPrimary(
                 primaryStage,
                 new Scene(new WelcomePane()),
                 Services.APPLICATION_INFO.getName() + " " + Services.APPLICATION_INFO.getVersion()

--- a/src/main/java/dev/railroadide/railroad/Railroad.java
+++ b/src/main/java/dev/railroadide/railroad/Railroad.java
@@ -15,6 +15,7 @@ import dev.railroadide.railroad.localization.L18n;
 import dev.railroadide.railroad.localization.Languages;
 import dev.railroadide.railroad.plugin.PluginManager;
 import dev.railroadide.railroad.plugin.defaults.DefaultEventBus;
+import dev.railroadide.railroad.plugin.spi.dto.Project;
 import dev.railroadide.railroad.plugin.spi.event.EventBus;
 import dev.railroadide.railroad.plugin.spi.events.ApplicationStartEvent;
 import dev.railroadide.railroad.plugin.spi.events.ApplicationStopEvent;
@@ -42,12 +43,16 @@ import javafx.application.Application;
 import javafx.application.HostServices;
 import javafx.application.Platform;
 import javafx.scene.Scene;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import okhttp3.OkHttpClient;
 
+import java.awt.*;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -130,7 +135,7 @@ public class Railroad extends Application {
                 try (ExecutorService executorService = HTTP_CLIENT.dispatcher().executorService()) {
                     executorService.shutdown();
                 }
-        
+
                 HTTP_CLIENT.connectionPool().evictAll();
             }))
         );
@@ -168,11 +173,21 @@ public class Railroad extends Application {
 
         try {
             SvgImageLoaderFactory.install(new PrimitiveDimensionProvider());
-            WINDOW_MANAGER.showPrimary(
+
+            List<Project> projects = Railroad.PROJECT_MANAGER.getProjects();
+
+            Optional<Project> project = projects.stream().max(Comparator.comparingLong(Project::getLastOpened))
+                .filter($ -> Boolean.TRUE.equals(Settings.OPEN_LAST_PROJECT_ON_START.getValue()));
+
+            project.ifPresentOrElse(project1 -> {
+                WINDOW_MANAGER.showPrimary(primaryStage, new Scene(new VBox()), "BEANS");
+                project1.open();
+            }, () -> WINDOW_MANAGER.showPrimary(
                 primaryStage,
                 new Scene(new WelcomePane()),
                 Services.APPLICATION_INFO.getName() + " " + Services.APPLICATION_INFO.getVersion()
-            );
+            ));
+
             LOGGER.info("Railroad started");
             EVENT_BUS.publish(new ApplicationStartEvent());
         } catch (Throwable exception) {

--- a/src/main/java/dev/railroadide/railroad/Railroad.java
+++ b/src/main/java/dev/railroadide/railroad/Railroad.java
@@ -180,9 +180,9 @@ public class Railroad extends Application {
             optProject.ifPresentOrElse(
                 project -> project.open(primaryStage), 
                 () -> WINDOW_MANAGER.showPrimary(
-                primaryStage,
-                new Scene(new WelcomePane()),
-                Services.APPLICATION_INFO.getName() + " " + Services.APPLICATION_INFO.getVersion()
+                    primaryStage,
+                    new Scene(new WelcomePane()),
+                    Services.APPLICATION_INFO.getName() + " " + Services.APPLICATION_INFO.getVersion()
             ));
 
             LOGGER.info("Railroad started");

--- a/src/main/java/dev/railroadide/railroad/Railroad.java
+++ b/src/main/java/dev/railroadide/railroad/Railroad.java
@@ -43,11 +43,9 @@ import javafx.application.Application;
 import javafx.application.HostServices;
 import javafx.application.Platform;
 import javafx.scene.Scene;
-import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import okhttp3.OkHttpClient;
 
-import java.awt.*;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -179,10 +177,7 @@ public class Railroad extends Application {
             Optional<Project> project = projects.stream().max(Comparator.comparingLong(Project::getLastOpened))
                 .filter($ -> Boolean.TRUE.equals(Settings.OPEN_LAST_PROJECT_ON_START.getValue()));
 
-            project.ifPresentOrElse(project1 -> {
-                WINDOW_MANAGER.showPrimary(primaryStage, new Scene(new VBox()), "BEANS");
-                project1.open();
-            }, () -> WINDOW_MANAGER.showPrimary(
+            project.ifPresentOrElse(project1 -> project1.open(primaryStage), () -> WINDOW_MANAGER.showPrimary(
                 primaryStage,
                 new Scene(new WelcomePane()),
                 Services.APPLICATION_INFO.getName() + " " + Services.APPLICATION_INFO.getVersion()

--- a/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
+++ b/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
@@ -193,8 +193,9 @@ public class IDESetup {
      * and notifies the plugins of the activity
      *
      * @param project The project to switch to
+     * @param stage The stage to switch to, can be null if a new stage is needed
      */
-    public static void switchToIDE(Project project) {
+    public static void switchToIDE(Project project, @Nullable Stage stage) {
         if (isSwitchingToIDE)
             return; // Prevent multiple simultaneous IDE window creations
 
@@ -203,40 +204,20 @@ public class IDESetup {
         Platform.runLater(() -> {
             try {
                 Scene ideScene = IDESetup.createIDEScene(project);
-                Stage ideStage = Railroad.WINDOW_MANAGER.getPrimaryStage();
-                ThemeManager.prepareSceneTransition(ideStage.getScene(), ideScene);
+                Stage ideStage = (stage == null) ? Railroad.WINDOW_MANAGER.getPrimaryStage() : stage;
+
                 ideStage.setTitle(Services.APPLICATION_INFO.getName() + " " + Services.APPLICATION_INFO.getVersion() + " - " + project.getAlias());
-                ideStage.setScene(ideScene);
                 ideStage.setResizable(true);
                 ideStage.setMaximized(true);
-                Railroad.WINDOW_MANAGER.setPrimaryStage(ideStage);
 
-                try {
-                    Railroad.PROJECT_MANAGER.setCurrentProject(project);
-                    Railroad.EVENT_BUS.publish(new ProjectEvent(project, ProjectEvent.EventType.OPENED));
-                } finally {
-                    isSwitchingToIDE = false;
+                if(stage == null){
+                    ThemeManager.prepareSceneTransition(ideStage.getScene(), ideScene);
+                    ideStage.setScene(ideScene);
+                    Railroad.WINDOW_MANAGER.setPrimaryStage(ideStage);
+                } else {
+                    ideStage.setScene(ideScene);
+                    Railroad.WINDOW_MANAGER.showPrimary(stage, ideScene, stage.getTitle());
                 }
-            } catch (Exception exception) {
-                isSwitchingToIDE = false;
-                throw exception;
-            }
-        });
-    }
-
-    public static void switchToIDE(Project project, Stage stage) {
-        if (isSwitchingToIDE)
-            return; // Prevent multiple simultaneous IDE window creations
-
-        isSwitchingToIDE = true;
-
-        Platform.runLater(() -> {
-            try {
-                Scene ideScene = IDESetup.createIDEScene(project);
-                stage.setTitle(Services.APPLICATION_INFO.getName() + " " + Services.APPLICATION_INFO.getVersion() + " - " + project.getAlias());
-                stage.setResizable(true);
-                stage.setMaximized(true);
-                Railroad.WINDOW_MANAGER.showPrimary(stage, ideScene, stage.getTitle());
 
                 try {
                     Railroad.PROJECT_MANAGER.setCurrentProject(project);

--- a/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
+++ b/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
@@ -210,7 +210,7 @@ public class IDESetup {
                 ideStage.setResizable(true);
                 ideStage.setMaximized(true);
 
-                if(stage == null){
+                if(stage == null) {
                     ThemeManager.prepareSceneTransition(ideStage.getScene(), ideScene);
                     ideStage.setScene(ideScene);
                     Railroad.WINDOW_MANAGER.setPrimaryStage(ideStage);

--- a/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
+++ b/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
@@ -204,7 +204,7 @@ public class IDESetup {
         Platform.runLater(() -> {
             try {
                 Scene ideScene = IDESetup.createIDEScene(project);
-                Stage ideStage = (stage == null) ? Railroad.WINDOW_MANAGER.getPrimaryStage() : stage;
+                Stage ideStage = stage == null ? Railroad.WINDOW_MANAGER.getPrimaryStage() : stage;
 
                 ideStage.setTitle(Services.APPLICATION_INFO.getName() + " " + Services.APPLICATION_INFO.getVersion() + " - " + project.getAlias());
                 ideStage.setResizable(true);

--- a/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
+++ b/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
@@ -224,6 +224,33 @@ public class IDESetup {
         });
     }
 
+    public static void switchToIDE(Project project, Stage stage) {
+        if (isSwitchingToIDE)
+            return; // Prevent multiple simultaneous IDE window creations
+
+        isSwitchingToIDE = true;
+
+        Platform.runLater(() -> {
+            try {
+                Scene ideScene = IDESetup.createIDEScene(project);
+                stage.setTitle(Services.APPLICATION_INFO.getName() + " " + Services.APPLICATION_INFO.getVersion() + " - " + project.getAlias());
+                stage.setResizable(true);
+                stage.setMaximized(true);
+                Railroad.WINDOW_MANAGER.showPrimary(stage, ideScene, stage.getTitle());
+
+                try {
+                    Railroad.PROJECT_MANAGER.setCurrentProject(project);
+                    Railroad.EVENT_BUS.publish(new ProjectEvent(project, ProjectEvent.EventType.OPENED));
+                } finally {
+                    isSwitchingToIDE = false;
+                }
+            } catch (Exception exception) {
+                isSwitchingToIDE = false;
+                throw exception;
+            }
+        });
+    }
+
 
     /**
      * Find the best tab pane for files (CodeArea) in the given parent.

--- a/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
+++ b/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
@@ -193,7 +193,7 @@ public class IDESetup {
      * and notifies the plugins of the activity
      *
      * @param project The project to switch to
-     * @param stage The stage to switch to, can be null if a new stage is needed
+     * @param stage The stage to switch to. Set to {@code null} if a new stage with a transition is required
      */
     public static void switchToIDE(Project project, @Nullable Stage stage) {
         if (isSwitchingToIDE)

--- a/src/main/java/dev/railroadide/railroad/plugin/spi/dto/Project.java
+++ b/src/main/java/dev/railroadide/railroad/plugin/spi/dto/Project.java
@@ -68,7 +68,6 @@ public interface Project extends JsonSerializable<JsonObject> {
      * 
      * @param stage The stage to use for the IDE, can be {@code null} if a new stage should be used
      */
-
     void open(@Nullable Stage stage);
 
     /**

--- a/src/main/java/dev/railroadide/railroad/plugin/spi/dto/Project.java
+++ b/src/main/java/dev/railroadide/railroad/plugin/spi/dto/Project.java
@@ -12,6 +12,7 @@ import dev.railroadide.railroad.project.facet.FacetType;
 import dev.railroadide.railroad.utility.json.JsonSerializable;
 import dev.railroadide.railroad.vcs.git.GitManager;
 import javafx.scene.image.Image;
+import javafx.stage.Stage;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -65,6 +66,8 @@ public interface Project extends JsonSerializable<JsonObject> {
      * Open the project in the IDE.
      */
     void open();
+
+    void open(Stage stage);
 
     /**
      * Get the unique identifier of the project.

--- a/src/main/java/dev/railroadide/railroad/plugin/spi/dto/Project.java
+++ b/src/main/java/dev/railroadide/railroad/plugin/spi/dto/Project.java
@@ -65,6 +65,8 @@ public interface Project extends JsonSerializable<JsonObject> {
 
     /**
      * Open the project in the IDE.
+     * 
+     * @param stage The stage to use for the IDE, can be {@code null} if a new stage should be used
      */
 
     void open(@Nullable Stage stage);

--- a/src/main/java/dev/railroadide/railroad/plugin/spi/dto/Project.java
+++ b/src/main/java/dev/railroadide/railroad/plugin/spi/dto/Project.java
@@ -13,6 +13,7 @@ import dev.railroadide.railroad.utility.json.JsonSerializable;
 import dev.railroadide.railroad.vcs.git.GitManager;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -65,9 +66,8 @@ public interface Project extends JsonSerializable<JsonObject> {
     /**
      * Open the project in the IDE.
      */
-    void open();
 
-    void open(Stage stage);
+    void open(@Nullable Stage stage);
 
     /**
      * Get the unique identifier of the project.

--- a/src/main/java/dev/railroadide/railroad/project/RailroadProject.java
+++ b/src/main/java/dev/railroadide/railroad/project/RailroadProject.java
@@ -32,6 +32,7 @@ import javafx.scene.image.Image;
 import javafx.stage.Stage;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
@@ -196,17 +197,7 @@ public class RailroadProject implements Project {
     }
 
     @Override
-    public void open() {
-        Railroad.LOGGER.debug("Opening project: {}", getPathString());
-        setLastOpened(System.currentTimeMillis());
-        Railroad.PROJECT_MANAGER.updateProjectInfo(this);
-        IDESetup.switchToIDE(this);
-        discoverFacets();
-        this.gitManager.detectRepository();
-    }
-
-    @Override
-    public void open(Stage stage){
+    public void open(@Nullable Stage stage){
         Railroad.LOGGER.debug("Opening project: {}", getPathString());
         setLastOpened(System.currentTimeMillis());
         Railroad.PROJECT_MANAGER.updateProjectInfo(this);

--- a/src/main/java/dev/railroadide/railroad/project/RailroadProject.java
+++ b/src/main/java/dev/railroadide/railroad/project/RailroadProject.java
@@ -23,12 +23,13 @@ import dev.railroadide.railroad.vcs.Repository;
 import dev.railroadide.railroad.vcs.git.GitClient;
 import dev.railroadide.railroad.vcs.git.GitManager;
 import dev.railroadide.railroad.vcs.git.execution.GitProcessRunner;
-import javafx.beans.property.*;
 import javafx.application.Platform;
+import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.scene.image.Image;
+import javafx.stage.Stage;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
@@ -200,6 +201,16 @@ public class RailroadProject implements Project {
         setLastOpened(System.currentTimeMillis());
         Railroad.PROJECT_MANAGER.updateProjectInfo(this);
         IDESetup.switchToIDE(this);
+        discoverFacets();
+        this.gitManager.detectRepository();
+    }
+
+    @Override
+    public void open(Stage stage){
+        Railroad.LOGGER.debug("Opening project: {}", getPathString());
+        setLastOpened(System.currentTimeMillis());
+        Railroad.PROJECT_MANAGER.updateProjectInfo(this);
+        IDESetup.switchToIDE(this, stage);
         discoverFacets();
         this.gitManager.detectRepository();
     }

--- a/src/main/java/dev/railroadide/railroad/project/onboarding/creation/ui/ProjectCreationPane.java
+++ b/src/main/java/dev/railroadide/railroad/project/onboarding/creation/ui/ProjectCreationPane.java
@@ -62,7 +62,7 @@ public class ProjectCreationPane extends RRBorderPane {
         Platform.runLater(() -> {
             try {
                 var project = new RailroadProject(ctx.projectDir(), ctx.data().getAsString(ProjectData.DefaultKeys.NAME));
-                IDESetup.switchToIDE(project);
+                IDESetup.switchToIDE(project, null);
             } catch (Exception exception) {
                 Railroad.LOGGER.error("Failed to open project in IDE", exception);
 

--- a/src/main/java/dev/railroadide/railroad/settings/Settings.java
+++ b/src/main/java/dev/railroadide/railroad/settings/Settings.java
@@ -263,6 +263,13 @@ public final class Settings {
         .canBeNull(false)
         .build());
 
+    public static final Setting<Boolean> OPEN_LAST_PROJECT_ON_START = registerSetting(Setting.builder(Boolean.class, "railroad:open_last_project_on_start")
+        .treePath("projects")
+        .category(SettingCategory.simple("railroad:projects.project"))
+        .codec(DefaultSettingCodecs.BOOLEAN)
+        .defaultValue(false)
+        .build());
+
     public static void initialize() {
         // intentionally empty - triggers class loading and static init
     }

--- a/src/main/java/dev/railroadide/railroad/welcome/imports/WelcomeImportProjectsPane.java
+++ b/src/main/java/dev/railroadide/railroad/welcome/imports/WelcomeImportProjectsPane.java
@@ -111,7 +111,7 @@ public class WelcomeImportProjectsPane extends RRHBox {
 
             var project = Railroad.PROJECT_MANAGER.newProject(new RailroadProject(projectDir));
             if (SettingsHandler.getValue(Settings.SWITCH_TO_IDE_AFTER_IMPORT)) {
-                Platform.runLater(() -> IDESetup.switchToIDE(project));
+                Platform.runLater(() -> IDESetup.switchToIDE(project, null));
             }
         }).exceptionally(exception -> {
             showError(exception);

--- a/src/main/resources/assets/railroad/lang/en_us.lang
+++ b/src/main/resources/assets/railroad/lang/en_us.lang
@@ -332,6 +332,12 @@ railroad.settings.projects.defaults.author.default_author.description=Set the au
 railroad.settings.projects.defaults.author.projects.default_author.title=Override default project author
 railroad.settings.projects.defaults.author.projects.default_author.description=Set the author name Railroad pre-fills during project onboarding. Leave blank to fall back to the system user name.
 
+railroad.settings.projects.project.title=Project
+railroad.settings.projects.project.description=Configure settings related to opening of projects.
+railroad.settings.projects.project.open_last_project_on_start.title=Reopen last project on startup.
+railroad.settings.projects.project.open_last_project_on_start.description=Reopen the most recently opened project when railroad starts up, skipping the welcome page.
+
+
 # Theme management
 railroad.home.settings.appearance.theme=Select a Theme
 railroad.home.settings.appearance.downloadtheme=Download themes


### PR DESCRIPTION
This pull request introduces a new feature that allows the application to automatically reopen the most recently opened project on startup, skipping the welcome page if the user has enabled this setting. It also adds the necessary infrastructure for project opening with a specific `Stage`, updates the `Project` interface, and provides localization for the new setting.

**New Feature: Reopen Last Project on Startup**
- The application now checks the `OPEN_LAST_PROJECT_ON_START` setting on startup and, if enabled, automatically opens the most recently accessed project instead of showing the welcome screen. [[1]](diffhunk://#diff-a6afe6843bfccb875a0648e2e087f63357cb24008c31563a28f3489498f0c9a4L171-R185) [[2]](diffhunk://#diff-f58e2d95b98564b298c10aadca1bdeedf29f182ed6047dd55091792dad7e66e8R266-R272)

**API and Interface Updates**
- Added an overloaded `open(Stage stage)` method to the `Project` interface and implemented it in `RailroadProject`, enabling project opening with a specified JavaFX `Stage`. [[1]](diffhunk://#diff-f2ffc715a68f7f76fe9204c628ee09bd35ceee6a21e9f9ea8f991cc2e295b694R70-R71) [[2]](diffhunk://#diff-c5e74c40ada2850dac678e3c1d809941dc2bdbcc9e337c49fb727d17217bafd5R208-R217)
- Updated the project opening logic in the main application class to use the new `open(Stage)` method when appropriate.

**IDESetup Enhancements**
- Added a new `switchToIDE(Project project, Stage stage)` method to allow switching to the IDE with a specified stage, supporting the new project opening flow.

**Localization and Settings**
- Introduced a new setting, `OPEN_LAST_PROJECT_ON_START`, with localization strings for the UI, allowing users to configure this behavior from the settings menu. [[1]](diffhunk://#diff-f58e2d95b98564b298c10aadca1bdeedf29f182ed6047dd55091792dad7e66e8R266-R272) [[2]](diffhunk://#diff-b4fae1f8d68fe3a0011f2d23e3998d01949a770d42ca70fcefb9c70b95ea6bd1R335-R340)

Fixes #93 