### PR TITLE
Add project opening options in menu with dialog for window selection

### DIFF
--- a/src/main/java/dev/railroadide/railroad/Railroad.java
+++ b/src/main/java/dev/railroadide/railroad/Railroad.java
@@ -19,10 +19,7 @@ import dev.railroadide.railroad.plugin.spi.dto.Project;
 import dev.railroadide.railroad.plugin.spi.event.EventBus;
 import dev.railroadide.railroad.plugin.spi.events.ApplicationStartEvent;
 import dev.railroadide.railroad.plugin.spi.events.ApplicationStopEvent;
-import dev.railroadide.railroad.project.LicenseRegistry;
-import dev.railroadide.railroad.project.MappingChannelRegistry;
-import dev.railroadide.railroad.project.ProjectManager;
-import dev.railroadide.railroad.project.ProjectTypeRegistry;
+import dev.railroadide.railroad.project.*;
 import dev.railroadide.railroad.project.facet.Facet;
 import dev.railroadide.railroad.project.facet.FacetTypeAdapter;
 import dev.railroadide.railroad.settings.Settings;
@@ -172,18 +169,25 @@ public class Railroad extends Application {
         try {
             SvgImageLoaderFactory.install(new PrimitiveDimensionProvider());
 
-            List<Project> projects = Railroad.PROJECT_MANAGER.getProjects();
 
-            Optional<Project> optProject = projects.stream().max(Comparator.comparingLong(Project::getLastOpened))
-                .filter($ -> Boolean.TRUE.equals(Settings.OPEN_LAST_PROJECT_ON_START.getValue()));
+            List<Project> projects = Railroad.PROJECT_MANAGER.getProjects();
+            Optional<Project> optProject = getParameters()
+                .getNamed()
+                .entrySet()
+                .stream()
+                .filter(entry -> "project".equals(entry.getKey()))
+                .map(entry -> (Project) new RailroadProject(Path.of(entry.getValue())))
+                .findFirst()
+                .or(() -> projects.stream().max(Comparator.comparingLong(Project::getLastOpened))
+                    .filter(_ -> Boolean.TRUE.equals(Settings.OPEN_LAST_PROJECT_ON_START.getValue())));
 
             optProject.ifPresentOrElse(
-                project -> project.open(primaryStage), 
+                project -> project.open(primaryStage),
                 () -> WINDOW_MANAGER.showPrimary(
                     primaryStage,
                     new Scene(new WelcomePane()),
                     Services.APPLICATION_INFO.getName() + " " + Services.APPLICATION_INFO.getVersion()
-            ));
+                ));
 
             LOGGER.info("Railroad started");
             EVENT_BUS.publish(new ApplicationStartEvent());

