### PR TITLE
fix/Deduplicate projects and harden config saves

### DIFF
--- a/src/main/java/dev/railroadide/railroad/config/Config.java
+++ b/src/main/java/dev/railroadide/railroad/config/Config.java
@@ -8,7 +8,9 @@ import dev.railroadide.railroad.plugin.spi.dto.Project;
 import dev.railroadide.railroad.project.RailroadProject;
 import dev.railroadide.railroad.utility.json.JsonSerializable;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -123,6 +125,7 @@ public class Config implements JsonSerializable<JsonObject> {
         inspectionRuleTagEnabledOverrides.clear();
         inspectionRuleSeverityOverrides.clear();
 
+        List<Project> loadedProjects = new ArrayList<>();
         if (json.has("Projects")) {
             JsonElement projects = json.get("Projects");
             if (projects.isJsonArray()) {
@@ -132,9 +135,16 @@ public class Config implements JsonSerializable<JsonObject> {
                         continue;
 
                     Optional<RailroadProject> optProject = RailroadProject.createFromJson(project.getAsJsonObject());
-                    optProject.ifPresent(Railroad.PROJECT_MANAGER::newProject);
+                    optProject.ifPresent(loadedProjects::add);
                 }
             }
+        }
+        Railroad.PROJECT_MANAGER.setProjects(loadedProjects);
+        if (loadedProjects.size() != Railroad.PROJECT_MANAGER.getProjects().size()) {
+            Railroad.LOGGER.warn(
+                "Removed {} duplicate project entries while loading configuration",
+                loadedProjects.size() - Railroad.PROJECT_MANAGER.getProjects().size()
+            );
         }
 
         if (json.has("EnabledPlugins")) {

--- a/src/main/java/dev/railroadide/railroad/config/ConfigHandler.java
+++ b/src/main/java/dev/railroadide/railroad/config/ConfigHandler.java
@@ -5,8 +5,10 @@ import dev.railroadide.railroad.utility.OperatingSystem;
 import dev.railroadide.railroad.Railroad;
 
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 
 public final class ConfigHandler {
     private static final ConfigHandler INSTANCE = new ConfigHandler();
@@ -39,13 +41,29 @@ public final class ConfigHandler {
         };
     }
 
-    public static void saveConfig() {
+    public static synchronized void saveConfig() {
         Railroad.LOGGER.info("Updating config file");
 
         Path railroadDataPath = getConfigDirectory();
         try {
             Files.createDirectories(railroadDataPath);
-            Files.writeString(railroadDataPath.resolve("config.json"), Railroad.GSON.toJson(INSTANCE.config.toJson()));
+            Path configPath = railroadDataPath.resolve("config.json");
+            Path temporaryConfigPath = Files.createTempFile(railroadDataPath, "config-", ".json.tmp");
+            try {
+                Files.writeString(temporaryConfigPath, Railroad.GSON.toJson(INSTANCE.config.toJson()));
+                try {
+                    Files.move(
+                        temporaryConfigPath,
+                        configPath,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING
+                    );
+                } catch (AtomicMoveNotSupportedException ignored) {
+                    Files.move(temporaryConfigPath, configPath, StandardCopyOption.REPLACE_EXISTING);
+                }
+            } finally {
+                Files.deleteIfExists(temporaryConfigPath);
+            }
         } catch (IOException exception) {
             throw new IllegalStateException("Error updating config.json", exception);
         }

--- a/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
@@ -28,7 +28,6 @@ import org.kordamp.ikonli.javafx.FontIcon;
 
 import java.io.IOException;
 import java.util.Comparator;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Builds the main IDE menu bar with all menu items, accelerators, and icons.
@@ -49,38 +48,11 @@ public final class IDEMenuBarFactory {
         var recentProjects = new LocalizedMenu("railroad.menu.file.recent_projects");
         recentProjects.setGraphic(new FontIcon(FontAwesomeSolid.FOLDER_OPEN));
         recentProjects.getItems().addAll(Railroad.PROJECT_MANAGER.getProjects().stream()
-            .sorted(Comparator.comparingLong(Project::getLastOpened))
+            .sorted(Comparator.comparingLong(Project::getLastOpened).reversed())
             .limit(5)
             .map(project -> {
                 MenuItem menuItem = new MenuItem(project.getAlias());
-
-                RRButton thisWindowButton = new RRButton("railroad.recent_projects.dialog.this_window_button");
-                RRButton newWindowButton = new RRButton("railroad.recent_projects.dialog.new_window_button");
-                RRButton cancelButton = new RRButton("railroad.recent_projects.dialog.cancel_button");
-
-                AtomicReference<Stage> dialog = new AtomicReference<>();
-
-                menuItem.setOnAction(_ -> dialog.set(WindowBuilder.createDialog("railroad.recent_projects.dialog.title", new DialogBuilder()
-                    .title("railroad.recent_projects.dialog.title")
-                    .content(L18n.localize("railroad.recent_projects.dialog.description", project.getAlias()))
-                    .buttons(thisWindowButton, newWindowButton, cancelButton))));
-
-                thisWindowButton.setOnAction(_ -> {
-                    project.open(Railroad.WINDOW_MANAGER.getPrimaryStage());
-                    dialog.get().close();
-                });
-
-                newWindowButton.setOnAction(_ -> {
-                    try {
-                        RailroadProcessLauncher.openProject(project.getPath());
-                        dialog.get().close();
-                    } catch (IOException exception) {
-                        Railroad.LOGGER.error("An error occurred trying to start a new Railroad process", exception);
-                    }
-                });
-
-                cancelButton.setOnAction(_ -> dialog.get().close());
-
+                menuItem.setOnAction(_ -> showOpenProjectDialog(project));
                 return menuItem;
             }).toList());
 
@@ -208,5 +180,32 @@ public final class IDEMenuBarFactory {
         }
         menuBar.getStyleClass().add("rr-menu-bar");
         return menuBar;
+    }
+
+    private static void showOpenProjectDialog(Project project) {
+        var thisWindowButton = new RRButton("railroad.recent_projects.dialog.this_window_button");
+        var newWindowButton = new RRButton("railroad.recent_projects.dialog.new_window_button");
+        var cancelButton = new RRButton("railroad.recent_projects.dialog.cancel_button");
+
+        Stage dialog = WindowBuilder.createDialog("railroad.recent_projects.dialog.title", new DialogBuilder()
+            .title("railroad.recent_projects.dialog.title")
+            .content(L18n.localize("railroad.recent_projects.dialog.description", project.getAlias()))
+            .buttons(thisWindowButton, newWindowButton, cancelButton));
+
+        thisWindowButton.setOnAction(_ -> {
+            project.open(Railroad.WINDOW_MANAGER.getPrimaryStage());
+            dialog.close();
+        });
+
+        newWindowButton.setOnAction(_ -> {
+            try {
+                RailroadProcessLauncher.openProject(project.getPath());
+                dialog.close();
+            } catch (IOException exception) {
+                Railroad.LOGGER.error("An error occurred trying to start a new Railroad process", exception);
+            }
+        });
+
+        cancelButton.setOnAction(_ -> dialog.close());
     }
 }

--- a/src/main/java/dev/railroadide/railroad/project/ProjectManager.java
+++ b/src/main/java/dev/railroadide/railroad/project/ProjectManager.java
@@ -8,55 +8,82 @@ import javafx.collections.ObservableList;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.Path;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 @Getter
 public final class ProjectManager {
     private final ObservableList<Project> projects = FXCollections.observableArrayList();
+    private final Runnable configSaver;
     @Getter
     private Project openProject;
 
-    public void updateProjectInfo(Project project) {
-        updateProjectInfo(project, false);
+    public ProjectManager() {
+        this(ConfigHandler::saveConfig);
     }
 
-    public void updateProjectInfo(Project project, boolean removeProject) {
+    ProjectManager(Runnable configSaver) {
+        this.configSaver = Objects.requireNonNull(configSaver, "configSaver");
+    }
+
+    public Project updateProjectInfo(Project project) {
+        Objects.requireNonNull(project, "project");
         Railroad.LOGGER.info("Starting project update: {}", project.getId());
-        boolean found = false;
-        if (removeProject) {
-            Railroad.LOGGER.info("Removing project: {}", project.getId());
-            projects.removeIf(projectObj -> projectObj.getId().equals(project.getId()));
-            ConfigHandler.saveConfig();
-            return;
+
+        Optional<Project> existingProject = findProject(project.getPath());
+        if (existingProject.isPresent()) {
+            Project existing = existingProject.get();
+            existing.setLastOpened(project.getLastOpened());
+            Railroad.LOGGER.info("Updated project: {} last opened to: {}", existing.getId(), project.getLastOpened());
+            configSaver.run();
+            return existing;
         }
 
-        for (Project projectObj : projects) {
-            if (projectObj.getId().equals(project.getId())) {
-                found = true;
-                projectObj.setLastOpened(project.getLastOpened());
-                Railroad.LOGGER.info("Starting update project: {} last opened to: {}", project.getId(), project.getLastOpened());
-            }
-        }
-
-        if (!found) {
-            Railroad.LOGGER.info("Create new Project");
-            projects.add(project);
-        }
-
-        ConfigHandler.saveConfig();
-    }
-
-    public void setProjects(Collection<? extends Project> projectCollection) {
-        this.projects.setAll(projectCollection);
-    }
-
-    public Project newProject(Project project) {
-        updateProjectInfo(project);
+        Railroad.LOGGER.info("Creating new project entry for: {}", project.getPath());
+        projects.add(project);
+        configSaver.run();
         return project;
     }
 
+    public Optional<Project> findProject(Path path) {
+        String pathKey = ProjectPathIdentity.key(path);
+        return projects.stream()
+            .filter(project -> ProjectPathIdentity.key(project.getPath()).equals(pathKey))
+            .findFirst();
+    }
+
+    public void setProjects(Collection<? extends Project> projectCollection) {
+        Objects.requireNonNull(projectCollection, "projectCollection");
+
+        Map<String, Project> projectsByPath = new LinkedHashMap<>();
+        for (Project project : projectCollection) {
+            if (project == null)
+                continue;
+
+            String pathKey = ProjectPathIdentity.key(project.getPath());
+            Project existing = projectsByPath.get(pathKey);
+            if (existing == null || project.getLastOpened() > existing.getLastOpened()) {
+                projectsByPath.put(pathKey, project);
+            }
+        }
+
+        this.projects.setAll(projectsByPath.values());
+    }
+
+    public Project newProject(Project project) {
+        return updateProjectInfo(project);
+    }
+
     public void removeProject(Project project) {
-        updateProjectInfo(project, true);
+        Objects.requireNonNull(project, "project");
+        Railroad.LOGGER.info("Removing project: {}", project.getId());
+        String pathKey = ProjectPathIdentity.key(project.getPath());
+        projects.removeIf(projectObj -> ProjectPathIdentity.key(projectObj.getPath()).equals(pathKey));
+        configSaver.run();
     }
 
     public void setCurrentProject(@Nullable Project project) {

--- a/src/main/java/dev/railroadide/railroad/project/ProjectPathIdentity.java
+++ b/src/main/java/dev/railroadide/railroad/project/ProjectPathIdentity.java
@@ -1,0 +1,31 @@
+package dev.railroadide.railroad.project;
+
+import dev.railroadide.railroad.utility.OperatingSystem;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class ProjectPathIdentity {
+    private ProjectPathIdentity() {
+    }
+
+    public static Path normalize(Path path) {
+        Path normalized = Objects.requireNonNull(path, "path").toAbsolutePath().normalize();
+        try {
+            return normalized.toRealPath();
+        } catch (IOException ignored) {
+            return normalized;
+        }
+    }
+
+    public static String key(Path path) {
+        String key = normalize(path).toString();
+        return OperatingSystem.isWindows() ? key.toLowerCase(Locale.ROOT) : key;
+    }
+
+    public static boolean matches(Path first, Path second) {
+        return key(first).equals(key(second));
+    }
+}

--- a/src/main/java/dev/railroadide/railroad/project/RailroadProject.java
+++ b/src/main/java/dev/railroadide/railroad/project/RailroadProject.java
@@ -74,7 +74,7 @@ public class RailroadProject implements Project {
     }
 
     public RailroadProject(Path path, String alias, Image icon) {
-        this.path.set(path);
+        this.path.set(ProjectPathIdentity.normalize(path));
         this.alias.set(alias);
         this.icon.set(icon == null ? createIcon() : icon);
         this.dataStore = new ProjectDataStore(this);
@@ -200,10 +200,12 @@ public class RailroadProject implements Project {
     public void open(@Nullable Stage stage){
         Railroad.LOGGER.debug("Opening project: {}", getPathString());
         setLastOpened(System.currentTimeMillis());
-        Railroad.PROJECT_MANAGER.updateProjectInfo(this);
-        IDESetup.switchToIDE(this, stage);
-        discoverFacets();
-        this.gitManager.detectRepository();
+        Project project = Railroad.PROJECT_MANAGER.updateProjectInfo(this);
+        IDESetup.switchToIDE(project, stage);
+        if (project instanceof RailroadProject railroadProject) {
+            railroadProject.discoverFacets();
+        }
+        project.getGitManager().detectRepository();
     }
 
     @Override
@@ -220,12 +222,12 @@ public class RailroadProject implements Project {
             return false;
 
         RailroadProject project = (RailroadProject) obj;
-        return path.equals(project.path);
+        return ProjectPathIdentity.matches(getPath(), project.getPath());
     }
 
     @Override
     public int hashCode() {
-        return path.hashCode();
+        return ProjectPathIdentity.key(getPath()).hashCode();
     }
 
     @Override
@@ -272,10 +274,10 @@ public class RailroadProject implements Project {
             if (pathElement.isJsonPrimitive()) {
                 JsonPrimitive pathPrimitive = pathElement.getAsJsonPrimitive();
                 if (pathPrimitive.isString()) {
-                    this.path.set(Path.of(pathElement.getAsString()));
+                    this.path.set(ProjectPathIdentity.normalize(Path.of(pathElement.getAsString())));
                 } else if (pathPrimitive.isNumber()) {
                     try {
-                        this.path.set(Path.of(String.valueOf(pathPrimitive.getAsNumber())));
+                        this.path.set(ProjectPathIdentity.normalize(Path.of(String.valueOf(pathPrimitive.getAsNumber()))));
                     } catch (Exception exception) {
                         Railroad.LOGGER.warn("Project JSON 'Path' is not a valid path: {}", pathElement, exception);
                     }

--- a/src/main/java/dev/railroadide/railroad/project/onboarding/creation/ui/ProjectCreationPane.java
+++ b/src/main/java/dev/railroadide/railroad/project/onboarding/creation/ui/ProjectCreationPane.java
@@ -1,7 +1,6 @@
 package dev.railroadide.railroad.project.onboarding.creation.ui;
 
 import dev.railroadide.railroad.Railroad;
-import dev.railroadide.railroad.ide.IDESetup;
 import dev.railroadide.railroad.project.ProjectContext;
 import dev.railroadide.railroad.project.ProjectData;
 import dev.railroadide.railroad.project.RailroadProject;
@@ -62,7 +61,7 @@ public class ProjectCreationPane extends RRBorderPane {
         Platform.runLater(() -> {
             try {
                 var project = new RailroadProject(ctx.projectDir(), ctx.data().getAsString(ProjectData.DefaultKeys.NAME));
-                IDESetup.switchToIDE(project, null);
+                project.open(null);
             } catch (Exception exception) {
                 Railroad.LOGGER.error("Failed to open project in IDE", exception);
 


### PR DESCRIPTION
This PR fixes the issues presented by #593 and #594 by where opening a recent project would cause projects to duplicate. This was a fundamental issue with how projects were represented and added to the project list. We now run a deduplication pass by having each project path have an "identity", allowing us to safely normalize a path and ensure no duplications.

There is also a minor fix in here that can fix a possible exception thrown when opening the open project dialog introduced in #594  due to the re-used buttons and UI elements, which JavaFX strictly forbids.