### PR TITLE
feat: Add file creation dialog to project explorer menu

### DIFF
--- a/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
+++ b/src/main/java/dev/railroadide/railroad/ide/IDESetup.java
@@ -69,12 +69,13 @@ public class IDESetup {
      */
     public static Scene createIDEScene(Project project) {
         var root = new RRBorderPane();
-        var topBar = new RRHBox(IDEMenuBarFactory.create(), new Region(), RunControlsPane.create(project));
+        var projectExplorerPane = new ProjectExplorerPane(project, root);
+        var topBar = new RRHBox(IDEMenuBarFactory.create(projectExplorerPane), new Region(), RunControlsPane.create(project));
         HBox.setHgrow(topBar.getChildren().get(1), Priority.ALWAYS);
         root.setTop(topBar);
 
         var leftPane = new DetachableTabPane();
-        leftPane.addTab("Project", new ProjectExplorerPane(project, root));
+        leftPane.addTab("Project", projectExplorerPane);
         leftPane.addTab("Git Commit", new GitCommitPane(project));
         leftPane.addTab("Git Overview", new GitOverviewPane(project));
         leftPane.addTab("Git Commit List", new GitCommitListPane(project));

--- a/src/main/java/dev/railroadide/railroad/ide/projectexplorer/ProjectExplorerPane.java
+++ b/src/main/java/dev/railroadide/railroad/ide/projectexplorer/ProjectExplorerPane.java
@@ -791,6 +791,17 @@ public class ProjectExplorerPane extends RRVBox implements WatchTask.FileChangeL
         return true;
     }
 
+    public Path getSelectedDirectory() {
+        TreeItem<PathItem> selected =
+            treeView.getSelectionModel().getSelectedItem();
+
+        if (selected == null)
+            return project.getPath();
+
+        Path path = selected.getValue().getPath();
+        return Files.isDirectory(path) ? path : path.getParent();
+    }
+
     private record OpenTabLocation(DetachableTabPane tabPane, Tab tab) {
     }
 }

--- a/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
@@ -2,6 +2,9 @@ package dev.railroadide.railroad.ide.ui.setup;
 
 import dev.railroadide.railroad.Railroad;
 import dev.railroadide.railroad.RailroadProcessLauncher;
+import dev.railroadide.railroad.ide.projectexplorer.FileCreateType;
+import dev.railroadide.railroad.ide.projectexplorer.ProjectExplorerPane;
+import dev.railroadide.railroad.ide.projectexplorer.dialog.CreateFileDialog;
 import dev.railroadide.railroad.localization.L18n;
 import dev.railroadide.railroad.plugin.spi.dto.Project;
 import dev.railroadide.railroad.settings.keybinds.KeybindData;
@@ -23,10 +26,12 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;
 import org.kordamp.ikonli.javafx.FontIcon;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Comparator;
 
 /**
@@ -36,10 +41,15 @@ public final class IDEMenuBarFactory {
     private IDEMenuBarFactory() {
     }
 
-    public static MenuBar create() {
+    public static MenuBar create(ProjectExplorerPane projectExplorerPane) {
         var newFileItem = new LocalizedMenuItem("railroad.menu.file.new_file");
         newFileItem.setGraphic(new FontIcon(FontAwesomeSolid.FILE));
         newFileItem.setKeybindData(new KeybindData(KeyCode.N, new KeyCombination.Modifier[]{KeyCombination.SHORTCUT_DOWN}));
+        newFileItem.setOnAction(_ -> {
+            Path directoryPath = projectExplorerPane.getSelectedDirectory();
+            Window window = projectExplorerPane.getScene().getWindow();
+            CreateFileDialog.open(window, directoryPath, FileCreateType.FILE);
+        });
 
         var openFileItem = new LocalizedMenuItem("railroad.menu.file.open_file");
         openFileItem.setGraphic(new FontIcon(FontAwesomeSolid.FOLDER_OPEN));


### PR DESCRIPTION
This pull request improves the integration between the project explorer and the main menu bar, enabling context-aware file creation in the IDE. The main changes involve passing the `ProjectExplorerPane` to the menu bar so that the "New File" action opens a dialog in the currently selected directory. Additionally, a helper method was added to retrieve the selected directory from the project explorer.

**Project Explorer and Menu Bar Integration:**

* The `IDESetup` class now creates a single `ProjectExplorerPane` instance and passes it to the `IDEMenuBarFactory.create()` method, allowing the menu bar to interact with the project explorer.
* The `IDEMenuBarFactory.create()` method signature was updated to accept a `ProjectExplorerPane` argument and now uses it to determine the directory for new file creation.

**Context-Aware File Creation:**

* The "New File" menu item now opens the `CreateFileDialog` in the directory currently selected in the `ProjectExplorerPane`, making file creation context-sensitive.

**Project Explorer Helper Method:**

* A new `getSelectedDirectory()` method was added to `ProjectExplorerPane` to return the currently selected directory or the project root if none is selected.

**Dependency and Import Updates:**

* Added necessary imports for `ProjectExplorerPane`, `CreateFileDialog`, and related classes to support the new functionality. [[1]](diffhunk://#diff-12ee25602e777c16a1e3c9e88b089c06562da139c45e60d6b5f2a8104ff81facR5-R7) [[2]](diffhunk://#diff-12ee25602e777c16a1e3c9e88b089c06562da139c45e60d6b5f2a8104ff81facR29-R34)