--- a/src/main/java/dev/railroadide/railroad/RailroadProcessLauncher.java
+++ b/src/main/java/dev/railroadide/railroad/RailroadProcessLauncher.java
@@ -1,0 +1,101 @@
+package dev.railroadide.railroad;
+
+import dev.railroadide.railroad.utility.OperatingSystem;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class RailroadProcessLauncher {
+    private RailroadProcessLauncher() {
+    }
+
+    public static void openProject(Path projectPath) throws IOException {
+        String projectArgument =
+            "--project=" + projectPath.toAbsolutePath().normalize();
+
+        // Packaged jpackage application
+        String packagedLauncher = System.getProperty("jpackage.app-path");
+        if (packagedLauncher != null && !packagedLauncher.isBlank()) {
+            new ProcessBuilder(packagedLauncher, projectArgument).start();
+            return;
+        }
+
+        launchDevelopmentProcess(projectArgument);
+    }
+
+    private static void launchDevelopmentProcess(
+        String projectArgument
+    ) throws IOException {
+        Path javaExecutable = Path.of(
+            System.getProperty("java.home"),
+            "bin",
+            OperatingSystem.isWindows() ? "java.exe" : "java"
+        );
+
+        List<String> command = new ArrayList<>();
+        command.add(javaExecutable.toString());
+
+        // Preserve JVM options supplied by Gradle/IntelliJ.
+        for (String argument : ManagementFactory
+            .getRuntimeMXBean()
+            .getInputArguments()) {
+
+            // A second process cannot reuse the debugger's listening port.
+            if (argument.startsWith("-agentlib:jdwp=")
+                || argument.startsWith("-Xrunjdwp:")) {
+                continue;
+            }
+
+            command.add(argument);
+        }
+
+        addModulePathIfNecessary(command);
+
+        command.add("-cp");
+        command.add(System.getProperty("java.class.path"));
+        command.add(RailroadLauncher.class.getName());
+        command.add(projectArgument);
+
+        new ProcessBuilder(command)
+            .directory(Path.of(System.getProperty("user.dir")).toFile())
+            .inheritIO()
+            .start();
+    }
+
+    private static void addModulePathIfNecessary(List<String> command) {
+        boolean alreadyPresent = command.stream().anyMatch(argument ->
+            argument.equals("--module-path")
+                || argument.equals("-p")
+                || argument.startsWith("--module-path=")
+        );
+
+        if (alreadyPresent) {
+            return;
+        }
+
+        String modulePath = System.getProperty("jdk.module.path");
+        if (modulePath == null || modulePath.isBlank()) {
+            return;
+        }
+
+        command.add("--module-path");
+        command.add(modulePath);
+
+        String modules = ModuleLayer.boot()
+            .modules()
+            .stream()
+            .map(Module::getName)
+            .filter(name -> name.startsWith("javafx."))
+            .sorted()
+            .collect(Collectors.joining(","));
+
+        if (!modules.isBlank()) {
+            command.add("--add-modules");
+            command.add(modules);
+        }
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
@@ -1,14 +1,18 @@
 package dev.railroadide.railroad.ide.ui.setup;
 
 import dev.railroadide.railroad.Railroad;
+import dev.railroadide.railroad.RailroadProcessLauncher;
 import dev.railroadide.railroad.plugin.spi.dto.Project;
-import dev.railroadide.railroad.utility.OperatingSystem;
 import dev.railroadide.railroad.settings.keybinds.KeybindData;
 import dev.railroadide.railroad.settings.ui.SettingsPane;
+import dev.railroadide.railroad.ui.RRButton;
 import dev.railroadide.railroad.ui.RRMenuBar;
 import dev.railroadide.railroad.ui.localized.LocalizedCheckMenuItem;
 import dev.railroadide.railroad.ui.localized.LocalizedMenu;
 import dev.railroadide.railroad.ui.localized.LocalizedMenuItem;
+import dev.railroadide.railroad.utility.OperatingSystem;
+import dev.railroadide.railroad.window.DialogBuilder;
+import dev.railroadide.railroad.window.WindowBuilder;
 import dev.railroadide.railroad.window.WindowManager;
 import javafx.application.Platform;
 import javafx.scene.control.MenuBar;
@@ -17,10 +21,13 @@ import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
+import javafx.stage.Stage;
 import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;
 import org.kordamp.ikonli.javafx.FontIcon;
 
+import java.io.IOException;
 import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Builds the main IDE menu bar with all menu items, accelerators, and icons.
@@ -45,7 +52,34 @@ public final class IDEMenuBarFactory {
             .limit(5)
             .map(project -> {
                 MenuItem menuItem = new MenuItem(project.getAlias());
-                menuItem.setOnAction(_ -> project.open(Railroad.WINDOW_MANAGER.getPrimaryStage()));
+
+                RRButton thisWindowButton = new RRButton("This Window");
+                RRButton newWindowButton = new RRButton("New Window");
+                RRButton cancelButton = new RRButton("Cancel");
+
+                AtomicReference<Stage> dialog = new AtomicReference<>();
+
+                menuItem.setOnAction(_ -> dialog.set(WindowBuilder.createDialog("Open Project", new DialogBuilder()
+                    .title("Open Project")
+                    .content("Where would you like to open the project '" + project.getAlias() + "'?")
+                    .buttons(thisWindowButton, newWindowButton, cancelButton))));
+
+                thisWindowButton.setOnAction(_ -> {
+                    project.open(Railroad.WINDOW_MANAGER.getPrimaryStage());
+                    dialog.get().close();
+                });
+
+                newWindowButton.setOnAction(_ -> {
+                    try {
+                        RailroadProcessLauncher.openProject(project.getPath());
+                        dialog.get().close();
+                    } catch (IOException exception) {
+                        Railroad.LOGGER.error("An error occurred trying to start a new Railroad process", exception);
+                    }
+                });
+
+                cancelButton.setOnAction(_ -> dialog.get().close());
+
                 return menuItem;
             }).toList());
 

--- a/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
@@ -2,6 +2,7 @@ package dev.railroadide.railroad.ide.ui.setup;
 
 import dev.railroadide.railroad.Railroad;
 import dev.railroadide.railroad.RailroadProcessLauncher;
+import dev.railroadide.railroad.localization.L18n;
 import dev.railroadide.railroad.plugin.spi.dto.Project;
 import dev.railroadide.railroad.settings.keybinds.KeybindData;
 import dev.railroadide.railroad.settings.ui.SettingsPane;
@@ -53,15 +54,15 @@ public final class IDEMenuBarFactory {
             .map(project -> {
                 MenuItem menuItem = new MenuItem(project.getAlias());
 
-                RRButton thisWindowButton = new RRButton("This Window");
-                RRButton newWindowButton = new RRButton("New Window");
-                RRButton cancelButton = new RRButton("Cancel");
+                RRButton thisWindowButton = new RRButton("railroad.recent_projects.dialog.this_window_button");
+                RRButton newWindowButton = new RRButton("railroad.recent_projects.dialog.new_window_button");
+                RRButton cancelButton = new RRButton("railroad.recent_projects.dialog.cancel_button");
 
                 AtomicReference<Stage> dialog = new AtomicReference<>();
 
-                menuItem.setOnAction(_ -> dialog.set(WindowBuilder.createDialog("Open Project", new DialogBuilder()
-                    .title("Open Project")
-                    .content("Where would you like to open the project '" + project.getAlias() + "'?")
+                menuItem.setOnAction(_ -> dialog.set(WindowBuilder.createDialog("railroad.recent_projects.dialog.title", new DialogBuilder()
+                    .title("railroad.recent_projects.dialog.title")
+                    .content(L18n.localize("railroad.recent_projects.dialog.description", project.getAlias()))
                     .buttons(thisWindowButton, newWindowButton, cancelButton))));
 
                 thisWindowButton.setOnAction(_ -> {

--- a/src/main/resources/assets/railroad/lang/en_us.lang
+++ b/src/main/resources/assets/railroad/lang/en_us.lang
@@ -502,6 +502,7 @@ railroad.menu.file.open_file=Open File...
 railroad.menu.file.save=Save
 railroad.menu.file.save_as=Save As...
 railroad.menu.file.exit=Exit
+railroad.menu.file.recent_projects=Recent Projects
 
 railroad.menu.edit=Edit
 railroad.menu.edit.undo=Undo

--- a/src/main/resources/assets/railroad/lang/en_us.lang
+++ b/src/main/resources/assets/railroad/lang/en_us.lang
@@ -1028,14 +1028,6 @@ railroad.git.sync.controls.remote.none=No remotes
 railroad.git.commit.details.unknown=Unknown
 
 # =============================================================================
-# Markdown
-# =============================================================================
-railroad.markdown.image_dialog.heading=Insert Image
-railroad.markdown.image_dialog.image_alt_text=Alt Text
-railroad.markdown.image_dialog.image_uri_prompt=Image URI
-railroad.markdown.image_dialog.insert=Insert
-
-# =============================================================================
 # Recent Projects
 # =============================================================================
 railroad.recent_projects.dialog.title=Open Project
@@ -1043,3 +1035,11 @@ railroad.recent_projects.dialog.this_window_button=This Window
 railroad.recent_projects.dialog.new_window_button=New Window
 railroad.recent_projects.dialog.cancel_button=Cancel
 railroad.recent_projects.dialog.description=Where would you like to open the project '%s'?
+
+# =============================================================================
+# Markdown
+# =============================================================================
+railroad.markdown.image_dialog.heading=Insert Image
+railroad.markdown.image_dialog.image_alt_text=Alt Text
+railroad.markdown.image_dialog.image_uri_prompt=Image URI
+railroad.markdown.image_dialog.insert=Insert

--- a/src/main/resources/assets/railroad/lang/en_us.lang
+++ b/src/main/resources/assets/railroad/lang/en_us.lang
@@ -1034,3 +1034,12 @@ railroad.markdown.image_dialog.heading=Insert Image
 railroad.markdown.image_dialog.image_alt_text=Alt Text
 railroad.markdown.image_dialog.image_uri_prompt=Image URI
 railroad.markdown.image_dialog.insert=Insert
+
+# =============================================================================
+# Recent Projects
+# =============================================================================
+railroad.recent_projects.dialog.title=Open Project
+railroad.recent_projects.dialog.this_window_button=This Window
+railroad.recent_projects.dialog.new_window_button=New Window
+railroad.recent_projects.dialog.cancel_button=Cancel
+railroad.recent_projects.dialog.description=Where would you like to open the project '%s'?


### PR DESCRIPTION
This pull request adds the ability to open recent projects in a new window, enhancing the user experience when working with multiple projects. It introduces a dialog prompt when opening a recent project, allowing the user to choose whether to open the project in the current window or a new one. The process launching logic is encapsulated in a new utility class, ensuring both packaged and development environments are supported.

**Recent Projects Multi-Window Support:**

* Added a dialog prompt when selecting a recent project from the menu, allowing the user to choose between opening the project in the current window or a new window.
* Introduced the `RailroadProcessLauncher` utility class to encapsulate logic for launching a new application process with the selected project, supporting both packaged and development environments.
* Updated the recent projects menu to use the new dialog and launching mechanism, improving usability.

**Startup Behavior:**

* Modified project startup logic in `Railroad.java` to prioritize opening a project specified via command-line arguments before falling back to the most recently opened project.

**Code Cleanup and Localization:**

* Added a localization key for "Recent Projects" in the language resource file.
* Cleaned up imports and refactored code for maintainability. [[1]](diffhunk://#diff-a6afe6843bfccb875a0648e2e087f63357cb24008c31563a28f3489498f0c9a4L22-R22) [[2]](diffhunk://#diff-12ee25602e777c16a1e3c9e88b089c06562da139c45e60d6b5f2a8104ff81facR4-R15) [[3]](diffhunk://#diff-12ee25602e777c16a1e3c9e88b089c06562da139c45e60d6b5f2a8104ff81facR24-R30)