### PR TITLE
feat: Add file opening functionality with file chooser dialog

### DIFF
--- a/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
@@ -7,6 +7,7 @@ import dev.railroadide.railroad.ide.projectexplorer.FileCreateType;
 import dev.railroadide.railroad.ide.projectexplorer.ProjectExplorerPane;
 import dev.railroadide.railroad.ide.projectexplorer.dialog.CreateFileDialog;
 import dev.railroadide.railroad.localization.L18n;
+import dev.railroadide.railroad.plugin.defaults.FileSystemDocument;
 import dev.railroadide.railroad.plugin.spi.dto.Project;
 import dev.railroadide.railroad.settings.keybinds.KeybindData;
 import dev.railroadide.railroad.settings.ui.SettingsPane;
@@ -27,10 +28,13 @@ import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
+import javafx.stage.FileChooser;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;
 import org.kordamp.ikonli.javafx.FontIcon;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -56,6 +60,21 @@ public final class IDEMenuBarFactory {
         var openFileItem = new LocalizedMenuItem("railroad.menu.file.open_file");
         openFileItem.setGraphic(new FontIcon(FontAwesomeSolid.FOLDER_OPEN));
         openFileItem.setAccelerator(new KeyCodeCombination(KeyCode.O, KeyCombination.SHORTCUT_DOWN));
+        openFileItem.setOnAction(_ -> {
+            Path directoryPath = Services.UI_MANAGER.lookup(UIIds.IDE.PROJECT_EXPLORER)
+                .map(ProjectExplorerPane::getSelectedDirectory)
+                .orElseGet(project::getPath);
+            Window window = Railroad.WINDOW_MANAGER.getPrimaryStage();
+            FileChooser fileChooser = new FileChooser();
+            fileChooser.setInitialDirectory(directoryPath.toFile());
+            File file = fileChooser.showOpenDialog(window);
+
+            if(file == null){
+                return;
+            }
+
+            Services.IDE_STATE.openDocument(new FileSystemDocument(file.toPath()));
+        });
 
         var recentProjects = new LocalizedMenu("railroad.menu.file.recent_projects");
         recentProjects.setGraphic(new FontIcon(FontAwesomeSolid.FOLDER_OPEN));

--- a/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
+++ b/src/main/java/dev/railroadide/railroad/ide/ui/setup/IDEMenuBarFactory.java
@@ -30,7 +30,6 @@ import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
-import javafx.stage.Window;
 import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;
 import org.kordamp.ikonli.javafx.FontIcon;
 
@@ -64,14 +63,11 @@ public final class IDEMenuBarFactory {
             Path directoryPath = Services.UI_MANAGER.lookup(UIIds.IDE.PROJECT_EXPLORER)
                 .map(ProjectExplorerPane::getSelectedDirectory)
                 .orElseGet(project::getPath);
-            Window window = Railroad.WINDOW_MANAGER.getPrimaryStage();
-            FileChooser fileChooser = new FileChooser();
+            var fileChooser = new FileChooser();
             fileChooser.setInitialDirectory(directoryPath.toFile());
-            File file = fileChooser.showOpenDialog(window);
-
-            if(file == null){
+            File file = fileChooser.showOpenDialog(Railroad.WINDOW_MANAGER.getPrimaryStage());
+            if(file == null)
                 return;
-            }
 
             Services.IDE_STATE.openDocument(new FileSystemDocument(file.toPath()));
         });


### PR DESCRIPTION
This pull request enhances the "Open File" menu item in the IDE menu bar by adding a file chooser dialog, allowing users to open files from the file system through the UI. The most important changes are:

**Feature Addition: File Open Dialog**

* Added an action handler to the `openFileItem` menu item that opens a `FileChooser` dialog, defaulting to the selected directory in the project explorer or the project root if none is selected. When a file is chosen, it is opened as a `FileSystemDocument` in the IDE.

**Dependency and Import Updates**

* Imported `FileSystemDocument` to support opening files from the file system.
* Added imports for `FileChooser`, `File`, and `Window` to enable file dialog functionality.

_**Requires document opening changes to function**_