### PR TITLE
Add recent projects menu to file menu for quick access

### DIFF
--- a/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
@@ -1,5 +1,7 @@
 package dev.railroadide.railroad.ide.ui.setup;
 
+import dev.railroadide.railroad.Railroad;
+import dev.railroadide.railroad.plugin.spi.dto.Project;
 import dev.railroadide.railroad.utility.OperatingSystem;
 import dev.railroadide.railroad.settings.keybinds.KeybindData;
 import dev.railroadide.railroad.settings.ui.SettingsPane;
@@ -10,12 +12,15 @@ import dev.railroadide.railroad.ui.localized.LocalizedMenuItem;
 import dev.railroadide.railroad.window.WindowManager;
 import javafx.application.Platform;
 import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;
 import org.kordamp.ikonli.javafx.FontIcon;
+
+import java.util.Comparator;
 
 /**
  * Builds the main IDE menu bar with all menu items, accelerators, and icons.
@@ -32,6 +37,17 @@ public final class IDEMenuBarFactory {
         var openFileItem = new LocalizedMenuItem("railroad.menu.file.open_file");
         openFileItem.setGraphic(new FontIcon(FontAwesomeSolid.FOLDER_OPEN));
         openFileItem.setAccelerator(new KeyCodeCombination(KeyCode.O, KeyCombination.SHORTCUT_DOWN));
+
+        var recentProjects = new LocalizedMenu("railroad.menu.file.recent_projects");
+        recentProjects.setGraphic(new FontIcon(FontAwesomeSolid.FOLDER_OPEN));
+        recentProjects.getItems().addAll(Railroad.PROJECT_MANAGER.getProjects().stream()
+            .sorted(Comparator.comparingLong(Project::getLastOpened))
+            .limit(5)
+            .map(project -> {
+                MenuItem menuItem = new MenuItem(project.getAlias());
+                menuItem.setOnAction(_ -> project.open(Railroad.WINDOW_MANAGER.getPrimaryStage()));
+                return menuItem;
+            }).toList());
 
         var saveItem = new LocalizedMenuItem("railroad.menu.file.save");
         saveItem.setGraphic(new FontIcon(FontAwesomeSolid.SAVE));
@@ -116,7 +132,7 @@ public final class IDEMenuBarFactory {
         terminalItem.setAccelerator(new KeyCodeCombination(KeyCode.T, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN));
 
         var fileMenu = new LocalizedMenu("railroad.menu.file");
-        fileMenu.getItems().addAll(newFileItem, openFileItem, saveItem, saveAsItem, new SeparatorMenuItem(), exitItem);
+        fileMenu.getItems().addAll(newFileItem, openFileItem, recentProjects, saveItem, saveAsItem, new SeparatorMenuItem(), exitItem);
         fileMenu.getStyleClass().add("rr-menu");
 
         var editMenu = new LocalizedMenu("railroad.menu.edit");


### PR DESCRIPTION
This pull request enhances the IDE menu bar by adding a "Recent Projects" submenu to the File menu, allowing users to quickly access up to five of their most recently opened projects. The submenu displays project aliases and opens the selected project when clicked.

**Menu Bar Improvements:**

* Added a "Recent Projects" submenu (`recentProjects`) to the File menu, displaying up to five recently opened projects sorted by last opened time. Each entry opens the corresponding project when selected. [[1]](diffhunk://#diff-12ee25602e777c16a1e3c9e88b089c06562da139c45e60d6b5f2a8104ff81facR41-R51) [[2]](diffhunk://#diff-12ee25602e777c16a1e3c9e88b089c06562da139c45e60d6b5f2a8104ff81facL119-R135)
* Updated imports to include necessary classes for project management and menu creation. [[1]](diffhunk://#diff-12ee25602e777c16a1e3c9e88b089c06562da139c45e60d6b5f2a8104ff81facR3-R4) [[2]](diffhunk://#diff-12ee25602e777c16a1e3c9e88b089c06562da139c45e60d6b5f2a8104ff81facR15-R24)

**NOTE: Currently in broken state due to race conditions; the same project appears multiple times in the dropdown and welcome project lists due to railroad not being built to handle multiple ide windows open at once.**